### PR TITLE
Tab-completion for /dpm sub-commands and plugin names (closes #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Tab-completion for `/dpm` sub-commands (`help`, `list`, `get`, `clean`, `stats`) and plugin names for `/dpm get`
-
-### Added
 - Version tracking — last-downloaded release tag is persisted in `dpm-versions.properties`; `/dpm get` skips re-download when already on the latest version and reports the current tag
 - `/dpm list` now shows installed plugins in green (with their version tag when known) and uninstalled plugins in grey
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- Tab-completion for `/dpm` sub-commands (`help`, `list`, `get`, `clean`, `stats`) and plugin names for `/dpm get`
+
+### Added
 - Version tracking — last-downloaded release tag is persisted in `dpm-versions.properties`; `/dpm get` skips re-download when already on the latest version and reports the current tag
 - `/dpm list` now shows installed plugins in green (with their version tag when known) and uninstalled plugins in grey
 

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -11,6 +11,7 @@ import dansplugins.dpm.services.PluginFolderService;
 import dansplugins.dpm.services.VersionStore;
 import dansplugins.dpm.utils.Logger;
 import dansplugins.dpm.utils.ProjectRecordInitializer;
+import dansplugins.dpm.utils.TabCompleter;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
@@ -72,14 +73,14 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     @Override
     public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, String[] args) {
         if (args.length == 1) {
-            return filterByPrefix(Arrays.asList("help", "list", "get", "clean", "stats"), args[0]);
+            return TabCompleter.filterByPrefix(Arrays.asList("help", "list", "get", "clean", "stats"), args[0]);
         }
         if (args.length == 2 && args[0].equalsIgnoreCase("get")) {
             List<String> names = new ArrayList<>();
             for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
                 names.add(record.getName());
             }
-            return filterByPrefix(names, args[1]);
+            return TabCompleter.filterByPrefix(names, args[1]);
         }
         return Collections.emptyList();
     }
@@ -146,17 +147,6 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     /**
      * Initializes Ponder's command service with the plugin's commands.
      */
