### PR TITLE
Dynamic GitHub release retrieval, full plugin roster, duplicate JAR prevention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # IntelliJ
 out/
 test/
+!src/test/
 
 # Compiled class file
 *.class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Dynamic GitHub release retrieval — `/dpm get` now fetches the latest release JAR automatically via the GitHub API instead of relying on hardcoded versioned URLs
+- 10 additional public DPC plugin repos registered (Bluemap_MedievalFactions, Bookshelves-You-Can-Use, Conquest-Recipes, Dans-Set-Home, Democracy, FlyCommand, Herald, KDRTracker, Medieval-Cookery, MiniFactions)
+- Informative "no published release yet" message when a plugin has no GitHub release
+
+### Changed
+- Download runs asynchronously so it no longer blocks the main server thread
+
+### Removed
+- ChatHub (repo no longer exists)
+
 ## [0.4]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 - ChatHub (repo no longer exists)
 
-## [0.4]
+## [0.4.0]
 
 ### Added
 - `/dpm help`, `/dpm list`, `/dpm get`, `/dpm stats` commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Dynamic GitHub release retrieval — `/dpm get` now fetches the latest release JAR automatically via the GitHub API instead of relying on hardcoded versioned URLs
 - 9 additional public DPC plugin repos registered (Bluemap_MedievalFactions, Bookshelves-You-Can-Use, Dans-Set-Home, Democracy, FlyCommand, Herald, KDRTracker, Medieval-Cookery, MiniFactions)
 - Informative "no published release yet" message when a plugin has no GitHub release
+- `/dpm clean` command to remove duplicate plugin JARs from the plugins folder
 
 ### Changed
 - Download runs asynchronously so it no longer blocks the main server thread
+- Conflicting JARs (e.g. manually installed versioned copies) are automatically removed before a new version is downloaded
 - Conquest-Recipes switched from Spigot direct-link to GitHub release retrieval
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Dynamic GitHub release retrieval — `/dpm get` now fetches the latest release JAR automatically via the GitHub API instead of relying on hardcoded versioned URLs
-- 10 additional public DPC plugin repos registered (Bluemap_MedievalFactions, Bookshelves-You-Can-Use, Conquest-Recipes, Dans-Set-Home, Democracy, FlyCommand, Herald, KDRTracker, Medieval-Cookery, MiniFactions)
+- 9 additional public DPC plugin repos registered (Bluemap_MedievalFactions, Bookshelves-You-Can-Use, Dans-Set-Home, Democracy, FlyCommand, Herald, KDRTracker, Medieval-Cookery, MiniFactions)
 - Informative "no published release yet" message when a plugin has no GitHub release
 
 ### Changed
 - Download runs asynchronously so it no longer blocks the main server thread
+- Conquest-Recipes switched from Spigot direct-link to GitHub release retrieval
 
 ### Removed
 - ChatHub (repo no longer exists)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.4.0]
+
 ### Added
+- `/dpm help`, `/dpm list`, `/dpm get`, `/dpm stats` commands
+- In-game browsing and downloading of DPC plugins
 - Dynamic GitHub release retrieval — `/dpm get` now fetches the latest release JAR automatically via the GitHub API instead of relying on hardcoded versioned URLs
 - 9 additional public DPC plugin repos registered (Bluemap_MedievalFactions, Bookshelves-You-Can-Use, Dans-Set-Home, Democracy, FlyCommand, Herald, KDRTracker, Medieval-Cookery, MiniFactions)
 - Informative "no published release yet" message when a plugin has no GitHub release
@@ -17,9 +21,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 - ChatHub (repo no longer exists)
-
-## [0.4.0]
-
-### Added
-- `/dpm help`, `/dpm list`, `/dpm get`, `/dpm stats` commands
-- In-game browsing and downloading of DPC plugins

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -7,4 +7,5 @@ All commands use `/dpm` or `/danspluginmanager` as the base.
 | `/dpm help` | View a list of commands. | `dpm.help` |
 | `/dpm list` | List available DPC plugins. | `dpm.list` |
 | `/dpm get <plugin-name>` | Download a DPC plugin to the server. | `dpm.get` |
+| `/dpm clean` | Remove duplicate plugin JARs from the plugins folder. | `dpm.clean` |
 | `/dpm stats` | View plugin statistics. | `dpm.stats` |

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -6,5 +6,5 @@ All commands use `/dpm` or `/danspluginmanager` as the base.
 |---------|-------------|------------|
 | `/dpm help` | View a list of commands. | `dpm.help` |
 | `/dpm list` | List available DPC plugins. | `dpm.list` |
-| `/dpm get <project-name>` | Download a DPC plugin to the server. | `dpm.get` |
+| `/dpm get <plugin-name>` | Download a DPC plugin to the server. | `dpm.get` |
 | `/dpm stats` | View plugin statistics. | `dpm.stats` |

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -5,6 +5,6 @@ All commands use `/dpm` or `/danspluginmanager` as the base.
 | Command | Description | Permission |
 |---------|-------------|------------|
 | `/dpm help` | View a list of commands. | `dpm.help` |
-| `/dpm list` | List available DPC plugin project records. | `dpm.list` |
+| `/dpm list` | List available DPC plugins. | `dpm.list` |
 | `/dpm get <project-name>` | Download a DPC plugin to the server. | `dpm.get` |
 | `/dpm stats` | View plugin statistics. | `dpm.stats` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,8 @@ Thank you for your interest in contributing to Dans Plugin Manager! This guide w
 ## Requirements
 
 - A GitHub account
-- Git installed on your local machine
-- A Java IDE or text editor
-- A basic understanding of Java
+- Git
+- Java 9+ and Maven
 
 ## Getting Started
 
@@ -23,43 +22,30 @@ Thank you for your interest in contributing to Dans Plugin Manager! This guide w
 3. Clone your fork: `git clone https://github.com/<your-username>/Dans-Plugin-Manager.git`
 4. Open the project in your IDE.
 5. Build the plugin: `mvn clean package`
-   If you encounter errors, please open an issue.
 
 ## Identifying What to Work On
 
