### PR TITLE
Add /dpm update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-- Tab-completion for `/dpm` sub-commands (`help`, `list`, `get`, `clean`, `stats`) and plugin names for `/dpm get`
+- Tab-completion for `/dpm` sub-commands (`help`, `list`, `get`, `clean`, `stats`, `update`) and plugin names for `/dpm get`
 - Version tracking — last-downloaded release tag is persisted in `dpm-versions.properties`; `/dpm get` skips re-download when already on the latest version and reports the current tag
 - `/dpm list` now shows installed plugins in green (with their version tag when known) and uninstalled plugins in grey
+- `/dpm update` — checks every installed managed plugin against the latest GitHub release and downloads any that are out of date; prints a per-plugin result and a summary line
 
 ## [0.4.0]
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -9,3 +9,4 @@ All commands use `/dpm` or `/danspluginmanager` as the base.
 | `/dpm get <plugin-name>` | Download a DPC plugin to the server. | `dpm.get` |
 | `/dpm clean` | Remove duplicate plugin JARs from the plugins folder. | `dpm.clean` |
 | `/dpm stats` | View plugin statistics. | `dpm.stats` |
+| `/dpm update` | Update all installed managed plugins to their latest release. | `dpm.update` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -14,7 +14,8 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 
 1. Run `/dpm list` to see all DPC plugins. Green entries are installed (with version tag when known); grey entries are not yet installed.
 2. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). If the plugin is already on the latest version, the download is skipped.
-3. Restart the server to activate the downloaded plugin.
+3. Run `/dpm update` to check every installed managed plugin against its latest GitHub release and download any that are out of date.
+4. Restart the server to activate downloaded or updated plugins.
 
 ## Permissions
 
@@ -25,6 +26,7 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 | `dpm.stats` | `true` | View plugin statistics. |
 | `dpm.get` | `op` | Download a plugin to the server. |
 | `dpm.clean` | `op` | Remove duplicate plugin JARs. |
+| `dpm.update` | `op` | Update all installed managed plugins. |
 
 ## Support
 

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -73,7 +73,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     @Override
     public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, String[] args) {
         if (args.length == 1) {
-            return TabCompleter.filterByPrefix(Arrays.asList("help", "list", "get", "clean", "stats"), args[0]);
+            return TabCompleter.filterByPrefix(Arrays.asList("help", "list", "get", "clean", "stats", "update"), args[0]);
         }
         if (args.length == 2 && args[0].equalsIgnoreCase("get")) {
             List<String> names = new ArrayList<>();
@@ -153,7 +153,8 @@ public final class DansPluginManager extends PonderBukkitPlugin {
                 new GetCommand(ephemeralData, downloadService, versionStore, this),
                 new ListCommand(ephemeralData, pluginFolderService, versionStore),
                 new StatsCommand(ephemeralData),
-                new CleanCommand(ephemeralData, pluginFolderService, this)
+                new CleanCommand(ephemeralData, pluginFolderService, this),
+                new UpdateCommand(ephemeralData, downloadService, pluginFolderService, versionStore, this)
         ));
         commandService.initialize(commands, "That command wasn't found.");
     }

--- a/src/main/java/dansplugins/dpm/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/HelpCommand.java
@@ -24,6 +24,7 @@ public class HelpCommand extends AbstractPluginCommand {
         commandSender.sendMessage(ChatColor.AQUA + "/dpm get <plugin-name> - Download a plugin.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm clean - Remove duplicate plugin JARs.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm stats - View plugin statistics.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm update - Update all installed plugins.");
         return true;
     }
 

--- a/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
@@ -1,0 +1,97 @@
+package dansplugins.dpm.commands;
+
+import dansplugins.dpm.data.EphemeralData;
+import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.services.DownloadService;
+import dansplugins.dpm.services.PluginFolderService;
+import dansplugins.dpm.services.VersionStore;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
+import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UpdateCommand extends AbstractPluginCommand {
+    private final EphemeralData ephemeralData;
+    private final DownloadService downloadService;
+    private final PluginFolderService pluginFolderService;
+    private final VersionStore versionStore;
+    private final Plugin plugin;
+
+    public UpdateCommand(EphemeralData ephemeralData, DownloadService downloadService,
+                         PluginFolderService pluginFolderService, VersionStore versionStore,
+                         Plugin plugin) {
+        super(new ArrayList<>(List.of("update")), new ArrayList<>(List.of("dpm.update")));
+        this.ephemeralData = ephemeralData;
+        this.downloadService = downloadService;
+        this.pluginFolderService = pluginFolderService;
+        this.versionStore = versionStore;
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender) {
+        List<ProjectRecord> installed = getInstalledPlugins();
+        if (installed.isEmpty()) {
+            sender.sendMessage(ChatColor.YELLOW + "No managed plugins are currently installed.");
+            return true;
+        }
+        sender.sendMessage(ChatColor.AQUA + "Checking " + installed.size() + " installed plugin(s) for updates...");
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> runUpdates(sender, installed));
+        return true;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        return execute(sender);
+    }
+
+    private List<ProjectRecord> getInstalledPlugins() {
+        List<ProjectRecord> installed = new ArrayList<>();
+        for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
+            if (pluginFolderService.isInstalled(record)) {
+                installed.add(record);
+            }
+        }
+        return installed;
+    }
+
+    private void runUpdates(CommandSender sender, List<ProjectRecord> records) {
+        int updated = 0;
+        int upToDate = 0;
+        int failed = 0;
+
+        for (ProjectRecord record : records) {
+            int result = downloadService.downloadLatest(record);
+            if (result == DownloadService.ALREADY_UP_TO_DATE) {
+                upToDate++;
+            } else if (result > 0) {
+                updated++;
+                String tag = versionStore.getStoredTag(record.getName());
+                String version = tag != null ? " " + tag : "";
+                final String msg = ChatColor.GREEN + "Updated " + record.getName() + version + ".";
+                Bukkit.getScheduler().runTask(plugin, () -> sender.sendMessage(msg));
+            } else {
+                failed++;
+                final String msg = ChatColor.RED + "Failed to update " + record.getName() + ".";
+                Bukkit.getScheduler().runTask(plugin, () -> sender.sendMessage(msg));
+            }
+        }
+
+        final int finalUpdated = updated;
+        final int finalUpToDate = upToDate;
+        final int finalFailed = failed;
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            sender.sendMessage(ChatColor.AQUA + "Update complete: "
+                    + ChatColor.GREEN + finalUpdated + " updated"
+                    + ChatColor.AQUA + ", " + finalUpToDate + " already up to date"
+                    + (finalFailed > 0 ? ChatColor.RED + ", " + finalFailed + " failed" : "") + ".");
+            if (finalUpdated > 0) {
+                sender.sendMessage(ChatColor.YELLOW + "Restart the server to load updated plugins.");
+            }
+        });
+    }
+}

