### PR TITLE
Add /dpm info command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Version tracking — last-downloaded release tag is persisted in `dpm-versions.properties`; `/dpm get` skips re-download when already on the latest version and reports the current tag
 - `/dpm list` now shows installed plugins in green (with their version tag when known) and uninstalled plugins in grey
 - `/dpm update` — checks every installed managed plugin against the latest GitHub release and downloads any that are out of date; prints a per-plugin result and a summary line
+- `/dpm info <plugin-name>` — shows latest release tag and install/update status for a single plugin without downloading anything
 
 ## [0.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-- Tab-completion for `/dpm` sub-commands (`help`, `list`, `get`, `clean`, `stats`, `update`) and plugin names for `/dpm get`
+- Tab-completion for `/dpm` sub-commands (`help`, `list`, `get`, `clean`, `stats`, `update`, `info`) and plugin names for `/dpm get` and `/dpm info`
 - Version tracking — last-downloaded release tag is persisted in `dpm-versions.properties`; `/dpm get` skips re-download when already on the latest version and reports the current tag
 - `/dpm list` now shows installed plugins in green (with their version tag when known) and uninstalled plugins in grey
 - `/dpm update` — checks every installed managed plugin against the latest GitHub release and downloads any that are out of date; prints a per-plugin result and a summary line
-- `/dpm info <plugin-name>` — shows latest release tag and install/update status for a single plugin without downloading anything
+- `/dpm info <plugin-name>` — shows GitHub owner, repository, latest release tag, publish date, and install/update status for a single plugin without downloading anything
 
 ## [0.4.0]
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -10,3 +10,4 @@ All commands use `/dpm` or `/danspluginmanager` as the base.
 | `/dpm clean` | Remove duplicate plugin JARs from the plugins folder. | `dpm.clean` |
 | `/dpm stats` | View plugin statistics. | `dpm.stats` |
 | `/dpm update` | Update all installed managed plugins to their latest release. | `dpm.update` |
+| `/dpm info <plugin-name>` | Show latest release tag and install status for a plugin. | `dpm.info` |

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -10,4 +10,4 @@ All commands use `/dpm` or `/danspluginmanager` as the base.
 | `/dpm clean` | Remove duplicate plugin JARs from the plugins folder. | `dpm.clean` |
 | `/dpm stats` | View plugin statistics. | `dpm.stats` |
 | `/dpm update` | Update all installed managed plugins to their latest release. | `dpm.update` |
-| `/dpm info <plugin-name>` | Show latest release tag and install status for a plugin. | `dpm.info` |
+| `/dpm info <plugin-name>` | Show GitHub owner, repo, latest release tag, publish date, and install status for a plugin. | `dpm.info` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -14,7 +14,7 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 
 1. Run `/dpm list` to see all DPC plugins. Green entries are installed (with version tag when known); grey entries are not yet installed.
 2. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). If the plugin is already on the latest version, the download is skipped.
-3. Run `/dpm info <plugin-name>` to see the latest release tag and install status for a specific plugin before downloading.
+3. Run `/dpm info <plugin-name>` to see the GitHub owner, repository, latest release tag, publish date, and install status for a specific plugin before downloading.
 4. Run `/dpm update` to check every installed managed plugin against its latest GitHub release and download any that are out of date.
 5. Restart the server to activate downloaded or updated plugins.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -14,8 +14,9 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 
 1. Run `/dpm list` to see all DPC plugins. Green entries are installed (with version tag when known); grey entries are not yet installed.
 2. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). If the plugin is already on the latest version, the download is skipped.
-3. Run `/dpm update` to check every installed managed plugin against its latest GitHub release and download any that are out of date.
-4. Restart the server to activate downloaded or updated plugins.
+3. Run `/dpm info <plugin-name>` to see the latest release tag and install status for a specific plugin before downloading.
+4. Run `/dpm update` to check every installed managed plugin against its latest GitHub release and download any that are out of date.
+5. Restart the server to activate downloaded or updated plugins.
 
 ## Permissions
 
@@ -27,6 +28,7 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 | `dpm.get` | `op` | Download a plugin to the server. |
 | `dpm.clean` | `op` | Remove duplicate plugin JARs. |
 | `dpm.update` | `op` | Update all installed managed plugins. |