-    List<String> filterByPrefix(List<String> options, String partial) {
-        String lower = partial.toLowerCase();
-        List<String> result = new ArrayList<>();
-        for (String option : options) {
-            if (option.startsWith(lower)) {
-                result.add(option);
-            }
-        }
-        return result;
-    }
-
     private void initializeCommandService() {
         ArrayList<AbstractPluginCommand> commands = new ArrayList<>(Arrays.asList(
                 new HelpCommand(),

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -2,6 +2,7 @@ package dansplugins.dpm;
 
 import dansplugins.dpm.commands.*;
 import dansplugins.dpm.data.EphemeralData;
+import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.factories.ProjectRecordFactory;
 import dansplugins.dpm.services.ConfigService;
 import dansplugins.dpm.services.DownloadService;
@@ -20,6 +21,8 @@ import preponderous.ponder.minecraft.bukkit.services.CommandService;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author Daniel McCoy Stephenson
@@ -66,6 +69,21 @@ public final class DansPluginManager extends PonderBukkitPlugin {
      * @param args Arguments of the core command. Often sub-commands.
      * @return A boolean indicating whether the execution of the command was successful.
      */
+    @Override
+    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, String[] args) {
+        if (args.length == 1) {
+            return filterByPrefix(Arrays.asList("help", "list", "get", "clean", "stats"), args[0]);
+        }
+        if (args.length == 2 && args[0].equalsIgnoreCase("get")) {
+            List<String> names = new ArrayList<>();
+            for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
+                names.add(record.getName());
+            }
+            return filterByPrefix(names, args[1]);
+        }
+        return Collections.emptyList();
+    }
+
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, String[] args) {
         if (args.length == 0) {
@@ -128,6 +146,17 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     /**
      * Initializes Ponder's command service with the plugin's commands.
      */
+    List<String> filterByPrefix(List<String> options, String partial) {
+        String lower = partial.toLowerCase();
+        List<String> result = new ArrayList<>();
+        for (String option : options) {
+            if (option.startsWith(lower)) {
+                result.add(option);
+            }
+        }
+        return result;
+    }
+
     private void initializeCommandService() {
         ArrayList<AbstractPluginCommand> commands = new ArrayList<>(Arrays.asList(
                 new HelpCommand(),

--- a/src/main/java/dansplugins/dpm/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/HelpCommand.java
@@ -20,7 +20,7 @@ public class HelpCommand extends AbstractPluginCommand {
     public boolean execute(CommandSender commandSender) {
         commandSender.sendMessage(ChatColor.AQUA + "=== DPM Commands ===");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm help - View this list of commands.");
-        commandSender.sendMessage(ChatColor.AQUA + "/dpm list - List available plugins.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm list - List plugins with install status.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm get <plugin-name> - Download a plugin.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm clean - Remove duplicate plugin JARs.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm stats - View plugin statistics.");

--- a/src/main/java/dansplugins/dpm/utils/TabCompleter.java
+++ b/src/main/java/dansplugins/dpm/utils/TabCompleter.java
@@ -1,0 +1,24 @@
+package dansplugins.dpm.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TabCompleter {
+
+    private TabCompleter() {}
+
+    /**
+     * Returns every option whose lowercase form starts with the lowercase form
+     * of {@code partial}, preserving original casing in the returned strings.
+     */
+    public static List<String> filterByPrefix(List<String> options, String partial) {
+        String lower = partial.toLowerCase();
+        List<String> result = new ArrayList<>();
+        for (String option : options) {
+            if (option.toLowerCase().startsWith(lower)) {
+                result.add(option);
+            }
+        }
+        return result;
+    }
+}

--- a/src/test/java/dansplugins/dpm/TabCompletionTest.java
+++ b/src/test/java/dansplugins/dpm/TabCompletionTest.java
@@ -1,5 +1,6 @@
 package dansplugins.dpm;
 
+import dansplugins.dpm.utils.TabCompleter;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -7,23 +8,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/**
- * Tests the tab-completion helper in isolation without a running Bukkit server.
- * DansPluginManager is not instantiated — only filterByPrefix() is exercised.
- */
 class TabCompletionTest {
-
-    // Thin stand-in that exposes the package-private method without Bukkit.
-    private final DansPluginManager plugin = null;
-
-    private List<String> filter(List<String> options, String partial) {
-        String lower = partial.toLowerCase();
-        List<String> result = new java.util.ArrayList<>();
-        for (String option : options) {
-            if (option.startsWith(lower)) result.add(option);
-        }
-        return result;
-    }
 
     private static final List<String> SUBCOMMANDS =
             Arrays.asList("help", "list", "get", "clean", "stats");
@@ -34,29 +19,28 @@ class TabCompletionTest {
 
     @Test
     void filterByPrefix_emptyPartialReturnsAll() {
-        assertEquals(SUBCOMMANDS, filter(SUBCOMMANDS, ""));
+        assertEquals(SUBCOMMANDS, TabCompleter.filterByPrefix(SUBCOMMANDS, ""));
     }
 
     @Test
     void filterByPrefix_exactMatchReturnsOne() {
-        assertEquals(List.of("get"), filter(SUBCOMMANDS, "get"));
+        assertEquals(List.of("get"), TabCompleter.filterByPrefix(SUBCOMMANDS, "get"));
     }
 
     @Test
     void filterByPrefix_prefixMatchReturnsSubset() {
-        List<String> result = filter(SUBCOMMANDS, "l");
-        assertEquals(List.of("list"), result);
+        assertEquals(List.of("list"), TabCompleter.filterByPrefix(SUBCOMMANDS, "l"));
     }
 
     @Test
     void filterByPrefix_caseInsensitiveMatch() {
-        assertEquals(List.of("get"), filter(SUBCOMMANDS, "GET"));
-        assertEquals(List.of("clean"), filter(SUBCOMMANDS, "CL"));
+        assertEquals(List.of("get"), TabCompleter.filterByPrefix(SUBCOMMANDS, "GET"));
+        assertEquals(List.of("clean"), TabCompleter.filterByPrefix(SUBCOMMANDS, "CL"));
     }
 
     @Test
     void filterByPrefix_noMatchReturnsEmpty() {
-        assertTrue(filter(SUBCOMMANDS, "xyz").isEmpty());
+        assertTrue(TabCompleter.filterByPrefix(SUBCOMMANDS, "xyz").isEmpty());
     }
 
     // -------------------------------------------------------------------------
@@ -69,7 +53,7 @@ class TabCompletionTest {
                 "medievalfactions", "medievaleconomy", "medievalroleplayengine",
                 "currencies", "simpleskills"
         );
-        List<String> result = filter(plugins, "medieval");
+        List<String> result = TabCompleter.filterByPrefix(plugins, "medieval");
         assertEquals(3, result.size());
         assertTrue(result.containsAll(Arrays.asList(
                 "medievalfactions", "medievaleconomy", "medievalroleplayengine")));
@@ -78,7 +62,7 @@ class TabCompletionTest {
     @Test
     void filterByPrefix_singleCharacterNarrows() {
         List<String> plugins = Arrays.asList("currencies", "conquestrecipes", "simpleskills");
-        List<String> result = filter(plugins, "c");
-        assertEquals(List.of("currencies", "conquestrecipes"), result);
+        assertEquals(List.of("currencies", "conquestrecipes"),
+                TabCompleter.filterByPrefix(plugins, "c"));
     }
 }

--- a/src/test/java/dansplugins/dpm/TabCompletionTest.java
+++ b/src/test/java/dansplugins/dpm/TabCompletionTest.java
@@ -1,0 +1,84 @@
+package dansplugins.dpm;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests the tab-completion helper in isolation without a running Bukkit server.
+ * DansPluginManager is not instantiated — only filterByPrefix() is exercised.
+ */
+class TabCompletionTest {
+
+    // Thin stand-in that exposes the package-private method without Bukkit.
+    private final DansPluginManager plugin = null;
+
+    private List<String> filter(List<String> options, String partial) {
+        String lower = partial.toLowerCase();
+        List<String> result = new java.util.ArrayList<>();
+        for (String option : options) {
+            if (option.startsWith(lower)) result.add(option);
+        }
+        return result;
+    }
+
+    private static final List<String> SUBCOMMANDS =
+            Arrays.asList("help", "list", "get", "clean", "stats");
+
+    // -------------------------------------------------------------------------
+    // sub-command completion
+    // -------------------------------------------------------------------------
+
+    @Test
+    void filterByPrefix_emptyPartialReturnsAll() {
+        assertEquals(SUBCOMMANDS, filter(SUBCOMMANDS, ""));
+    }
+
+    @Test
+    void filterByPrefix_exactMatchReturnsOne() {
+        assertEquals(List.of("get"), filter(SUBCOMMANDS, "get"));
+    }
+
+    @Test
+    void filterByPrefix_prefixMatchReturnsSubset() {
+        List<String> result = filter(SUBCOMMANDS, "l");
+        assertEquals(List.of("list"), result);
+    }
+
+    @Test
+    void filterByPrefix_caseInsensitiveMatch() {
+        assertEquals(List.of("get"), filter(SUBCOMMANDS, "GET"));
+        assertEquals(List.of("clean"), filter(SUBCOMMANDS, "CL"));
+    }
+
+    @Test
+    void filterByPrefix_noMatchReturnsEmpty() {
+        assertTrue(filter(SUBCOMMANDS, "xyz").isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // plugin-name completion
+    // -------------------------------------------------------------------------
+
+    @Test
+    void filterByPrefix_partialPluginNameNarrowsResults() {
+        List<String> plugins = Arrays.asList(
+                "medievalfactions", "medievaleconomy", "medievalroleplayengine",
+                "currencies", "simpleskills"
+        );
+        List<String> result = filter(plugins, "medieval");
+        assertEquals(3, result.size());
+        assertTrue(result.containsAll(Arrays.asList(
+                "medievalfactions", "medievaleconomy", "medievalroleplayengine")));
+    }
+
+    @Test
+    void filterByPrefix_singleCharacterNarrows() {
+        List<String> plugins = Arrays.asList("currencies", "conquestrecipes", "simpleskills");
+        List<String> result = filter(plugins, "c");
+        assertEquals(List.of("currencies", "conquestrecipes"), result);
+    }
+}


### PR DESCRIPTION
## What

Adds tab-completion so `/dpm <tab>` shows available sub-commands and `/dpm get <tab>` narrows to registered plugin names.

## Changes

- `DansPluginManager.onTabComplete()` — completes sub-commands (`help`, `list`, `get`, `clean`, `stats`) on the first argument; completes registered plugin names on the second argument when the sub-command is `get`
- Matching is case-insensitive and prefix-based: `/dpm get med<tab>` returns `medievalfactions`, `medievaleconomy`, `medievalroleplayengine`, etc.
- `filterByPrefix()` is package-private for unit testing without a Bukkit runtime

## Tests (74 total, up from 67)

`TabCompletionTest` — 7 tests: empty partial returns all, exact match, prefix narrows to subset, case-insensitive match, no match returns empty, multi-result plugin name narrowing, single-character narrowing.

## Test plan
- [ ] `mvn test` — 74 tests, 0 failures
- [ ] `/dpm <tab>` lists all five sub-commands
- [ ] `/dpm g<tab>` completes to `get`
- [ ] `/dpm get <tab>` lists all 28 registered plugin names
- [ ] `/dpm get med<tab>` narrows to the three medieval plugins
- [ ] `/dpm get MED<tab>` narrows correctly (case-insensitive)
- [ ] `/dpm list <tab>` returns nothing (no further args expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_