--- a/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
@@ -62,12 +62,15 @@ public class UpdateCommand extends AbstractPluginCommand {
     private void runUpdates(CommandSender sender, List<ProjectRecord> records) {
         int updated = 0;
         int upToDate = 0;
+        int skipped = 0;
         int failed = 0;
 
         for (ProjectRecord record : records) {
             int result = downloadService.downloadLatest(record);
             if (result == DownloadService.ALREADY_UP_TO_DATE) {
                 upToDate++;
+            } else if (result == DownloadService.NO_RELEASE) {
+                skipped++;
             } else if (result > 0) {
                 updated++;
                 String tag = versionStore.getStoredTag(record.getName());
@@ -83,12 +86,21 @@ public class UpdateCommand extends AbstractPluginCommand {
 
         final int finalUpdated = updated;
         final int finalUpToDate = upToDate;
+        final int finalSkipped = skipped;
         final int finalFailed = failed;
         Bukkit.getScheduler().runTask(plugin, () -> {
-            sender.sendMessage(ChatColor.AQUA + "Update complete: "
-                    + ChatColor.GREEN + finalUpdated + " updated"
-                    + ChatColor.AQUA + ", " + finalUpToDate + " already up to date"
-                    + (finalFailed > 0 ? ChatColor.RED + ", " + finalFailed + " failed" : "") + ".");
+            StringBuilder summary = new StringBuilder();
+            summary.append(ChatColor.AQUA).append("Update complete: ")
+                   .append(ChatColor.GREEN).append(finalUpdated).append(" updated")
+                   .append(ChatColor.AQUA).append(", ").append(finalUpToDate).append(" already up to date");
+            if (finalSkipped > 0) {
+                summary.append(ChatColor.AQUA).append(", ").append(finalSkipped).append(" skipped (no release)");
+            }
+            if (finalFailed > 0) {
+                summary.append(ChatColor.RED).append(", ").append(finalFailed).append(" failed");
+            }
+            summary.append(ChatColor.AQUA).append(".");
+            sender.sendMessage(summary.toString());
             if (finalUpdated > 0) {
                 sender.sendMessage(ChatColor.YELLOW + "Restart the server to load updated plugins.");
             }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -18,3 +18,5 @@ permissions:
     default: op
   dpm.clean:
     default: op
+  dpm.update:
+    default: op

--- a/src/test/java/dansplugins/dpm/TabCompletionTest.java
+++ b/src/test/java/dansplugins/dpm/TabCompletionTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class TabCompletionTest {
 
     private static final List<String> SUBCOMMANDS =
-            Arrays.asList("help", "list", "get", "clean", "stats");
+            Arrays.asList("help", "list", "get", "clean", "stats", "update");
 
     // -------------------------------------------------------------------------
     // sub-command completion
@@ -41,6 +41,11 @@ class TabCompletionTest {
     @Test
     void filterByPrefix_noMatchReturnsEmpty() {
         assertTrue(TabCompleter.filterByPrefix(SUBCOMMANDS, "xyz").isEmpty());
+    }
+
+    @Test
+    void filterByPrefix_updatePrefixMatchesOnlyUpdate() {
+        assertEquals(List.of("update"), TabCompleter.filterByPrefix(SUBCOMMANDS, "u"));
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `UpdateCommand` that iterates over all installed managed plugins, calls `downloadLatest()` on each asynchronously, and reports per-plugin results plus a final summary line
- Wires `update` into tab-completion sub-command list
- Adds `dpm.update` permission (default: op) to `plugin.yml`
- Updates `HelpCommand`, `COMMANDS.md`, `USER_GUIDE.md`, and `CHANGELOG.md`

Closes #12

## Test plan

- [ ] `/dpm update` with no managed plugins installed → "No managed plugins are currently installed."
- [ ] `/dpm update` with all plugins already up to date → summary shows 0 updated, N already up to date
- [ ] `/dpm update` after a new release is available → downloads the updated JAR, prints per-plugin "Updated vX.Y.Z." and summary with restart reminder
- [ ] Tab-complete `/dpm up<TAB>` → completes to `update`
- [ ] Player without `dpm.update` cannot run the command

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_