+| `dpm.info` | `true` | View release and install info for a plugin. |
 
 ## Support
 

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -73,9 +73,9 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     @Override
     public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, String[] args) {
         if (args.length == 1) {
-            return TabCompleter.filterByPrefix(Arrays.asList("help", "list", "get", "clean", "stats", "update"), args[0]);
+            return TabCompleter.filterByPrefix(Arrays.asList("help", "list", "get", "clean", "stats", "update", "info"), args[0]);
         }
-        if (args.length == 2 && args[0].equalsIgnoreCase("get")) {
+        if (args.length == 2 && (args[0].equalsIgnoreCase("get") || args[0].equalsIgnoreCase("info"))) {
             List<String> names = new ArrayList<>();
             for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
                 names.add(record.getName());
@@ -154,7 +154,8 @@ public final class DansPluginManager extends PonderBukkitPlugin {
                 new ListCommand(ephemeralData, pluginFolderService, versionStore),
                 new StatsCommand(ephemeralData),
                 new CleanCommand(ephemeralData, pluginFolderService, this),
-                new UpdateCommand(ephemeralData, downloadService, pluginFolderService, versionStore, this)
+                new UpdateCommand(ephemeralData, downloadService, pluginFolderService, versionStore, this),
+                new InfoCommand(ephemeralData, gitHubReleaseService, pluginFolderService, versionStore, this)
         ));
         commandService.initialize(commands, "That command wasn't found.");
     }

--- a/src/main/java/dansplugins/dpm/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/HelpCommand.java
@@ -25,6 +25,7 @@ public class HelpCommand extends AbstractPluginCommand {
         commandSender.sendMessage(ChatColor.AQUA + "/dpm clean - Remove duplicate plugin JARs.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm stats - View plugin statistics.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm update - Update all installed plugins.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm info <plugin-name> - Show release and install info for a plugin.");
         return true;
     }
 

--- a/src/main/java/dansplugins/dpm/commands/InfoCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/InfoCommand.java
@@ -1,0 +1,86 @@
+package dansplugins.dpm.commands;
+
+import dansplugins.dpm.data.EphemeralData;
+import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.objects.ReleaseInfo;
+import dansplugins.dpm.services.GitHubReleaseService;
+import dansplugins.dpm.services.PluginFolderService;
+import dansplugins.dpm.services.VersionStore;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
+import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class InfoCommand extends AbstractPluginCommand {
+    private final EphemeralData ephemeralData;
+    private final GitHubReleaseService gitHubReleaseService;
+    private final PluginFolderService pluginFolderService;
+    private final VersionStore versionStore;
+    private final Plugin plugin;
+
+    public InfoCommand(EphemeralData ephemeralData, GitHubReleaseService gitHubReleaseService,
+                       PluginFolderService pluginFolderService, VersionStore versionStore,
+                       Plugin plugin) {
+        super(new ArrayList<>(List.of("info")), new ArrayList<>(List.of("dpm.info")));
+        this.ephemeralData = ephemeralData;
+        this.gitHubReleaseService = gitHubReleaseService;
+        this.pluginFolderService = pluginFolderService;
+        this.versionStore = versionStore;
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender) {
+        sender.sendMessage(ChatColor.RED + "Usage: /dpm info <plugin-name>");
+        return false;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        String name = args[0];
+        ProjectRecord record = ephemeralData.getProjectRecord(name);
+        if (record == null) {
+            sender.sendMessage(ChatColor.RED + "Plugin not found: " + name);
+            return false;
+        }
+        sender.sendMessage(ChatColor.AQUA + "Fetching release info for " + record.getName() + "...");
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            ReleaseInfo release = gitHubReleaseService.getLatestRelease(record.getOwner(), record.getRepo());
+            Bukkit.getScheduler().runTask(plugin, () -> showInfo(sender, record, release));
+        });
+        return true;
+    }
+
+    private void showInfo(CommandSender sender, ProjectRecord record, ReleaseInfo release) {
+        sender.sendMessage(ChatColor.AQUA + "=== " + record.getName() + " ===");
+
+        if (release == ReleaseInfo.NO_RELEASE) {
+            sender.sendMessage(ChatColor.YELLOW + "Latest release: None published yet");
+        } else if (release == null) {
+            sender.sendMessage(ChatColor.RED + "Latest release: (could not fetch — check console for details)");
+        } else {
+            sender.sendMessage(ChatColor.WHITE + "Latest release: " + ChatColor.GREEN + release.getTagName());
+        }
+
+        boolean installed = pluginFolderService.isInstalled(record);
+        String storedTag = versionStore.getStoredTag(record.getName());
+
+        if (installed) {
+            String version = storedTag != null ? storedTag : "(version unknown)";
+            sender.sendMessage(ChatColor.WHITE + "Installed: " + ChatColor.GREEN + "Yes (" + version + ")");
+            if (release != null && release != ReleaseInfo.NO_RELEASE) {
+                if (storedTag != null && storedTag.equals(release.getTagName())) {
+                    sender.sendMessage(ChatColor.WHITE + "Status: " + ChatColor.GREEN + "Up to date");
+                } else {
+                    sender.sendMessage(ChatColor.WHITE + "Status: " + ChatColor.YELLOW + "Update available");
+                }
+            }
+        } else {
+            sender.sendMessage(ChatColor.WHITE + "Installed: " + ChatColor.GRAY + "No");
+        }
+    }
+}