-### Issues
-
-Work items are tracked as [GitHub issues](https://github.com/Dans-Plugins/Dans-Plugin-Manager/issues).
-
-### Milestones
-
-Issues are grouped into [milestones](https://github.com/Dans-Plugins/Dans-Plugin-Manager/milestones) representing upcoming releases.
+Work items are tracked as [GitHub issues](https://github.com/Dans-Plugins/Dans-Plugin-Manager/issues), grouped into [milestones](https://github.com/Dans-Plugins/Dans-Plugin-Manager/milestones) representing upcoming releases.
 
 ## Making Changes
 
 1. Make sure an issue exists for the work. If not, create one.
-2. Switch to `main`: `git checkout main`
-3. Create a branch: `git checkout -b <branch-name>`
-4. Make your changes.
-5. Test your changes.
-6. Commit: `git commit -m "Description of changes"`
-7. Push: `git push origin <branch-name>`
-8. Open a pull request against `main`, link the related issue with `#<number>`.
-9. Address review feedback.
+2. Create a branch off `main`: `git checkout -b <branch-name>`
+3. Make and test your changes.
+4. Commit: `git commit -m "Description of changes"`
+5. Push: `git push origin <branch-name>`
+6. Open a pull request against `main`, linking the related issue with `#<number>`.
+7. Address review feedback.
 
 ## Testing
 
-Run the build with:
+Build and place the JAR into a local Spigot server's `plugins/` folder:
 
-Linux / macOS:
+```
+mvn clean package
+```
 
-    mvn clean package
-
-Windows:
-
-    mvn clean package
-
-For manual testing, place the built JAR from `target/` into a local Spigot server's `plugins` folder and restart the server.
+The built JAR is in `target/`.
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,26 @@
 # Dan's Plugin Manager
 
 ## Description
-This Minecraft plugin is intended to allow operators to easily download the community's plugins in-game or through a server console.
+This Minecraft plugin lets server operators download DPC plugins in-game or from the server console.
 
 ## Download
-You can download the plugin here:
 https://github.com/Dans-Plugins/Dans-Plugin-Manager/releases
 
 ## Usage
-- [User Guide](https://github.com/Dans-Plugins/Dans-Plugin-Manager/wiki/Guide) (coming soon)
-- [List of Commands](https://github.com/Dans-Plugins/Dans-Plugin-Manager/wiki/Commands) (coming soon)
-- [FAQ](https://github.com/Dans-Plugins/Dans-Plugin-Manager/wiki/FAQ) (coming soon)
+- [User Guide](USER_GUIDE.md)
+- [Commands](COMMANDS.md)
 
 ## Support
-You can find the support discord server [here](https://discord.gg/xXtuAQ2).
-
-### Experiencing a bug?
-Please fill out a bug report [here](https://github.com/Dans-Plugins/Dans-Plugin-Manager/issues?q=is%3Aissue+is%3Aopen+label%3Abug).
-
-- [Known Bugs](https://github.com/Dans-Plugins/Dans-Plugin-Manager/issues?q=is%3Aopen+is%3Aissue+label%3Abug)
+[Discord](https://discord.gg/xXtuAQ2) — [Bug reports](https://github.com/Dans-Plugins/Dans-Plugin-Manager/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
 
 ## Contributing
-- [Notes for Developers](https://github.com/Dans-Plugins/Dans-Plugin-Manager/wiki/Developer-Notes) (coming soon)
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Authors and acknowledgement
-Name | Main Contributions
+## Authors
+Name | Contributions
 ------------ | -------------
 Daniel Stephenson | Creator
 Mr-Deej | Minor cleanup and fixes
 
 ## License
 MIT
-
-## Project Status
-This project is in active development.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -24,6 +24,7 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 | `dpm.list` | `true` | List available plugins. |
 | `dpm.stats` | `true` | View plugin statistics. |
 | `dpm.get` | `op` | Download a plugin to the server. |
+| `dpm.clean` | `op` | Remove duplicate plugin JARs. |
 
 ## Support
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -13,7 +13,7 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 ## Getting Started
 
 1. Run `/dpm list` to see available plugins.
-2. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder.
+2. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`).
 3. Restart the server to activate the downloaded plugin.
 
 ## Permissions

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## What is Dans Plugin Manager?
 
-Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse and download DPC plugins directly from within the game, without leaving the server.
+Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse and download DPC plugins in-game or from the server console.
 
 ## Installation
 
@@ -14,7 +14,7 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 
 1. Run `/dpm list` to see available plugins.
 2. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder.
-3. Restart or reload your server to activate the downloaded plugin.
+3. Restart the server to activate the downloaded plugin.
 
 ## Permissions
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
         </plugins>
         <resources>
             <resource>
@@ -83,7 +88,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
+            <version>5.10.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dansplugins</groupId>
     <artifactId>DansPluginManager</artifactId>
-    <version>0.4-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Dan's Plugin Manager</name>

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -6,6 +6,7 @@ import dansplugins.dpm.factories.ProjectRecordFactory;
 import dansplugins.dpm.services.ConfigService;
 import dansplugins.dpm.services.DownloadService;
 import dansplugins.dpm.services.GitHubReleaseService;
+import dansplugins.dpm.services.PluginFolderService;
 import dansplugins.dpm.utils.Logger;
 import dansplugins.dpm.utils.ProjectRecordInitializer;
 import org.bukkit.command.Command;
@@ -32,7 +33,8 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     private final ConfigService configService = new ConfigService(this);
     private final Logger logger = new Logger(this);
     private final GitHubReleaseService gitHubReleaseService = new GitHubReleaseService(logger);
-    private final DownloadService downloadService = new DownloadService(logger, gitHubReleaseService);
+    private final PluginFolderService pluginFolderService = new PluginFolderService();
+    private final DownloadService downloadService = new DownloadService(logger, gitHubReleaseService, pluginFolderService);
 
     /**
      * This runs when the server starts.
@@ -127,7 +129,8 @@ public final class DansPluginManager extends PonderBukkitPlugin {
                 new HelpCommand(),
                 new GetCommand(ephemeralData, downloadService, this),
                 new ListCommand(ephemeralData),
-                new StatsCommand(ephemeralData)
+                new StatsCommand(ephemeralData),
+                new CleanCommand(ephemeralData, pluginFolderService, this)
         ));
         commandService.initialize(commands, "That command wasn't found.");
     }

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -5,6 +5,7 @@ import dansplugins.dpm.data.EphemeralData;
 import dansplugins.dpm.factories.ProjectRecordFactory;
 import dansplugins.dpm.services.ConfigService;
 import dansplugins.dpm.services.DownloadService;
+import dansplugins.dpm.services.GitHubReleaseService;
 import dansplugins.dpm.utils.Logger;
 import dansplugins.dpm.utils.ProjectRecordInitializer;
 import org.bukkit.command.Command;
@@ -30,7 +31,8 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     private final ProjectRecordInitializer projectRecordInitializer = new ProjectRecordInitializer(projectRecordFactory);
     private final ConfigService configService = new ConfigService(this);
     private final Logger logger = new Logger(this);
-    private final DownloadService downloadService = new DownloadService(logger);
+    private final GitHubReleaseService gitHubReleaseService = new GitHubReleaseService(logger);
+    private final DownloadService downloadService = new DownloadService(logger, gitHubReleaseService);
 
     /**
      * This runs when the server starts.

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -125,7 +125,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     private void initializeCommandService() {
         ArrayList<AbstractPluginCommand> commands = new ArrayList<>(Arrays.asList(
                 new HelpCommand(),
-                new GetCommand(ephemeralData, downloadService),
+                new GetCommand(ephemeralData, downloadService, this),
                 new ListCommand(ephemeralData),
                 new StatsCommand(ephemeralData)
         ));

--- a/src/main/java/dansplugins/dpm/commands/CleanCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/CleanCommand.java
@@ -1,0 +1,62 @@
+package dansplugins.dpm.commands;
+
+import dansplugins.dpm.data.EphemeralData;
+import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.services.PluginFolderService;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
+import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Daniel McCoy Stephenson
+ */
+public class CleanCommand extends AbstractPluginCommand {
+    private final EphemeralData ephemeralData;
+    private final PluginFolderService pluginFolderService;
+    private final Plugin plugin;
+
+    public CleanCommand(EphemeralData ephemeralData, PluginFolderService pluginFolderService, Plugin plugin) {
+        super(new ArrayList<>(List.of("clean")), new ArrayList<>(List.of("dpm.clean")));
+        this.ephemeralData = ephemeralData;
+        this.pluginFolderService = pluginFolderService;
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean execute(CommandSender commandSender) {
+        commandSender.sendMessage(ChatColor.AQUA + "Scanning for duplicate plugin JARs...");
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            List<String> removed = new ArrayList<>();
+            for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
+                for (File conflict : pluginFolderService.findConflictingJars(record)) {
+                    if (conflict.delete()) {
+                        removed.add(conflict.getName() + " (" + record.getName() + ")");
+                    }
+                }
+            }
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                if (removed.isEmpty()) {
+                    commandSender.sendMessage(ChatColor.GREEN + "No duplicate JARs found.");
+                } else {
+                    commandSender.sendMessage(ChatColor.GREEN + "Removed " + removed.size() + " duplicate JAR(s):");
+                    for (String entry : removed) {
+                        commandSender.sendMessage(ChatColor.AQUA + "  - " + entry);
+                    }
+                    commandSender.sendMessage(ChatColor.YELLOW + "Restart the server to apply changes.");
+                }
+            });
+        });
+        return true;
+    }
+
+    @Override
+    public boolean execute(CommandSender commandSender, String[] args) {
+        return execute(commandSender);
+    }
+}

--- a/src/main/java/dansplugins/dpm/commands/GetCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/GetCommand.java
@@ -37,18 +37,20 @@ public class GetCommand extends AbstractPluginCommand {
             commandSender.sendMessage(ChatColor.RED + "A project record wasn't found with that name.");
             return false;
         }
-        int bytesRead = downloadService.downloadLatest(projectRecord);
-        if (bytesRead == 0) {
+        int result = downloadService.downloadLatest(projectRecord);
+        if (result == DownloadService.NO_RELEASE) {
+            commandSender.sendMessage(ChatColor.YELLOW + projectRecord.getName() + " has no published release yet. Try again later.");
+            return false;
+        }
+        if (result == 0) {
             commandSender.sendMessage(ChatColor.RED + "No bytes were read.");
             return false;
         }
-        else if (bytesRead == -1) {
-            commandSender.sendMessage(ChatColor.RED + "Something went wrong.");
+        if (result < 0) {
+            commandSender.sendMessage(ChatColor.RED + "Something went wrong downloading " + projectRecord.getName() + ".");
             return false;
         }
-        else {
-            commandSender.sendMessage(ChatColor.GREEN + "Success! " + bytesRead + " bytes were retrieved. Restart the server in order to enable " + projectRecord.getName() + ".");
-            return true;
-        }
+        commandSender.sendMessage(ChatColor.GREEN + "Success! " + result + " chunks retrieved. Restart the server to enable " + projectRecord.getName() + ".");
+        return true;
     }
 }

--- a/src/main/java/dansplugins/dpm/commands/GetCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/GetCommand.java
@@ -37,7 +37,7 @@ public class GetCommand extends AbstractPluginCommand {
             commandSender.sendMessage(ChatColor.RED + "A project record wasn't found with that name.");
             return false;
         }
-        int bytesRead = downloadService.downloadFromLink(projectRecord);
+        int bytesRead = downloadService.downloadLatest(projectRecord);
         if (bytesRead == 0) {
             commandSender.sendMessage(ChatColor.RED + "No bytes were read.");
             return false;

--- a/src/main/java/dansplugins/dpm/commands/GetCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/GetCommand.java
@@ -29,7 +29,7 @@ public class GetCommand extends AbstractPluginCommand {
 
     @Override
     public boolean execute(CommandSender commandSender) {
-        commandSender.sendMessage(ChatColor.RED + "Usage: /dpm get <project-record-name>");
+        commandSender.sendMessage(ChatColor.RED + "Usage: /dpm get <plugin-name>");
         return false;
     }
 
@@ -38,21 +38,21 @@ public class GetCommand extends AbstractPluginCommand {
         String name = args[0];
         ProjectRecord projectRecord = ephemeralData.getProjectRecord(name);
         if (projectRecord == null) {
-            commandSender.sendMessage(ChatColor.RED + "A project record wasn't found with that name.");
+            commandSender.sendMessage(ChatColor.RED + "Plugin not found: " + name);
             return false;
         }
         commandSender.sendMessage(ChatColor.AQUA + "Fetching " + projectRecord.getName() + "...");
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             int result = downloadService.downloadLatest(projectRecord);
-            if (result == DownloadService.NO_RELEASE) {
-                commandSender.sendMessage(ChatColor.YELLOW + projectRecord.getName() + " has no published release yet. Try again later.");
-            } else if (result == 0) {
-                commandSender.sendMessage(ChatColor.RED + "No bytes were read.");
-            } else if (result < 0) {
-                commandSender.sendMessage(ChatColor.RED + "Something went wrong downloading " + projectRecord.getName() + ".");
-            } else {
-                commandSender.sendMessage(ChatColor.GREEN + "Success! " + result + " chunks retrieved. Restart the server to enable " + projectRecord.getName() + ".");
-            }
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                if (result == DownloadService.NO_RELEASE) {
+                    commandSender.sendMessage(ChatColor.YELLOW + projectRecord.getName() + " has no published release yet. Try again later.");
+                } else if (result <= 0) {
+                    commandSender.sendMessage(ChatColor.RED + "Something went wrong downloading " + projectRecord.getName() + ".");
+                } else {
+                    commandSender.sendMessage(ChatColor.GREEN + "Downloaded " + (result / 1024) + " KB. Restart the server to enable " + projectRecord.getName() + ".");
+                }
+            });
         });
         return true;
     }

--- a/src/main/java/dansplugins/dpm/commands/GetCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/GetCommand.java
@@ -3,8 +3,10 @@ package dansplugins.dpm.commands;
 import dansplugins.dpm.data.EphemeralData;
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.services.DownloadService;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
 import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
 
 import java.util.ArrayList;
@@ -16,11 +18,13 @@ import java.util.List;
 public class GetCommand extends AbstractPluginCommand {
     private final EphemeralData ephemeralData;
     private final DownloadService downloadService;
+    private final Plugin plugin;
 
-    public GetCommand(EphemeralData ephemeralData, DownloadService downloadService) {
+    public GetCommand(EphemeralData ephemeralData, DownloadService downloadService, Plugin plugin) {
         super(new ArrayList<>(List.of("get")), new ArrayList<>(List.of("dpm.get")));
         this.ephemeralData = ephemeralData;
         this.downloadService = downloadService;
+        this.plugin = plugin;
     }
 
     @Override
@@ -37,20 +41,19 @@ public class GetCommand extends AbstractPluginCommand {
             commandSender.sendMessage(ChatColor.RED + "A project record wasn't found with that name.");
             return false;
         }
-        int result = downloadService.downloadLatest(projectRecord);
-        if (result == DownloadService.NO_RELEASE) {
-            commandSender.sendMessage(ChatColor.YELLOW + projectRecord.getName() + " has no published release yet. Try again later.");
-            return false;
-        }
-        if (result == 0) {
-            commandSender.sendMessage(ChatColor.RED + "No bytes were read.");
-            return false;
-        }
-        if (result < 0) {
-            commandSender.sendMessage(ChatColor.RED + "Something went wrong downloading " + projectRecord.getName() + ".");
-            return false;
-        }
-        commandSender.sendMessage(ChatColor.GREEN + "Success! " + result + " chunks retrieved. Restart the server to enable " + projectRecord.getName() + ".");
+        commandSender.sendMessage(ChatColor.AQUA + "Fetching " + projectRecord.getName() + "...");
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            int result = downloadService.downloadLatest(projectRecord);
+            if (result == DownloadService.NO_RELEASE) {
+                commandSender.sendMessage(ChatColor.YELLOW + projectRecord.getName() + " has no published release yet. Try again later.");
+            } else if (result == 0) {
+                commandSender.sendMessage(ChatColor.RED + "No bytes were read.");
+            } else if (result < 0) {
+                commandSender.sendMessage(ChatColor.RED + "Something went wrong downloading " + projectRecord.getName() + ".");
+            } else {
+                commandSender.sendMessage(ChatColor.GREEN + "Success! " + result + " chunks retrieved. Restart the server to enable " + projectRecord.getName() + ".");
+            }
+        });
         return true;
     }
 }

--- a/src/main/java/dansplugins/dpm/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/HelpCommand.java
@@ -19,10 +19,11 @@ public class HelpCommand extends AbstractPluginCommand {
     @Override
     public boolean execute(CommandSender commandSender) {
         commandSender.sendMessage(ChatColor.AQUA + "=== DPM Commands ===");
-        commandSender.sendMessage(ChatColor.AQUA + "/dpm help - View a list of helpful commands.");
-        commandSender.sendMessage(ChatColor.AQUA + "/dpm list - List project records.");
-        commandSender.sendMessage(ChatColor.AQUA + "/dpm get <project-record-name> - Download a project");
-        commandSender.sendMessage(ChatColor.AQUA + "/dpm stats - View relevant stats.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm help - View this list of commands.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm list - List available plugins.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm get <plugin-name> - Download a plugin.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm clean - Remove duplicate plugin JARs.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm stats - View plugin statistics.");
         return true;
     }
 

--- a/src/main/java/dansplugins/dpm/data/EphemeralData.java
+++ b/src/main/java/dansplugins/dpm/data/EphemeralData.java
@@ -5,6 +5,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class EphemeralData {
     private final ArrayList<ProjectRecord> projectRecords = new ArrayList<>();
@@ -31,6 +32,10 @@ public class EphemeralData {
         for (ProjectRecord projectRecord : projectRecords) {
             commandSender.sendMessage(ChatColor.AQUA + projectRecord.getName());
         }
+    }
+
+    public List<ProjectRecord> getAllProjectRecords() {
+        return new ArrayList<>(projectRecords);
     }
 
     public int getNumProjectRecords() {

--- a/src/main/java/dansplugins/dpm/factories/ProjectRecordFactory.java
+++ b/src/main/java/dansplugins/dpm/factories/ProjectRecordFactory.java
@@ -13,8 +13,4 @@ public class ProjectRecordFactory {
     public void createGitHubRecord(String name, String owner, String repo) {
         ephemeralData.addProjectRecord(ProjectRecord.forGitHub(name, owner, repo));
     }
-
-    public void createDirectLinkRecord(String name, String directLink) {
-        ephemeralData.addProjectRecord(ProjectRecord.forDirectLink(name, directLink));
-    }
 }

--- a/src/main/java/dansplugins/dpm/factories/ProjectRecordFactory.java
+++ b/src/main/java/dansplugins/dpm/factories/ProjectRecordFactory.java
@@ -10,8 +10,11 @@ public class ProjectRecordFactory {
         this.ephemeralData = ephemeralData;
     }
 
-    public void createProjectRecord(String name, String link) {
-        ProjectRecord projectRecord = new ProjectRecord(name, link);
-        ephemeralData.addProjectRecord(projectRecord);
+    public void createGitHubRecord(String name, String owner, String repo) {
+        ephemeralData.addProjectRecord(new ProjectRecord(name, owner, repo));
+    }
+
+    public void createDirectLinkRecord(String name, String directLink) {
+        ephemeralData.addProjectRecord(new ProjectRecord(name, directLink));
     }
 }

--- a/src/main/java/dansplugins/dpm/factories/ProjectRecordFactory.java
+++ b/src/main/java/dansplugins/dpm/factories/ProjectRecordFactory.java
@@ -11,10 +11,10 @@ public class ProjectRecordFactory {
     }
 
     public void createGitHubRecord(String name, String owner, String repo) {
-        ephemeralData.addProjectRecord(new ProjectRecord(name, owner, repo));
+        ephemeralData.addProjectRecord(ProjectRecord.forGitHub(name, owner, repo));
     }
 
     public void createDirectLinkRecord(String name, String directLink) {
-        ephemeralData.addProjectRecord(new ProjectRecord(name, directLink));
+        ephemeralData.addProjectRecord(ProjectRecord.forDirectLink(name, directLink));
     }
 }

--- a/src/main/java/dansplugins/dpm/objects/ProjectRecord.java
+++ b/src/main/java/dansplugins/dpm/objects/ProjectRecord.java
@@ -6,18 +6,19 @@ public class ProjectRecord {
     private final String repo;
     private final String directLink;
 
-    public ProjectRecord(String name, String owner, String repo) {
+    private ProjectRecord(String name, String owner, String repo, String directLink) {
         this.name = name;
         this.owner = owner;
         this.repo = repo;
-        this.directLink = null;
+        this.directLink = directLink;
     }
 
-    public ProjectRecord(String name, String directLink) {
-        this.name = name;
-        this.owner = null;
-        this.repo = null;
-        this.directLink = directLink;
+    public static ProjectRecord forGitHub(String name, String owner, String repo) {
+        return new ProjectRecord(name, owner, repo, null);
+    }
+
+    public static ProjectRecord forDirectLink(String name, String directLink) {
+        return new ProjectRecord(name, null, null, directLink);
     }
 
     public String getName() {

--- a/src/main/java/dansplugins/dpm/objects/ProjectRecord.java
+++ b/src/main/java/dansplugins/dpm/objects/ProjectRecord.java
@@ -1,27 +1,42 @@
 package dansplugins.dpm.objects;
 
 public class ProjectRecord {
-    private String name;
-    private String link;
+    private final String name;
+    private final String owner;
+    private final String repo;
+    private final String directLink;
 
-    public ProjectRecord(String name, String link) {
+    public ProjectRecord(String name, String owner, String repo) {
         this.name = name;
-        this.link = link;
+        this.owner = owner;
+        this.repo = repo;
+        this.directLink = null;
+    }
+
+    public ProjectRecord(String name, String directLink) {
+        this.name = name;
+        this.owner = null;
+        this.repo = null;
+        this.directLink = directLink;
     }
 
     public String getName() {
         return name;
     }
 
-    public void setName(String name) {
-        this.name = name;
+    public boolean isGitHubHosted() {
+        return owner != null && repo != null;
     }
 
-    public String getLink() {
-        return link;
+    public String getOwner() {
+        return owner;
     }
 
-    public void setLink(String link) {
-        this.link = link;
+    public String getRepo() {
+        return repo;
+    }
+
+    public String getDirectLink() {
+        return directLink;
     }
 }

--- a/src/main/java/dansplugins/dpm/objects/ProjectRecord.java
+++ b/src/main/java/dansplugins/dpm/objects/ProjectRecord.java
@@ -4,29 +4,19 @@ public class ProjectRecord {
     private final String name;
     private final String owner;
     private final String repo;
-    private final String directLink;
 
-    private ProjectRecord(String name, String owner, String repo, String directLink) {
+    private ProjectRecord(String name, String owner, String repo) {
         this.name = name;
         this.owner = owner;
         this.repo = repo;
-        this.directLink = directLink;
     }
 
     public static ProjectRecord forGitHub(String name, String owner, String repo) {
-        return new ProjectRecord(name, owner, repo, null);
-    }
-
-    public static ProjectRecord forDirectLink(String name, String directLink) {
-        return new ProjectRecord(name, null, null, directLink);
+        return new ProjectRecord(name, owner, repo);
     }
 
     public String getName() {
         return name;
-    }
-
-    public boolean isGitHubHosted() {
-        return owner != null && repo != null;
     }
 
     public String getOwner() {
@@ -35,9 +25,5 @@ public class ProjectRecord {
 
     public String getRepo() {
         return repo;
-    }
-
-    public String getDirectLink() {
-        return directLink;
     }
 }

--- a/src/main/java/dansplugins/dpm/services/ConfigService.java
+++ b/src/main/java/dansplugins/dpm/services/ConfigService.java
@@ -1,20 +1,10 @@
 package dansplugins.dpm.services;
 
-/*
-    To add a new config option, the following methods must be altered:
-    - saveMissingConfigDefaultsIfNotPresent
-    - setConfigOption()
-    - sendConfigList()
- */
-
 import dansplugins.dpm.DansPluginManager;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 
-/**
- * @author Daniel McCoy Stephenson
- */
 public class ConfigService {
     private final DansPluginManager dansPluginManager;
 
@@ -25,51 +15,41 @@ public class ConfigService {
     }
 
     public void saveMissingConfigDefaultsIfNotPresent() {
-        // set version
         if (!getConfig().isString("version")) {
             getConfig().addDefault("version", dansPluginManager.getVersion());
         } else {
             getConfig().set("version", dansPluginManager.getVersion());
         }
-
-        // save config options
-        if (!isSet("debugMode")) { getConfig().set("debugMode", false); }
-
+        if (!isSet("debugMode")) {
+            getConfig().set("debugMode", false);
+        }
         getConfig().options().copyDefaults(true);
         dansPluginManager.saveConfig();
     }
 
     public void setConfigOption(String option, String value, CommandSender sender) {
-        if (getConfig().isSet(option)) {
-            if (option.equalsIgnoreCase("version")) {
-                sender.sendMessage(ChatColor.RED + "Cannot set version.");
-                return;
-            } else if (option.equalsIgnoreCase("A")) {
-                getConfig().set(option, Integer.parseInt(value));
-                sender.sendMessage(ChatColor.GREEN + "Integer set.");
-            } else if (option.equalsIgnoreCase("debugMode")) {
-                getConfig().set(option, Boolean.parseBoolean(value));
-                sender.sendMessage(ChatColor.GREEN + "Boolean set.");
-            } else if (option.equalsIgnoreCase("C")) {
-                getConfig().set(option, Double.parseDouble(value));
-                sender.sendMessage(ChatColor.GREEN + "Double set.");
-            } else {
-                getConfig().set(option, value);
-                sender.sendMessage(ChatColor.GREEN + "String set.");
-            }
-
-            // save
-            dansPluginManager.saveConfig();
-            altered = true;
-        } else {
+        if (!getConfig().isSet(option)) {
             sender.sendMessage(ChatColor.RED + "That config option wasn't found.");
+            return;
         }
+        if (option.equalsIgnoreCase("version")) {
+            sender.sendMessage(ChatColor.RED + "Cannot set version.");
+            return;
+        }
+        if (option.equalsIgnoreCase("debugMode")) {
+            getConfig().set(option, Boolean.parseBoolean(value));
+        } else {
+            getConfig().set(option, value);
+        }
+        dansPluginManager.saveConfig();
+        altered = true;
+        sender.sendMessage(ChatColor.GREEN + "Config option updated.");
     }
 
     public void sendConfigList(CommandSender sender) {
-        sender.sendMessage(ChatColor.AQUA + "=== Config List ===");
-        sender.sendMessage(ChatColor.AQUA + "version: " + getConfig().getString("version")
-                + ", debugMode: " + getString("debugMode"));
+        sender.sendMessage(ChatColor.AQUA + "=== Config ===");
+        sender.sendMessage(ChatColor.AQUA + "version: " + getConfig().getString("version"));
+        sender.sendMessage(ChatColor.AQUA + "debugMode: " + getConfig().getBoolean("debugMode"));
     }
 
     public boolean hasBeenAltered() {
@@ -84,32 +64,8 @@ public class ConfigService {
         return getConfig().isSet(option);
     }
 
-    public int getInt(String option) {
-        return getConfig().getInt(option);
-    }
-
-    public int getIntOrDefault(String option, int defaultValue) {
-        int toReturn = getInt(option);
-        if (toReturn == 0) {
-            return defaultValue;
-        }
-        return toReturn;
-    }
-
     public boolean getBoolean(String option) {
         return getConfig().getBoolean(option);
-    }
-
-    public double getDouble(String option) {
-        return getConfig().getDouble(option);
-    }
-
-    public double getDoubleOrDefault(String option, double defaultValue) {
-        double toReturn = getDouble(option);
-        if (toReturn == 0) {
-            return defaultValue;
-        }
-        return toReturn;
     }
 
     public String getString(String option) {
@@ -118,9 +74,6 @@ public class ConfigService {
 
     public String getStringOrDefault(String option, String defaultValue) {
         String toReturn = getString(option);
-        if (toReturn == null) {
-            return defaultValue;
-        }
-        return toReturn;
+        return toReturn != null ? toReturn : defaultValue;
     }
 }

--- a/src/main/java/dansplugins/dpm/services/DownloadService.java
+++ b/src/main/java/dansplugins/dpm/services/DownloadService.java
@@ -65,7 +65,7 @@ public class DownloadService {
         }
     }
 
-    private int readAndWrite(String link, String path) throws IOException {
+    int readAndWrite(String link, String path) throws IOException {
         File dest = new File(path);
         try (BufferedInputStream in = new BufferedInputStream(new URL(link).openStream());
              FileOutputStream out = new FileOutputStream(dest)) {

--- a/src/main/java/dansplugins/dpm/services/DownloadService.java
+++ b/src/main/java/dansplugins/dpm/services/DownloadService.java
@@ -9,6 +9,9 @@ import java.io.IOException;
 import java.net.URL;
 
 public class DownloadService {
+    /** No published release found on GitHub for this plugin. */
+    public static final int NO_RELEASE = -2;
+
     private static final String PATH_TO_PLUGINS_FOLDER = "./plugins/";
 
     private final Logger logger;
@@ -19,8 +22,16 @@ public class DownloadService {
         this.gitHubReleaseService = gitHubReleaseService;
     }
 
+    /**
+     * Resolves the download URL (querying GitHub if needed) and downloads the JAR.
+     * Returns the number of chunks read on success, {@link #NO_RELEASE} if no release
+     * has been published yet, or -1 on other errors.
+     */
     public int downloadLatest(ProjectRecord projectRecord) {
         String downloadUrl = resolveDownloadUrl(projectRecord);
+        if (GitHubReleaseService.NO_RELEASE.equals(downloadUrl)) {
+            return NO_RELEASE;
+        }
         if (downloadUrl == null) {
             logger.log("Could not resolve a download URL for " + projectRecord.getName() + ".");
             return -1;

--- a/src/main/java/dansplugins/dpm/services/DownloadService.java
+++ b/src/main/java/dansplugins/dpm/services/DownloadService.java
@@ -9,25 +9,39 @@ import java.io.IOException;
 import java.net.URL;
 
 public class DownloadService {
+    private static final String PATH_TO_PLUGINS_FOLDER = "./plugins/";
+
     private final Logger logger;
+    private final GitHubReleaseService gitHubReleaseService;
 
-    private final static String PATH_TO_PLUGINS_FOLDER = "./plugins/";
-
-    public DownloadService(Logger logger) {
+    public DownloadService(Logger logger, GitHubReleaseService gitHubReleaseService) {
         this.logger = logger;
+        this.gitHubReleaseService = gitHubReleaseService;
     }
 
-    public int downloadFromLink(ProjectRecord projectRecord) {
-        return downloadFromLink(projectRecord.getLink(), PATH_TO_PLUGINS_FOLDER + projectRecord.getName() + ".jar");
-    }
-
-    public int downloadFromLink(String link, String path) {
-        try {
-            return readAndWrite(link, path);
-        } catch (IOException e) {
-            logger.log("Something went wrong downloading from a link.");
+    public int downloadLatest(ProjectRecord projectRecord) {
+        String downloadUrl = resolveDownloadUrl(projectRecord);
+        if (downloadUrl == null) {
+            logger.log("Could not resolve a download URL for " + projectRecord.getName() + ".");
             return -1;
         }
+        return downloadFromUrl(downloadUrl, PATH_TO_PLUGINS_FOLDER + projectRecord.getName() + ".jar");
+    }
+
+    public int downloadFromUrl(String url, String path) {
+        try {
+            return readAndWrite(url, path);
+        } catch (IOException e) {
+            logger.log("Something went wrong downloading from " + url + ": " + e.getMessage());
+            return -1;
+        }
+    }
+
+    private String resolveDownloadUrl(ProjectRecord projectRecord) {
+        if (projectRecord.isGitHubHosted()) {
+            return gitHubReleaseService.getLatestJarDownloadUrl(projectRecord.getOwner(), projectRecord.getRepo());
+        }
+        return projectRecord.getDirectLink();
     }
 
     private int readAndWrite(String link, String path) throws IOException {

--- a/src/main/java/dansplugins/dpm/services/DownloadService.java
+++ b/src/main/java/dansplugins/dpm/services/DownloadService.java
@@ -66,16 +66,20 @@ public class DownloadService {
     }
 
     private int readAndWrite(String link, String path) throws IOException {
-        int totalBytes = 0;
-        BufferedInputStream inputStream = new BufferedInputStream(new URL(link).openStream());
-        FileOutputStream fileOutputStream = new FileOutputStream(path);
-        byte[] data = new byte[1024];
-        int bytesRead;
-        while ((bytesRead = inputStream.read(data, 0, 1024)) != -1) {
-            totalBytes += bytesRead;
-            fileOutputStream.write(data, 0, bytesRead);
+        File dest = new File(path);
+        try (BufferedInputStream in = new BufferedInputStream(new URL(link).openStream());
+             FileOutputStream out = new FileOutputStream(dest)) {
+            int totalBytes = 0;
+            byte[] data = new byte[1024];
+            int bytesRead;
+            while ((bytesRead = in.read(data, 0, 1024)) != -1) {
+                totalBytes += bytesRead;
+                out.write(data, 0, bytesRead);
+            }
+            return totalBytes;
+        } catch (IOException e) {
+            dest.delete();
+            throw e;
         }
-        fileOutputStream.close();
-        return totalBytes;
     }
 }

--- a/src/main/java/dansplugins/dpm/services/DownloadService.java
+++ b/src/main/java/dansplugins/dpm/services/DownloadService.java
@@ -4,9 +4,11 @@ import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.utils.Logger;
 
 import java.io.BufferedInputStream;
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.util.List;
 
 public class DownloadService {
     /** No published release found on GitHub for this plugin. */
@@ -16,14 +18,17 @@ public class DownloadService {
 
     private final Logger logger;
     private final GitHubReleaseService gitHubReleaseService;
+    private final PluginFolderService pluginFolderService;
 
-    public DownloadService(Logger logger, GitHubReleaseService gitHubReleaseService) {
+    public DownloadService(Logger logger, GitHubReleaseService gitHubReleaseService, PluginFolderService pluginFolderService) {
         this.logger = logger;
         this.gitHubReleaseService = gitHubReleaseService;
+        this.pluginFolderService = pluginFolderService;
     }
 
     /**
-     * Resolves the latest JAR URL via the GitHub API and downloads it.
+     * Resolves the latest JAR URL via the GitHub API, removes any conflicting
+     * JARs already in the plugins folder, then downloads the new version.
      * Returns bytes downloaded on success, {@link #NO_RELEASE} if no release
      * has been published yet, or -1 on other errors.
      */
@@ -36,7 +41,19 @@ public class DownloadService {
             logger.log("Could not resolve a download URL for " + projectRecord.getName() + ".");
             return -1;
         }
+        removeConflictingJars(projectRecord);
         return downloadFromUrl(downloadUrl, PATH_TO_PLUGINS_FOLDER + projectRecord.getName() + ".jar");
+    }
+
+    private void removeConflictingJars(ProjectRecord projectRecord) {
+        List<File> conflicts = pluginFolderService.findConflictingJars(projectRecord);
+        for (File conflict : conflicts) {
+            if (conflict.delete()) {
+                logger.log("Removed conflicting JAR before download: " + conflict.getName());
+            } else {
+                logger.log("Failed to remove conflicting JAR: " + conflict.getName());
+            }
+        }
     }
 
     private int downloadFromUrl(String url, String path) {

--- a/src/main/java/dansplugins/dpm/services/DownloadService.java
+++ b/src/main/java/dansplugins/dpm/services/DownloadService.java
@@ -23,12 +23,12 @@ public class DownloadService {
     }
 
     /**
-     * Resolves the download URL (querying GitHub if needed) and downloads the JAR.
-     * Returns the number of chunks read on success, {@link #NO_RELEASE} if no release
+     * Resolves the latest JAR URL via the GitHub API and downloads it.
+     * Returns bytes downloaded on success, {@link #NO_RELEASE} if no release
      * has been published yet, or -1 on other errors.
      */
     public int downloadLatest(ProjectRecord projectRecord) {
-        String downloadUrl = resolveDownloadUrl(projectRecord);
+        String downloadUrl = gitHubReleaseService.getLatestJarDownloadUrl(projectRecord.getOwner(), projectRecord.getRepo());
         if (GitHubReleaseService.NO_RELEASE.equals(downloadUrl)) {
             return NO_RELEASE;
         }
@@ -39,7 +39,7 @@ public class DownloadService {
         return downloadFromUrl(downloadUrl, PATH_TO_PLUGINS_FOLDER + projectRecord.getName() + ".jar");
     }
 
-    public int downloadFromUrl(String url, String path) {
+    private int downloadFromUrl(String url, String path) {
         try {
             return readAndWrite(url, path);
         } catch (IOException e) {
@@ -48,24 +48,17 @@ public class DownloadService {
         }
     }
 
-    private String resolveDownloadUrl(ProjectRecord projectRecord) {
-        if (projectRecord.isGitHubHosted()) {
-            return gitHubReleaseService.getLatestJarDownloadUrl(projectRecord.getOwner(), projectRecord.getRepo());
-        }
-        return projectRecord.getDirectLink();
-    }
-
     private int readAndWrite(String link, String path) throws IOException {
-        int bytesRead = 0;
+        int totalBytes = 0;
         BufferedInputStream inputStream = new BufferedInputStream(new URL(link).openStream());
         FileOutputStream fileOutputStream = new FileOutputStream(path);
         byte[] data = new byte[1024];
-        int byteContent;
-        while ((byteContent = inputStream.read(data, 0, 1024)) != -1) {
-            bytesRead++;
-            fileOutputStream.write(data, 0, byteContent);
+        int bytesRead;
+        while ((bytesRead = inputStream.read(data, 0, 1024)) != -1) {
+            totalBytes += bytesRead;
+            fileOutputStream.write(data, 0, bytesRead);
         }
         fileOutputStream.close();
-        return bytesRead;
+        return totalBytes;
     }
 }

--- a/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
+++ b/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 public class GitHubReleaseService {
     private static final String API_URL = "https://api.github.com/repos/%s/%s/releases/latest";
@@ -64,7 +65,7 @@ public class GitHubReleaseService {
     private String readStream(InputStream stream) throws IOException {
         if (stream == null) return "";
         StringBuilder sb = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 sb.append(line);
@@ -74,30 +75,50 @@ public class GitHubReleaseService {
     }
 
     /**
-     * Scopes the browser_download_url search to within the "assets" array to avoid
-     * false matches in release body text. Returns the first .jar asset URL found.
+     * Extracts the first .jar browser_download_url from within the assets array.
+     * Uses bracket-depth tracking to bound the search strictly to the assets array,
+     * and handles backslash-escaped characters within URL strings.
      */
     private String parseJarUrlFromAssets(String json) {
-        int assetsStart = json.indexOf("\"assets\":");
-        if (assetsStart == -1) return null;
-        // Search only from the assets field onward
-        String assetsSection = json.substring(assetsStart);
+        int assetsKeyIndex = json.indexOf("\"assets\":");
+        if (assetsKeyIndex == -1) return null;
+
+        int arrayOpen = json.indexOf('[', assetsKeyIndex);
+        if (arrayOpen == -1) return null;
+
+        // Find the matching closing bracket via depth tracking
+        int depth = 0;
+        int arrayClose = -1;
+        for (int i = arrayOpen; i < json.length(); i++) {
+            char c = json.charAt(i);
+            if (c == '[') depth++;
+            else if (c == ']') {
+                depth--;
+                if (depth == 0) {
+                    arrayClose = i;
+                    break;
+                }
+            }
+        }
+        if (arrayClose == -1) return null;
+
+        String assetsJson = json.substring(arrayOpen, arrayClose + 1);
         String key = "\"browser_download_url\"";
         int searchFrom = 0;
         while (true) {
-            int keyIndex = assetsSection.indexOf(key, searchFrom);
+            int keyIndex = assetsJson.indexOf(key, searchFrom);
             if (keyIndex == -1) break;
-            int colonIndex = assetsSection.indexOf(':', keyIndex + key.length());
+            int colonIndex = assetsJson.indexOf(':', keyIndex + key.length());
             if (colonIndex == -1) break;
-            int openQuote = assetsSection.indexOf('"', colonIndex + 1);
+            int openQuote = assetsJson.indexOf('"', colonIndex + 1);
             if (openQuote == -1) break;
-            // Collect characters until an unescaped closing quote
+            // Walk characters, respecting backslash escapes
             StringBuilder url = new StringBuilder();
             int i = openQuote + 1;
-            while (i < assetsSection.length()) {
-                char c = assetsSection.charAt(i);
+            while (i < assetsJson.length()) {
+                char c = assetsJson.charAt(i);
                 if (c == '\\') {
-                    i += 2; // skip escaped character
+                    i += 2;
                     continue;
                 }
                 if (c == '"') break;

--- a/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
+++ b/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
@@ -11,6 +11,9 @@ import java.net.URL;
 public class GitHubReleaseService {
     private static final String API_URL = "https://api.github.com/repos/%s/%s/releases/latest";
 
+    /** Returned when the repo exists but has no published (non-prerelease) release yet. */
+    public static final String NO_RELEASE = "__NO_RELEASE__";
+
     private final Logger logger;
 
     public GitHubReleaseService(Logger logger) {
@@ -18,13 +21,19 @@ public class GitHubReleaseService {
     }
 
     /**
-     * Returns the browser_download_url of the first .jar asset on the latest release,
-     * or null if none could be found.
+     * Returns the browser_download_url of the first .jar asset on the latest release.
+     * Returns {@link #NO_RELEASE} when GitHub reports 404 (no releases published yet).
+     * Returns null on network or other errors.
      */
     public String getLatestJarDownloadUrl(String owner, String repo) {
         String apiUrl = String.format(API_URL, owner, repo);
         try {
-            String json = fetchJson(apiUrl);
+            HttpURLConnection connection = openConnection(apiUrl);
+            int responseCode = connection.getResponseCode();
+            if (responseCode == 404) {
+                return NO_RELEASE;
+            }
+            String json = readResponse(connection);
             return parseJarUrl(json);
         } catch (IOException e) {
             logger.log("Failed to fetch release info for " + owner + "/" + repo + ": " + e.getMessage());
@@ -32,11 +41,15 @@ public class GitHubReleaseService {
         }
     }
 
-    private String fetchJson(String apiUrl) throws IOException {
+    private HttpURLConnection openConnection(String apiUrl) throws IOException {
         HttpURLConnection connection = (HttpURLConnection) new URL(apiUrl).openConnection();
         connection.setRequestProperty("Accept", "application/vnd.github+json");
         connection.setConnectTimeout(5000);
         connection.setReadTimeout(5000);
+        return connection;
+    }
+
+    private String readResponse(HttpURLConnection connection) throws IOException {
         StringBuilder sb = new StringBuilder();
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
             String line;

--- a/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
+++ b/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
@@ -1,0 +1,74 @@
+package dansplugins.dpm.services;
+
+import dansplugins.dpm.utils.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class GitHubReleaseService {
+    private static final String API_URL = "https://api.github.com/repos/%s/%s/releases/latest";
+
+    private final Logger logger;
+
+    public GitHubReleaseService(Logger logger) {
+        this.logger = logger;
+    }
+
+    /**
+     * Returns the browser_download_url of the first .jar asset on the latest release,
+     * or null if none could be found.
+     */
+    public String getLatestJarDownloadUrl(String owner, String repo) {
+        String apiUrl = String.format(API_URL, owner, repo);
+        try {
+            String json = fetchJson(apiUrl);
+            return parseJarUrl(json);
+        } catch (IOException e) {
+            logger.log("Failed to fetch release info for " + owner + "/" + repo + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private String fetchJson(String apiUrl) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(apiUrl).openConnection();
+        connection.setRequestProperty("Accept", "application/vnd.github+json");
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line);
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Minimal JSON extraction — finds the first "browser_download_url" whose value ends in ".jar".
+     * Avoids pulling in a JSON library so the plugin stays lightweight.
+     */
+    private String parseJarUrl(String json) {
+        String key = "\"browser_download_url\"";
+        int searchFrom = 0;
+        while (true) {
+            int keyIndex = json.indexOf(key, searchFrom);
+            if (keyIndex == -1) break;
+            int colonIndex = json.indexOf(':', keyIndex + key.length());
+            if (colonIndex == -1) break;
+            int openQuote = json.indexOf('"', colonIndex + 1);
+            if (openQuote == -1) break;
+            int closeQuote = json.indexOf('"', openQuote + 1);
+            if (closeQuote == -1) break;
+            String url = json.substring(openQuote + 1, closeQuote);
+            if (url.endsWith(".jar")) {
+                return url;
+            }
+            searchFrom = closeQuote + 1;
+        }
+        return null;
+    }
+}

--- a/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
+++ b/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
@@ -79,7 +79,7 @@ public class GitHubReleaseService {
      * Uses bracket-depth tracking to bound the search strictly to the assets array,
      * and handles backslash-escaped characters within URL strings.
      */
-    private String parseJarUrlFromAssets(String json) {
+    String parseJarUrlFromAssets(String json) {
         int assetsKeyIndex = json.indexOf("\"assets\":");
         if (assetsKeyIndex == -1) return null;
 

--- a/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
+++ b/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
@@ -4,6 +4,7 @@ import dansplugins.dpm.utils.Logger;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -27,31 +28,43 @@ public class GitHubReleaseService {
      */
     public String getLatestJarDownloadUrl(String owner, String repo) {
         String apiUrl = String.format(API_URL, owner, repo);
+        HttpURLConnection connection = null;
         try {
-            HttpURLConnection connection = openConnection(apiUrl);
+            connection = openConnection(apiUrl);
             int responseCode = connection.getResponseCode();
             if (responseCode == 404) {
                 return NO_RELEASE;
             }
-            String json = readResponse(connection);
-            return parseJarUrl(json);
+            if (responseCode != 200) {
+                String errorBody = readStream(connection.getErrorStream());
+                logger.log("GitHub API returned HTTP " + responseCode + " for " + owner + "/" + repo + ": " + errorBody);
+                return null;
+            }
+            String json = readStream(connection.getInputStream());
+            return parseJarUrlFromAssets(json);
         } catch (IOException e) {
-            logger.log("Failed to fetch release info for " + owner + "/" + repo + ": " + e.getMessage());
+            logger.log("Failed to reach GitHub API for " + owner + "/" + repo + ": " + e.getMessage());
             return null;
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
         }
     }
 
     private HttpURLConnection openConnection(String apiUrl) throws IOException {
         HttpURLConnection connection = (HttpURLConnection) new URL(apiUrl).openConnection();
         connection.setRequestProperty("Accept", "application/vnd.github+json");
+        connection.setRequestProperty("User-Agent", "Dans-Plugin-Manager");
         connection.setConnectTimeout(5000);
         connection.setReadTimeout(5000);
         return connection;
     }
 
-    private String readResponse(HttpURLConnection connection) throws IOException {
+    private String readStream(InputStream stream) throws IOException {
+        if (stream == null) return "";
         StringBuilder sb = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 sb.append(line);
@@ -61,26 +74,41 @@ public class GitHubReleaseService {
     }
 
     /**
-     * Minimal JSON extraction — finds the first "browser_download_url" whose value ends in ".jar".
-     * Avoids pulling in a JSON library so the plugin stays lightweight.
+     * Scopes the browser_download_url search to within the "assets" array to avoid
+     * false matches in release body text. Returns the first .jar asset URL found.
      */
-    private String parseJarUrl(String json) {
+    private String parseJarUrlFromAssets(String json) {
+        int assetsStart = json.indexOf("\"assets\":");
+        if (assetsStart == -1) return null;
+        // Search only from the assets field onward
+        String assetsSection = json.substring(assetsStart);
         String key = "\"browser_download_url\"";
         int searchFrom = 0;
         while (true) {
-            int keyIndex = json.indexOf(key, searchFrom);
+            int keyIndex = assetsSection.indexOf(key, searchFrom);
             if (keyIndex == -1) break;
-            int colonIndex = json.indexOf(':', keyIndex + key.length());
+            int colonIndex = assetsSection.indexOf(':', keyIndex + key.length());
             if (colonIndex == -1) break;
-            int openQuote = json.indexOf('"', colonIndex + 1);
+            int openQuote = assetsSection.indexOf('"', colonIndex + 1);
             if (openQuote == -1) break;
-            int closeQuote = json.indexOf('"', openQuote + 1);
-            if (closeQuote == -1) break;
-            String url = json.substring(openQuote + 1, closeQuote);
-            if (url.endsWith(".jar")) {
-                return url;
+            // Collect characters until an unescaped closing quote
+            StringBuilder url = new StringBuilder();
+            int i = openQuote + 1;
+            while (i < assetsSection.length()) {
+                char c = assetsSection.charAt(i);
+                if (c == '\\') {
+                    i += 2; // skip escaped character
+                    continue;
+                }
+                if (c == '"') break;
+                url.append(c);
+                i++;
             }
-            searchFrom = closeQuote + 1;
+            String downloadUrl = url.toString();
+            if (downloadUrl.endsWith(".jar")) {
+                return downloadUrl;
+            }
+            searchFrom = i + 1;
         }
         return null;
     }

--- a/src/main/java/dansplugins/dpm/services/PluginFolderService.java
+++ b/src/main/java/dansplugins/dpm/services/PluginFolderService.java
@@ -7,7 +7,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class PluginFolderService {
-    private static final String PLUGINS_FOLDER = "./plugins/";
+    private final String pluginsFolder;
+
+    public PluginFolderService() {
+        this("./plugins/");
+    }
+
+    PluginFolderService(String pluginsFolder) {
+        this.pluginsFolder = pluginsFolder;
+    }
 
     /**
      * Returns all JARs in the plugins folder whose normalized name matches the record
@@ -15,7 +23,7 @@ public class PluginFolderService {
      */
     public List<File> findConflictingJars(ProjectRecord record) {
         List<File> conflicts = new ArrayList<>();
-        File pluginsDir = new File(PLUGINS_FOLDER);
+        File pluginsDir = new File(pluginsFolder);
         File[] jars = pluginsDir.listFiles((dir, name) -> name.endsWith(".jar"));
         if (jars == null) return conflicts;
         String managedFilename = record.getName() + ".jar";
@@ -34,8 +42,8 @@ public class PluginFolderService {
      * (e.g. -4.6.3, -v1.0), strips hyphens and underscores, lowercases.
      *
      * Examples:
-     *   Medieval-Factions-4.6.3.jar -> medievalfactions
-     *   ActivityTracker-v1.0.jar    -> activitytracker
+     *   Medieval-Factions-4.6.3.jar  -> medievalfactions
+     *   ActivityTracker-v1.0.jar     -> activitytracker
      *   Bluemap_MedievalFactions.jar -> bluemapmedievalfactions
      */
     String normalize(String filename) {

--- a/src/main/java/dansplugins/dpm/services/PluginFolderService.java
+++ b/src/main/java/dansplugins/dpm/services/PluginFolderService.java
@@ -1,0 +1,47 @@
+package dansplugins.dpm.services;
+
+import dansplugins.dpm.objects.ProjectRecord;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PluginFolderService {
+    private static final String PLUGINS_FOLDER = "./plugins/";
+
+    /**
+     * Returns all JARs in the plugins folder whose normalized name matches the record
+     * but are not the managed file ({recordName}.jar).
+     */
+    public List<File> findConflictingJars(ProjectRecord record) {
+        List<File> conflicts = new ArrayList<>();
+        File pluginsDir = new File(PLUGINS_FOLDER);
+        File[] jars = pluginsDir.listFiles((dir, name) -> name.endsWith(".jar"));
+        if (jars == null) return conflicts;
+        String managedFilename = record.getName() + ".jar";
+        for (File jar : jars) {
+            if (jar.getName().equalsIgnoreCase(managedFilename)) continue;
+            if (normalize(jar.getName()).equals(record.getName())) {
+                conflicts.add(jar);
+            }
+        }
+        return conflicts;
+    }
+
+    /**
+     * Normalizes a JAR filename for comparison against a record name:
+     * strips the .jar extension, removes any trailing version suffix
+     * (e.g. -4.6.3, -v1.0), strips hyphens and underscores, lowercases.
+     *
+     * Examples:
+     *   Medieval-Factions-4.6.3.jar -> medievalfactions
+     *   ActivityTracker-v1.0.jar    -> activitytracker
+     *   Bluemap_MedievalFactions.jar -> bluemapmedievalfactions
+     */
+    String normalize(String filename) {
+        String name = filename.replaceAll("(?i)\\.jar$", "");
+        name = name.replaceAll("[-_]v?\\d.*$", "");
+        name = name.replaceAll("[-_]", "");
+        return name.toLowerCase();
+    }
+}

--- a/src/main/java/dansplugins/dpm/utils/ProjectRecordInitializer.java
+++ b/src/main/java/dansplugins/dpm/utils/ProjectRecordInitializer.java
@@ -3,6 +3,8 @@ package dansplugins.dpm.utils;
 import dansplugins.dpm.factories.ProjectRecordFactory;
 
 public class ProjectRecordInitializer {
+    private static final String DANS_PLUGINS = "Dans-Plugins";
+
     private final ProjectRecordFactory projectRecordFactory;
 
     public ProjectRecordInitializer(ProjectRecordFactory projectRecordFactory) {
@@ -10,32 +12,35 @@ public class ProjectRecordInitializer {
     }
 
     public void initializeProjectRecords() {
-        createRecord("activitytracker", "https://github.com/Dans-Plugins/Activity-Tracker/releases/download/v1.0/ActivityTracker-v1.0.jar");
-        createRecord("alternateaccountfinder", "https://github.com/Dans-Plugins/AlternateAccountFinder/releases/download/v1.1/AlternateAccountFinder-v1.1.jar");
-        createRecord("chathub", "https://github.com/Dans-Plugins/ChatHub/releases/download/v0.4/ChatHub-v0.4.jar");
-        createRecord("conquestrecipes", "https://www.spigotmc.org/resources/conquest-recipes.83594/download?version=355341");
-        createRecord("currencies", "https://github.com/Dans-Plugins/Currencies/releases/download/v1.2/Currencies-1.2.jar");
-        createRecord("dansessentials", "https://github.com/Dans-Plugins/Dans-Essentials/releases/download/2.2/Dans-Essentials-2.2.jar");
-        createRecord("dansspawnsystem", "https://github.com/Dans-Plugins/Dans-Spawn-System/releases/download/v1.1/Dans-Spawn-System-v1.1.jar");
-        createRecord("easylinks", "https://github.com/Dans-Plugins/Easy-Links/releases/tag/v0.2.1");
-        createRecord("examplemfexpansion", "https://github.com/Dans-Plugins/Example-MF-Expansion/releases/download/v1.0/ExampleMFExpansion-1.0.jar");
-        createRecord("fiefs", "https://github.com/Dans-Plugins/Fiefs/releases/download/v0.10/Fiefs-0.10.jar");
-        createRecord("foodspoilage", "https://github.com/Dans-Plugins/FoodSpoilage/releases/download/v2.0/FoodSpoilage-v2.0.jar");
-        createRecord("itemdisabler", "https://github.com/Dans-Plugins/ItemDisabler/releases/download/v0.1/ItemDisabler-0.1.jar");
-        createRecord("mailboxes", "https://github.com/Dans-Plugins/Mailboxes/releases/download/v1.1/Mailboxes-v1.1.jar");
-        createRecord("medievaleconomy", "https://github.com/Dans-Plugins/Medieval-Economy/releases/download/v1.1.1/Medieval-Economy-v1.1.1.jar");
-        createRecord("medievalfactions", "https://github.com/Dans-Plugins/Medieval-Factions/releases/download/v4.6.2/Medieval-Factions-4.6.2.jar");
-        createRecord("medievalroleplayengine", "https://github.com/Dans-Plugins/Medieval-Roleplay-Engine/releases/download/v1.9/Medieval-Roleplay-Engine-v1.9.jar");
-        createRecord("modassist", "https://github.com/Dans-Plugins/ModAssist/releases/download/v1.1/ModAssist-v1.1.jar");
-        createRecord("morerecipes", "https://github.com/Dans-Plugins/More-Recipes/releases/download/v1.5/More-Recipes-v1.5.jar");
-        createRecord("netheraccesscontroller", "https://github.com/Dans-Plugins/Nether-Access-Controller/releases/download/v1.0.1/NetherAccessController-v1.0.1.jar");
-        createRecord("nomorecreepers", "https://github.com/Dans-Plugins/NoMoreCreepers/releases/download/v0.5/NoMoreCreepers-0.5.jar");
-        createRecord("playerlore", "https://github.com/Dans-Plugins/PlayerLore/releases/download/v0.4/PlayerLore-0.4.jar");
-        createRecord("simpleskills", "https://github.com/Dans-Plugins/SimpleSkills/releases/download/v2.0/SimpleSkills-2.0.jar");
-        createRecord("wildpets", "https://github.com/Dans-Plugins/Wild-Pets/releases/download/1.4/WildPets-1.4.jar");
+        gh("activitytracker",          "Activity-Tracker");
+        gh("alternateaccountfinder",   "AlternateAccountFinder");
+        gh("chathub",                  "ChatHub");
+        gh("currencies",               "Currencies");
+        gh("dansessentials",           "Dans-Essentials");
+        gh("dansspawnsystem",          "Dans-Spawn-System");
+        gh("easylinks",               "Easy-Links");
+        gh("fiefs",                    "Fiefs");
+        gh("foodspoilage",             "FoodSpoilage");
+        gh("mailboxes",               "Mailboxes");
+        gh("medievaleconomy",          "Medieval-Economy");
+        gh("medievalfactions",         "Medieval-Factions");
+        gh("medievalroleplayengine",   "Medieval-Roleplay-Engine");
+        gh("morerecipes",              "More-Recipes");
+        gh("netheraccesscontroller",   "Nether-Access-Controller");
+        gh("nomorecreepers",           "NoMoreCreepers");
+        gh("playerlore",              "PlayerLore");
+        gh("simpleskills",             "SimpleSkills");
+        gh("wildpets",                 "Wild-Pets");
+
+        // Spigot-hosted — no GitHub releases API available
+        link("conquestrecipes", "https://www.spigotmc.org/resources/conquest-recipes.83594/download?version=355341");
     }
 
-    private void createRecord(String name, String link) {
-        projectRecordFactory.createProjectRecord(name, link);
+    private void gh(String name, String repo) {
+        projectRecordFactory.createGitHubRecord(name, DANS_PLUGINS, repo);
+    }
+
+    private void link(String name, String directLink) {
+        projectRecordFactory.createDirectLinkRecord(name, directLink);
     }
 }

--- a/src/main/java/dansplugins/dpm/utils/ProjectRecordInitializer.java
+++ b/src/main/java/dansplugins/dpm/utils/ProjectRecordInitializer.java
@@ -14,33 +14,35 @@ public class ProjectRecordInitializer {
     public void initializeProjectRecords() {
         gh("activitytracker",          "Activity-Tracker");
         gh("alternateaccountfinder",   "AlternateAccountFinder");
-        gh("chathub",                  "ChatHub");
+        gh("bluemapmedievalfactions",  "Bluemap_MedievalFactions");
+        gh("bookshelvesyoucanuse",     "Bookshelves-You-Can-Use");
+        gh("conquestrecipes",          "Conquest-Recipes");
         gh("currencies",               "Currencies");
         gh("dansessentials",           "Dans-Essentials");
+        gh("danssethome",              "Dans-Set-Home");
         gh("dansspawnsystem",          "Dans-Spawn-System");
-        gh("easylinks",               "Easy-Links");
+        gh("democracy",                "Democracy");
+        gh("easylinks",                "Easy-Links");
         gh("fiefs",                    "Fiefs");
+        gh("flycommand",               "FlyCommand");
         gh("foodspoilage",             "FoodSpoilage");
-        gh("mailboxes",               "Mailboxes");
+        gh("herald",                   "Herald");
+        gh("kdrtracker",               "KDRTracker");
+        gh("mailboxes",                "Mailboxes");
+        gh("medievalcookery",          "Medieval-Cookery");
         gh("medievaleconomy",          "Medieval-Economy");
         gh("medievalfactions",         "Medieval-Factions");
         gh("medievalroleplayengine",   "Medieval-Roleplay-Engine");
+        gh("minifactions",             "MiniFactions");
         gh("morerecipes",              "More-Recipes");
         gh("netheraccesscontroller",   "Nether-Access-Controller");
         gh("nomorecreepers",           "NoMoreCreepers");
-        gh("playerlore",              "PlayerLore");
+        gh("playerlore",               "PlayerLore");
         gh("simpleskills",             "SimpleSkills");
         gh("wildpets",                 "Wild-Pets");
-
-        // Spigot-hosted — no GitHub releases API available
-        link("conquestrecipes", "https://www.spigotmc.org/resources/conquest-recipes.83594/download?version=355341");
     }
 
     private void gh(String name, String repo) {
         projectRecordFactory.createGitHubRecord(name, DANS_PLUGINS, repo);
-    }
-
-    private void link(String name, String directLink) {
-        projectRecordFactory.createDirectLinkRecord(name, directLink);
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -16,3 +16,5 @@ permissions:
     default: true
   dpm.get:
     default: op
+  dpm.clean:
+    default: op

--- a/src/test/java/dansplugins/dpm/data/EphemeralDataTest.java
+++ b/src/test/java/dansplugins/dpm/data/EphemeralDataTest.java
@@ -1,0 +1,85 @@
+package dansplugins.dpm.data;
+
+import dansplugins.dpm.objects.ProjectRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EphemeralDataTest {
+
+    private EphemeralData data;
+
+    @BeforeEach
+    void setUp() {
+        data = new EphemeralData();
+        data.addProjectRecord(ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions"));
+        data.addProjectRecord(ProjectRecord.forGitHub("currencies", "Dans-Plugins", "Currencies"));
+    }
+
+    // -------------------------------------------------------------------------
+    // getProjectRecord()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getProjectRecord_exactMatch() {
+        assertNotNull(data.getProjectRecord("medievalfactions"));
+    }
+
+    @Test
+    void getProjectRecord_caseInsensitive() {
+        assertNotNull(data.getProjectRecord("MedievalFactions"));
+        assertNotNull(data.getProjectRecord("CURRENCIES"));
+    }
+
+    @Test
+    void getProjectRecord_returnsNullForUnknown() {
+        assertNull(data.getProjectRecord("notaplugin"));
+    }
+
+    // -------------------------------------------------------------------------
+    // getAllProjectRecords()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getAllProjectRecords_returnsAllRecords() {
+        assertEquals(2, data.getAllProjectRecords().size());
+    }
+
+    @Test
+    void getAllProjectRecords_returnsDefensiveCopy() {
+        List<ProjectRecord> copy = data.getAllProjectRecords();
+        copy.clear();
+        assertEquals(2, data.getAllProjectRecords().size());
+    }
+
+    // -------------------------------------------------------------------------
+    // getNumProjectRecords()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getNumProjectRecords_reflectsCurrentCount() {
+        assertEquals(2, data.getNumProjectRecords());
+        data.addProjectRecord(ProjectRecord.forGitHub("flycommand", "Dans-Plugins", "Fly-Command"));
+        assertEquals(3, data.getNumProjectRecords());
+    }
+
+    // -------------------------------------------------------------------------
+    // removeProjectRecord()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void removeProjectRecord_decreasesCount() {
+        ProjectRecord r = data.getProjectRecord("currencies");
+        assertTrue(data.removeProjectRecord(r));
+        assertEquals(1, data.getNumProjectRecords());
+    }
+
+    @Test
+    void removeProjectRecord_returnsFalseForAbsentRecord() {
+        ProjectRecord stranger = ProjectRecord.forGitHub("nothere", "Org", "Repo");
+        assertFalse(data.removeProjectRecord(stranger));
+    }
+}

--- a/src/test/java/dansplugins/dpm/objects/ProjectRecordTest.java
+++ b/src/test/java/dansplugins/dpm/objects/ProjectRecordTest.java
@@ -1,0 +1,35 @@
+package dansplugins.dpm.objects;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProjectRecordTest {
+
+    @Test
+    void forGitHub_storesName() {
+        ProjectRecord r = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
+        assertEquals("medievalfactions", r.getName());
+    }
+
+    @Test
+    void forGitHub_storesOwner() {
+        ProjectRecord r = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
+        assertEquals("Dans-Plugins", r.getOwner());
+    }
+
+    @Test
+    void forGitHub_storesRepo() {
+        ProjectRecord r = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
+        assertEquals("Medieval-Factions", r.getRepo());
+    }
+
+    @Test
+    void forGitHub_distinctInstancesAreIndependent() {
+        ProjectRecord a = ProjectRecord.forGitHub("alpha", "OrgA", "RepoA");
+        ProjectRecord b = ProjectRecord.forGitHub("beta", "OrgB", "RepoB");
+        assertNotEquals(a.getName(), b.getName());
+        assertNotEquals(a.getOwner(), b.getOwner());
+        assertNotEquals(a.getRepo(), b.getRepo());
+    }
+}

--- a/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
@@ -1,0 +1,68 @@
+package dansplugins.dpm.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DownloadServiceTest {
+
+    // Logger, GitHubReleaseService, and PluginFolderService are unused by readAndWrite.
+    private final DownloadService service = new DownloadService(null, null, null);
+
+    // -------------------------------------------------------------------------
+    // readAndWrite()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void readAndWrite_writesSourceBytesToDest(@TempDir Path tempDir) throws IOException {
+        byte[] content = {1, 2, 3, 4, 5};
+        File src = tempDir.resolve("source.bin").toFile();
+        Files.write(src.toPath(), content);
+
+        File dest = tempDir.resolve("dest.jar").toFile();
+        int bytes = service.readAndWrite(src.toURI().toString(), dest.getAbsolutePath());
+
+        assertEquals(content.length, bytes);
+        assertArrayEquals(content, Files.readAllBytes(dest.toPath()));
+    }
+
+    @Test
+    void readAndWrite_returnsZeroForEmptySource(@TempDir Path tempDir) throws IOException {
+        File src = tempDir.resolve("empty.bin").toFile();
+        src.createNewFile();
+
+        File dest = tempDir.resolve("dest.jar").toFile();
+        int bytes = service.readAndWrite(src.toURI().toString(), dest.getAbsolutePath());
+
+        assertEquals(0, bytes);
+        assertTrue(dest.exists());
+    }
+
+    @Test
+    void readAndWrite_deletesPartialFileOnFailure(@TempDir Path tempDir) throws IOException {
+        // Pre-create a file at the destination to simulate a partial download artifact.
+        File partial = tempDir.resolve("partial.jar").toFile();
+        partial.createNewFile();
+
+        // Port 1 is privileged and always refused — guarantees a connection error.
+        assertThrows(IOException.class, () ->
+                service.readAndWrite("http://localhost:1/nonexistent.jar", partial.getAbsolutePath())
+        );
+
+        assertFalse(partial.exists(), "Partial file must be deleted after a failed download");
+    }
+
+    @Test
+    void readAndWrite_throwsOnBadUrl(@TempDir Path tempDir) {
+        File dest = tempDir.resolve("dest.jar").toFile();
+        assertThrows(IOException.class, () ->
+                service.readAndWrite("not-a-valid-url", dest.getAbsolutePath())
+        );
+    }
+}

--- a/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
@@ -1,0 +1,90 @@
+package dansplugins.dpm.services;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GitHubReleaseServiceTest {
+
+    // Logger is only used for HTTP errors; null is safe for pure parsing tests.
+    private final GitHubReleaseService service = new GitHubReleaseService(null);
+
+    // -------------------------------------------------------------------------
+    // parseJarUrlFromAssets()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void parseJarUrlFromAssets_returnsJarUrl() {
+        String json = "{\"assets\":[{\"name\":\"Plugin-1.0.jar\"," +
+                "\"browser_download_url\":\"https://github.com/org/repo/releases/download/v1.0/Plugin-1.0.jar\"}]}";
+        assertEquals(
+                "https://github.com/org/repo/releases/download/v1.0/Plugin-1.0.jar",
+                service.parseJarUrlFromAssets(json)
+        );
+    }
+
+    @Test
+    void parseJarUrlFromAssets_skipsNonJarAssets() {
+        String json = "{\"assets\":[" +
+                "{\"name\":\"checksums.txt\",\"browser_download_url\":\"https://example.com/checksums.txt\"}," +
+                "{\"name\":\"Plugin-1.0.jar\",\"browser_download_url\":\"https://example.com/Plugin-1.0.jar\"}" +
+                "]}";
+        assertEquals("https://example.com/Plugin-1.0.jar", service.parseJarUrlFromAssets(json));
+    }
+
+    @Test
+    void parseJarUrlFromAssets_returnsNullWhenNoJarAsset() {
+        String json = "{\"assets\":[{\"name\":\"checksums.txt\"," +
+                "\"browser_download_url\":\"https://example.com/checksums.txt\"}]}";
+        assertNull(service.parseJarUrlFromAssets(json));
+    }
+
+    @Test
+    void parseJarUrlFromAssets_returnsNullForEmptyAssetsArray() {
+        assertNull(service.parseJarUrlFromAssets("{\"assets\":[]}"));
+    }
+
+    @Test
+    void parseJarUrlFromAssets_returnsNullWhenNoAssetsKey() {
+        assertNull(service.parseJarUrlFromAssets("{\"tag_name\":\"v1.0\"}"));
+    }
+
+    @Test
+    void parseJarUrlFromAssets_ignoresFakeUrlInReleaseBody() {
+        // A release body containing the literal text "browser_download_url" must not
+        // be matched — the search must be scoped to the assets array only.
+        String json = "{\"body\":\"see \\\"browser_download_url\\\": \\\"https://evil.com/fake.jar\\\" for details\"," +
+                "\"assets\":[{\"name\":\"Real-1.0.jar\"," +
+                "\"browser_download_url\":\"https://github.com/org/repo/releases/download/v1.0/Real-1.0.jar\"}]}";
+        assertEquals(
+                "https://github.com/org/repo/releases/download/v1.0/Real-1.0.jar",
+                service.parseJarUrlFromAssets(json)
+        );
+    }
+
+    @Test
+    void parseJarUrlFromAssets_handlesEscapedCharactersInUrl() {
+        // Ensure backslash-escaped sequences in the URL string don't break extraction.
+        String json = "{\"assets\":[{\"name\":\"Plugin-1.0.jar\"," +
+                "\"browser_download_url\":\"https://example.com/path\\/Plugin-1.0.jar\"}]}";
+        assertTrue(service.parseJarUrlFromAssets(json).endsWith(".jar"));
+    }
+
+    @Test
+    void parseJarUrlFromAssets_doesNotMatchBeyondAssetsArray() {
+        // Fields after the closing ] of assets must not be scanned.
+        String json = "{\"assets\":[]," +
+                "\"uploader\":{\"browser_download_url\":\"https://example.com/outside.jar\"}}";
+        assertNull(service.parseJarUrlFromAssets(json));
+    }
+
+    @Test
+    void parseJarUrlFromAssets_handlesMultipleAssets() {
+        String json = "{\"assets\":[" +
+                "{\"name\":\"Plugin-1.0-sources.jar\",\"browser_download_url\":\"https://example.com/Plugin-1.0-sources.jar\"}," +
+                "{\"name\":\"Plugin-1.0.jar\",\"browser_download_url\":\"https://example.com/Plugin-1.0.jar\"}" +
+                "]}";
+        // Should return the first .jar match
+        assertEquals("https://example.com/Plugin-1.0-sources.jar", service.parseJarUrlFromAssets(json));
+    }
+}

--- a/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
@@ -87,4 +87,16 @@ class GitHubReleaseServiceTest {
         // Should return the first .jar match
         assertEquals("https://example.com/Plugin-1.0-sources.jar", service.parseJarUrlFromAssets(json));
     }
+
+    @Test
+    void parseJarUrlFromAssets_emptyStringReturnsNull() {
+        assertNull(service.parseJarUrlFromAssets(""));
+    }
+
+    @Test
+    void parseJarUrlFromAssets_truncatedJsonReturnsNull() {
+        // No closing bracket — bracket-depth tracking should handle gracefully
+        String json = "{\"assets\":[{\"name\":\"Plugin-1.0.jar\",\"browser_download_url\":\"https://example.com/Plugin-1.0.jar\"";
+        assertNull(service.parseJarUrlFromAssets(json));
+    }
 }

--- a/src/test/java/dansplugins/dpm/services/PluginFolderServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/PluginFolderServiceTest.java
@@ -1,0 +1,143 @@
+package dansplugins.dpm.services;
+
+import dansplugins.dpm.objects.ProjectRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PluginFolderServiceTest {
+
+    private final PluginFolderService service = new PluginFolderService();
+
+    // -------------------------------------------------------------------------
+    // normalize()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void normalize_stripsExtension() {
+        assertEquals("medievalfactions", service.normalize("medievalfactions.jar"));
+    }
+
+    @Test
+    void normalize_stripsVersionSuffix() {
+        assertEquals("medievalfactions", service.normalize("Medieval-Factions-4.6.3.jar"));
+    }
+
+    @Test
+    void normalize_stripsVersionSuffixWithV() {
+        assertEquals("activitytracker", service.normalize("ActivityTracker-v1.0.jar"));
+    }
+
+    @Test
+    void normalize_stripsUnderscoreSeparators() {
+        assertEquals("bluemapmedievalfactions", service.normalize("Bluemap_MedievalFactions.jar"));
+    }
+
+    @Test
+    void normalize_stripsHyphensWithNoVersion() {
+        assertEquals("dansessentials", service.normalize("Dans-Essentials.jar"));
+    }
+
+    @Test
+    void normalize_stripsHyphensAndVersion() {
+        assertEquals("dansessentials", service.normalize("Dans-Essentials-2.2.jar"));
+    }
+
+    @Test
+    void normalize_camelCaseNoSeparators() {
+        assertEquals("wildpets", service.normalize("WildPets-1.4.jar"));
+    }
+
+    @Test
+    void normalize_singleWordPlugin() {
+        assertEquals("mailboxes", service.normalize("Mailboxes-v1.1.jar"));
+    }
+
+    @Test
+    void normalize_alreadyNormalized() {
+        assertEquals("simpleskills", service.normalize("simpleskills.jar"));
+    }
+
+    @Test
+    void normalize_mixedCaseExtension() {
+        assertEquals("currencies", service.normalize("Currencies.JAR"));
+    }
+
+    // -------------------------------------------------------------------------
+    // findConflictingJars()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void findConflictingJars_returnsVersionedCopy(@TempDir Path tempDir) throws IOException {
+        createFile(tempDir, "Medieval-Factions-4.6.3.jar");
+        createFile(tempDir, "medievalfactions.jar");
+
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
+
+        List<File> conflicts = svc.findConflictingJars(record);
+        assertEquals(1, conflicts.size());
+        assertEquals("Medieval-Factions-4.6.3.jar", conflicts.get(0).getName());
+    }
+
+    @Test
+    void findConflictingJars_ignoresManagedFile(@TempDir Path tempDir) throws IOException {
+        createFile(tempDir, "medievalfactions.jar");
+
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
+
+        assertTrue(svc.findConflictingJars(record).isEmpty());
+    }
+
+    @Test
+    void findConflictingJars_ignoresDifferentPlugin(@TempDir Path tempDir) throws IOException {
+        createFile(tempDir, "Medieval-Factions-4.6.3.jar");
+
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        ProjectRecord record = ProjectRecord.forGitHub("currencies", "Dans-Plugins", "Currencies");
+
+        assertTrue(svc.findConflictingJars(record).isEmpty());
+    }
+
+    @Test
+    void findConflictingJars_returnsMultipleConflicts(@TempDir Path tempDir) throws IOException {
+        createFile(tempDir, "Medieval-Factions-4.6.2.jar");
+        createFile(tempDir, "Medieval-Factions-4.6.3.jar");
+        createFile(tempDir, "medievalfactions.jar");
+
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
+
+        assertEquals(2, svc.findConflictingJars(record).size());
+    }
+
+    @Test
+    void findConflictingJars_emptyFolder(@TempDir Path tempDir) {
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
+
+        assertTrue(svc.findConflictingJars(record).isEmpty());
+    }
+
+    @Test
+    void findConflictingJars_ignoresNonJarFiles(@TempDir Path tempDir) throws IOException {
+        createFile(tempDir, "Medieval-Factions-4.6.3.zip");
+        createFile(tempDir, "Medieval-Factions-4.6.3.txt");
+
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
+
+        assertTrue(svc.findConflictingJars(record).isEmpty());
+    }
+
+    private void createFile(Path dir, String name) throws IOException {
+        new File(dir.toFile(), name).createNewFile();
+    }
+}

--- a/src/test/java/dansplugins/dpm/services/PluginFolderServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/PluginFolderServiceTest.java
@@ -69,6 +69,30 @@ class PluginFolderServiceTest {
         assertEquals("currencies", service.normalize("Currencies.JAR"));
     }
 
+    @Test
+    void normalize_stripsSnapshotQualifier() {
+        assertEquals("plugin", service.normalize("Plugin-1.0-SNAPSHOT.jar"));
+    }
+
+    @Test
+    void normalize_stripsAlphaQualifier() {
+        // Real-world filename from MiniFactions release history
+        assertEquals("minifactions", service.normalize("MiniFactions-0.1-ALPHA-4-17-2022.jar"));
+    }
+
+    @Test
+    void normalize_stripsUnderscoreVersion() {
+        assertEquals("wildpets", service.normalize("Wild_Pets_1.4.jar"));
+    }
+
+    @Test
+    void normalize_preservesEmbeddedDigitsInName() {
+        // The '3' is part of the plugin name, not a version — it must not be stripped
+        String result = service.normalize("Dans3Essentials-2.0.jar");
+        assertTrue(result.contains("3"), "Embedded digit in name should be preserved, got: " + result);
+        assertFalse(result.contains("2"), "Version digit should be stripped, got: " + result);
+    }
+
     // -------------------------------------------------------------------------
     // findConflictingJars()
     // -------------------------------------------------------------------------
@@ -132,6 +156,28 @@ class PluginFolderServiceTest {
         createFile(tempDir, "Medieval-Factions-4.6.3.txt");
 
         PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
+
+        assertTrue(svc.findConflictingJars(record).isEmpty());
+    }
+
+    @Test
+    void findConflictingJars_caseInsensitiveManagedFileExclusion(@TempDir Path tempDir) throws IOException {
+        // The managed file is in uppercase — it must still be recognised as the canonical copy
+        createFile(tempDir, "MEDIEVALFACTIONS.JAR");
+        createFile(tempDir, "Medieval-Factions-4.6.3.jar");
+
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
+
+        List<File> conflicts = svc.findConflictingJars(record);
+        assertEquals(1, conflicts.size());
+        assertEquals("Medieval-Factions-4.6.3.jar", conflicts.get(0).getName());
+    }
+
+    @Test
+    void findConflictingJars_nonExistentFolderReturnsEmpty() {
+        PluginFolderService svc = new PluginFolderService("/this/path/does/not/exist");
         ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
 
         assertTrue(svc.findConflictingJars(record).isEmpty());


### PR DESCRIPTION
## What

Replaces every hardcoded Spigot/direct-link URL with a live GitHub Releases API call, ensures all public DPC plugin repos are registered, prevents and cleans up duplicate JARs, fixes a resource leak, removes dead config code, and adds a full unit-test suite.

## Changes

### Dynamic GitHub release retrieval (closes #9)
- `GitHubReleaseService` — calls `GET /repos/{owner}/{repo}/releases/latest`, returns the first `.jar` asset URL; sentinel `NO_RELEASE` when no release exists yet; `User-Agent`, connect/read timeouts, `disconnect()` in finally
- `DownloadService.downloadLatest()` — resolves URL at runtime via the service; removes conflicting JARs before writing; reports bytes transferred
- `/dpm get` runs the download asynchronously and hands the result back to the main thread

### Full public plugin roster
- 28 public DPC plugins registered via `ProjectRecordFactory`; private repos and repos that don't exist excluded

### Duplicate JAR prevention (closes #11)
- `PluginFolderService` — filename normalisation (strip extension → strip version suffix → strip separators → lowercase) for fuzzy matching; `findConflictingJars()` scoped to JAR files only, excludes the canonical managed copy
- `/dpm clean` — async scan of all records, deletes versioned duplicates, reports results on the main thread
- `DownloadService` removes conflicts automatically before every download

### Resource leak fix (closes #15)
- `DownloadService.readAndWrite()` now uses try-with-resources so both streams are always closed; a partial JAR written before an exception is deleted on failure

### Dead config code removed (closes #19)
- `ConfigService.setConfigOption()` no longer contains placeholder branches for config keys `"A"` and `"C"`
- Unused `getInt`, `getIntOrDefault`, `getDouble`, `getDoubleOrDefault` helper methods removed
- `sendConfigList()` now outputs actual typed values rather than everything as a string

### Documentation
- `CHANGELOG.md` — Unreleased content collapsed into `[0.4.0]`
- `COMMANDS.md` — `/dpm clean` added; `<project-name>` → `<plugin-name>` throughout
- `USER_GUIDE.md` — `dpm.clean` permission row; step 2 example corrected
- `CONTRIBUTING.md` — simplified; removed duplicate build-steps section

### Unit tests (45 total)
- `GitHubReleaseServiceTest` — 11 tests: JAR URL extraction, asset scoping, edge cases (empty string, truncated JSON, fake URL in release body, escaped chars)
- `PluginFolderServiceTest` — 22 tests: normalisation variants (SNAPSHOT, alpha/beta qualifiers, underscores, embedded digits, mixed-case extensions), conflict detection edge cases (case-insensitive exclusion, non-existent folder, multiple conflicts)
- `ProjectRecordTest` — 4 tests: factory fields, getter correctness, instance independence
- `EphemeralDataTest` — 8 tests: case-insensitive lookup, null for unknown, defensive copy, count accuracy, remove behaviour

## Test plan
- [ ] `mvn test` — all 45 tests pass, 0 failures
- [ ] `/dpm list` shows all 28 registered plugins
- [ ] `/dpm get medievalfactions` downloads the latest JAR asynchronously and reports KB transferred
- [ ] `/dpm get <plugin-with-no-release>` reports "no published release yet" rather than an error
- [ ] Installing a versioned JAR alongside the managed copy and running `/dpm clean` removes the duplicate
- [ ] `/dpm get` on a plugin that already has a versioned copy removes it before downloading
- [ ] Interrupting a download mid-stream leaves no partial JAR in the plugins folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_