--- a/src/main/java/dansplugins/dpm/commands/InfoCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/InfoCommand.java
@@ -49,7 +49,7 @@ public class InfoCommand extends AbstractPluginCommand {
         }
         sender.sendMessage(ChatColor.AQUA + "Fetching release info for " + record.getName() + "...");
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            ReleaseInfo release = gitHubReleaseService.getLatestRelease(record.getOwner(), record.getRepo());
+            ReleaseInfo release = gitHubReleaseService.getLatestReleaseMetadata(record.getOwner(), record.getRepo());
             Bukkit.getScheduler().runTask(plugin, () -> showInfo(sender, record, release));
         });
         return true;
@@ -57,6 +57,8 @@ public class InfoCommand extends AbstractPluginCommand {
 
     private void showInfo(CommandSender sender, ProjectRecord record, ReleaseInfo release) {
         sender.sendMessage(ChatColor.AQUA + "=== " + record.getName() + " ===");
+        sender.sendMessage(ChatColor.WHITE + "Owner: " + ChatColor.AQUA + record.getOwner());
+        sender.sendMessage(ChatColor.WHITE + "Repository: " + ChatColor.AQUA + record.getRepo());
 
         if (release == ReleaseInfo.NO_RELEASE) {
             sender.sendMessage(ChatColor.YELLOW + "Latest release: None published yet");
@@ -64,6 +66,9 @@ public class InfoCommand extends AbstractPluginCommand {
             sender.sendMessage(ChatColor.RED + "Latest release: (could not fetch — check console for details)");
         } else {
             sender.sendMessage(ChatColor.WHITE + "Latest release: " + ChatColor.GREEN + release.getTagName());
+            if (release.getPublishedAt() != null) {
+                sender.sendMessage(ChatColor.WHITE + "Published: " + ChatColor.AQUA + formatDate(release.getPublishedAt()));
+            }
         }
 
         boolean installed = pluginFolderService.isInstalled(record);
@@ -82,5 +87,11 @@ public class InfoCommand extends AbstractPluginCommand {
         } else {
             sender.sendMessage(ChatColor.WHITE + "Installed: " + ChatColor.GRAY + "No");
         }
+    }
+
+    /** Trims the time component from an ISO 8601 timestamp, returning just the date. */
+    private String formatDate(String iso8601) {
+        int tIndex = iso8601.indexOf('T');
+        return tIndex > 0 ? iso8601.substring(0, tIndex) : iso8601;
     }
 }

--- a/src/main/java/dansplugins/dpm/objects/ReleaseInfo.java
+++ b/src/main/java/dansplugins/dpm/objects/ReleaseInfo.java
@@ -2,14 +2,20 @@ package dansplugins.dpm.objects;
 
 public class ReleaseInfo {
     /** Sentinel returned when a repo has no published release yet. */
-    public static final ReleaseInfo NO_RELEASE = new ReleaseInfo(null, null);
+    public static final ReleaseInfo NO_RELEASE = new ReleaseInfo(null, null, null);
 
     private final String tagName;
     private final String jarUrl;
+    private final String publishedAt;
 
     public ReleaseInfo(String tagName, String jarUrl) {
+        this(tagName, jarUrl, null);
+    }
+
+    public ReleaseInfo(String tagName, String jarUrl, String publishedAt) {
         this.tagName = tagName;
         this.jarUrl = jarUrl;
+        this.publishedAt = publishedAt;
     }
 
     public String getTagName() {
@@ -18,5 +24,9 @@ public class ReleaseInfo {
 
     public String getJarUrl() {
         return jarUrl;
+    }
+
+    public String getPublishedAt() {
+        return publishedAt;
     }
 }

--- a/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
+++ b/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
@@ -79,11 +79,61 @@ public class GitHubReleaseService {
     }
 
     /**
+     * Returns a {@link ReleaseInfo} with tag name and publish date for the latest release,
+     * without requiring a downloadable .jar asset. Returns {@link ReleaseInfo#NO_RELEASE}
+     * on 404, or null on network/other errors.
+     */
+    public ReleaseInfo getLatestReleaseMetadata(String owner, String repo) {
+        String apiUrl = String.format(API_URL, owner, repo);
+        HttpURLConnection connection = null;
+        try {
+            connection = openConnection(apiUrl);
+            int responseCode = connection.getResponseCode();
+            if (responseCode == 404) {
+                return ReleaseInfo.NO_RELEASE;
+            }
+            if (responseCode != 200) {
+                String errorBody = readStream(connection.getErrorStream());
+                logger.log("GitHub API returned HTTP " + responseCode + " for " + owner + "/" + repo + ": " + errorBody);
+                return null;
+            }
+            String json = readStream(connection.getInputStream());
+            String tagName = parseTagName(json);
+            String publishedAt = parsePublishedAt(json);
+            return new ReleaseInfo(tagName, null, publishedAt);
+        } catch (IOException e) {
+            logger.log("Failed to reach GitHub API for " + owner + "/" + repo + ": " + e.getMessage());
+            return null;
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    /**
      * Extracts the value of the top-level "tag_name" field. Tag names are simple
      * strings that never contain backslash escapes, so a direct quote scan suffices.
      */
     String parseTagName(String json) {
         String key = "\"tag_name\"";
+        int keyIndex = json.indexOf(key);
+        if (keyIndex == -1) return null;
+        int colonIndex = json.indexOf(':', keyIndex + key.length());
+        if (colonIndex == -1) return null;
+        int openQuote = json.indexOf('"', colonIndex + 1);
+        if (openQuote == -1) return null;
+        int closeQuote = json.indexOf('"', openQuote + 1);
+        if (closeQuote == -1) return null;
+        return json.substring(openQuote + 1, closeQuote);
+    }
+
+    /**
+     * Extracts the value of the top-level "published_at" field (ISO 8601 date string).
+     * Uses the same quote-scan approach as parseTagName.
+     */
+    String parsePublishedAt(String json) {
+        String key = "\"published_at\"";
         int keyIndex = json.indexOf(key);
         if (keyIndex == -1) return null;
         int colonIndex = json.indexOf(':', keyIndex + key.length());

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -20,3 +20,5 @@ permissions:
     default: op
   dpm.update:
     default: op
+  dpm.info:
+    default: true

--- a/src/test/java/dansplugins/dpm/TabCompletionTest.java
+++ b/src/test/java/dansplugins/dpm/TabCompletionTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class TabCompletionTest {
 
     private static final List<String> SUBCOMMANDS =
-            Arrays.asList("help", "list", "get", "clean", "stats", "update");
+            Arrays.asList("help", "list", "get", "clean", "stats", "update", "info");
 
     // -------------------------------------------------------------------------
     // sub-command completion
@@ -46,6 +46,11 @@ class TabCompletionTest {
     @Test
     void filterByPrefix_updatePrefixMatchesOnlyUpdate() {
         assertEquals(List.of("update"), TabCompleter.filterByPrefix(SUBCOMMANDS, "u"));
+    }
+
+    @Test
+    void filterByPrefix_infoPrefixMatchesOnlyInfo() {
+        assertEquals(List.of("info"), TabCompleter.filterByPrefix(SUBCOMMANDS, "i"));
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
@@ -115,6 +115,26 @@ class GitHubReleaseServiceTest {
     }
 
     // -------------------------------------------------------------------------
+    // parsePublishedAt()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void parsePublishedAt_returnsDate() {
+        String json = "{\"tag_name\":\"v1.0\",\"published_at\":\"2024-03-15T10:00:00Z\",\"assets\":[]}";
+        assertEquals("2024-03-15T10:00:00Z", service.parsePublishedAt(json));
+    }
+
+    @Test
+    void parsePublishedAt_returnsNullWhenMissing() {
+        assertNull(service.parsePublishedAt("{\"tag_name\":\"v1.0\",\"assets\":[]}"));
+    }
+
+    @Test
+    void parsePublishedAt_returnsNullForEmptyString() {
+        assertNull(service.parsePublishedAt(""));
+    }
+
+    // -------------------------------------------------------------------------
     // parseJarUrlFromAssets() — edge cases
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `InfoCommand` that fetches the latest GitHub release tag asynchronously and displays it alongside install/update status — without downloading anything
- Shows: latest release tag (or "None published yet" / fetch error), installed version (or "No"), and status ("Up to date" / "Update available") when applicable
- Tab-completion for `/dpm info <plugin-name>` wired alongside `/dpm get`
- `dpm.info` permission added (default: `true` — read-only, safe for all players)
- Docs updated: `HelpCommand`, `COMMANDS.md`, `USER_GUIDE.md`, `CHANGELOG.md`

Closes #18

## Test plan

- [ ] `/dpm info medievalfactions` on an installed, up-to-date plugin → shows tag, "Yes (vX.Y.Z)", "Up to date"
- [ ] `/dpm info medievalfactions` when an update is available → shows newer tag, "Update available"
- [ ] `/dpm info medievalfactions` when not installed → shows tag, "Installed: No"
- [ ] `/dpm info <plugin-with-no-release>` → shows "None published yet"
- [ ] `/dpm info` (no args) → "Usage: /dpm info <plugin-name>"
- [ ] `/dpm info unknownplugin` → "Plugin not found: unknownplugin"
- [ ] Tab-complete `/dpm inf<TAB>` → completes to `info`
- [ ] Tab-complete `/dpm info med<TAB>` → narrows to medieval* plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_