### PR TITLE
Add githubApiToken config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `/dpm list` shows installed plugins in green (with version tag when known) and uninstalled plugins in grey
 - `/dpm update` checks every installed managed plugin against the latest GitHub release and downloads any that are out of date
 - `/dpm info <plugin-name>` shows GitHub owner, repository, latest release tag, publish date, and install/update status without downloading anything
-- `githubApiToken` config option — when set, adds a `Bearer` token to all GitHub API requests, raising the unauthenticated rate limit (60 req/hr) to 5 000 req/hr
+- `githubToken` config option — when set, adds a `Bearer` token to all GitHub API requests, raising the unauthenticated rate limit (60 req/hr) to 5 000 req/hr
 
 ### Changed
 - Download runs asynchronously so it no longer blocks the main server thread

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Added
-- Tab-completion for `/dpm` sub-commands (`help`, `list`, `get`, `clean`, `stats`, `update`, `info`) and plugin names for `/dpm get` and `/dpm info`
-- Version tracking — last-downloaded release tag is persisted in `dpm-versions.properties`; `/dpm get` skips re-download when already on the latest version and reports the current tag
-- `/dpm list` now shows installed plugins in green (with their version tag when known) and uninstalled plugins in grey
-- `/dpm update` — checks every installed managed plugin against the latest GitHub release and downloads any that are out of date; prints a per-plugin result and a summary line
-- `/dpm info <plugin-name>` — shows GitHub owner, repository, latest release tag, publish date, and install/update status for a single plugin without downloading anything
-- `githubApiToken` config option — when set, adds a `Bearer` token to all GitHub API requests, raising the unauthenticated rate limit (60 req/hr) to 5 000 req/hr
-
 ## [0.4.0]
 
 ### Added
-- `/dpm help`, `/dpm list`, `/dpm get`, `/dpm stats` commands
+- `/dpm help`, `/dpm list`, `/dpm get`, `/dpm stats`, `/dpm clean`, `/dpm update`, `/dpm info` commands
 - In-game browsing and downloading of DPC plugins
-- Dynamic GitHub release retrieval — `/dpm get` now fetches the latest release JAR automatically via the GitHub API instead of relying on hardcoded versioned URLs
+- Dynamic GitHub release retrieval — `/dpm get` fetches the latest release JAR automatically via the GitHub API instead of relying on hardcoded versioned URLs
 - 9 additional public DPC plugin repos registered (Bluemap_MedievalFactions, Bookshelves-You-Can-Use, Dans-Set-Home, Democracy, FlyCommand, Herald, KDRTracker, Medieval-Cookery, MiniFactions)
 - Informative "no published release yet" message when a plugin has no GitHub release
-- `/dpm clean` command to remove duplicate plugin JARs from the plugins folder
+- Tab-completion for `/dpm` sub-commands and plugin names for `/dpm get` and `/dpm info`
+- Version tracking — last-downloaded release tag is persisted in `dpm-versions.properties`; `/dpm get` and `/dpm update` skip re-download when already on the latest version
+- `/dpm list` shows installed plugins in green (with version tag when known) and uninstalled plugins in grey
+- `/dpm update` checks every installed managed plugin against the latest GitHub release and downloads any that are out of date
+- `/dpm info <plugin-name>` shows GitHub owner, repository, latest release tag, publish date, and install/update status without downloading anything
+- `githubApiToken` config option — when set, adds a `Bearer` token to all GitHub API requests, raising the unauthenticated rate limit (60 req/hr) to 5 000 req/hr
 
 ### Changed
 - Download runs asynchronously so it no longer blocks the main server thread

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `/dpm list` now shows installed plugins in green (with their version tag when known) and uninstalled plugins in grey
 - `/dpm update` — checks every installed managed plugin against the latest GitHub release and downloads any that are out of date; prints a per-plugin result and a summary line
 - `/dpm info <plugin-name>` — shows GitHub owner, repository, latest release tag, publish date, and install/update status for a single plugin without downloading anything
+- `githubApiToken` config option — when set, adds a `Bearer` token to all GitHub API requests, raising the unauthenticated rate limit (60 req/hr) to 5 000 req/hr
 
 ## [0.4.0]
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -6,4 +6,4 @@ A `config.yml` is generated in `plugins/DansPluginManager/` on first run.
 |--------|------|---------|-------------|
 | `version` | String | *(plugin version)* | Plugin version. Do not edit manually. |
 | `debugMode` | Boolean | `false` | Enables verbose debug logging to the console. |
-| `githubApiToken` | String | `""` | Personal access token for the GitHub API. When set, raises the rate limit from 60 to 5 000 requests per hour. Generate one at GitHub → Settings → Developer settings → Personal access tokens (no scopes required for public repos). |
+| `githubToken` | String | `""` | Personal access token for the GitHub API. When set, raises the rate limit from 60 to 5 000 requests per hour. Generate one at GitHub → Settings → Developer settings → Personal access tokens (no scopes required for public repos). |

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -6,3 +6,4 @@ A `config.yml` is generated in `plugins/DansPluginManager/` on first run.
 |--------|------|---------|-------------|
 | `version` | String | *(plugin version)* | Plugin version. Do not edit manually. |
 | `debugMode` | Boolean | `false` | Enables verbose debug logging to the console. |
+| `githubApiToken` | String | `""` | Personal access token for the GitHub API. When set, raises the rate limit from 60 to 5 000 requests per hour. Generate one at GitHub → Settings → Developer settings → Personal access tokens (no scopes required for public repos). |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Thank you for your interest in contributing to Dans Plugin Manager! This guide w
 
 ## Identifying What to Work On
 
-Work items are tracked as [GitHub issues](https://github.com/Dans-Plugins/Dans-Plugin-Manager/issues), grouped into [milestones](https://github.com/Dans-Plugins/Dans-Plugin-Manager/milestones) representing upcoming releases.
+Work items are tracked as [GitHub issues](https://github.com/Dans-Plugins/Dans-Plugin-Manager/issues).
 
 ## Making Changes
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -13,8 +13,8 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 ## Getting Started
 
 1. Run `/dpm list` to see all DPC plugins. Green entries are installed (with version tag when known); grey entries are not yet installed.
-2. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). If the plugin is already on the latest version, the download is skipped.
-3. Run `/dpm info <plugin-name>` to see the GitHub owner, repository, latest release tag, publish date, and install status for a specific plugin before downloading.
+2. Run `/dpm info <plugin-name>` to see the GitHub owner, repository, latest release tag, publish date, and install status for a specific plugin before downloading.
+3. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). If the plugin is already on the latest version, the download is skipped.
 4. Run `/dpm update` to check every installed managed plugin against its latest GitHub release and download any that are out of date.
 5. Restart the server to activate downloaded or updated plugins.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -30,6 +30,20 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 | `dpm.update` | `op` | Update all installed managed plugins. |
 | `dpm.info` | `true` | View release and install info for a plugin. |
 
+## Configuration
+
+DPM generates a `config.yml` in `plugins/DansPluginManager/` on first run. See [CONFIG.md](CONFIG.md) for all options.
+
+The most useful option for operators running frequent updates is `githubToken`. GitHub limits unauthenticated API requests to 60 per hour. Setting a personal access token raises this to 5 000 per hour:
+
+1. Go to GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)
+2. Generate a new token with no scopes selected (public repo read access is granted by default)
+3. Add it to `config.yml`:
+   ```yaml
+   githubToken: "ghp_your_token_here"
+   ```
+4. Restart the server (or use `/dpm reload` once that command is available).
+
 ## Support
 
 Ask questions in the [Discord server](https://discord.gg/xXtuAQ2) or open a [GitHub issue](https://github.com/Dans-Plugins/Dans-Plugin-Manager/issues).

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -48,6 +48,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     @Override
     public void onEnable() {
         initializeConfig();
+        gitHubReleaseService.setApiToken(configService.getStringOrDefault("githubApiToken", ""));
         versionStore = new VersionStore(new File(getDataFolder(), "dpm-versions.properties"));
         downloadService = new DownloadService(logger, gitHubReleaseService, pluginFolderService, versionStore);
         initializeCommandService();

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -48,7 +48,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     @Override
     public void onEnable() {
         initializeConfig();
-        gitHubReleaseService.setApiToken(configService.getStringOrDefault("githubApiToken", ""));
+        gitHubReleaseService.setApiToken(configService.getStringOrDefault("githubToken", ""));
         versionStore = new VersionStore(new File(getDataFolder(), "dpm-versions.properties"));
         downloadService = new DownloadService(logger, gitHubReleaseService, pluginFolderService, versionStore);
         initializeCommandService();

--- a/src/main/java/dansplugins/dpm/services/ConfigService.java
+++ b/src/main/java/dansplugins/dpm/services/ConfigService.java
@@ -23,8 +23,8 @@ public class ConfigService {
         if (!isSet("debugMode")) {
             getConfig().set("debugMode", false);
         }
-        if (!isSet("githubApiToken")) {
-            getConfig().set("githubApiToken", "");
+        if (!isSet("githubToken")) {
+            getConfig().set("githubToken", "");
         }
         getConfig().options().copyDefaults(true);
         dansPluginManager.saveConfig();
@@ -53,9 +53,9 @@ public class ConfigService {
         sender.sendMessage(ChatColor.AQUA + "=== Config ===");
         sender.sendMessage(ChatColor.AQUA + "version: " + getConfig().getString("version"));
         sender.sendMessage(ChatColor.AQUA + "debugMode: " + getConfig().getBoolean("debugMode"));
-        String token = getConfig().getString("githubApiToken");
+        String token = getConfig().getString("githubToken");
         String tokenDisplay = (token != null && !token.isEmpty()) ? "(set)" : "(not set)";
-        sender.sendMessage(ChatColor.AQUA + "githubApiToken: " + tokenDisplay);
+        sender.sendMessage(ChatColor.AQUA + "githubToken: " + tokenDisplay);
     }
 
     public boolean hasBeenAltered() {

--- a/src/main/java/dansplugins/dpm/services/ConfigService.java
+++ b/src/main/java/dansplugins/dpm/services/ConfigService.java
@@ -23,6 +23,9 @@ public class ConfigService {
         if (!isSet("debugMode")) {
             getConfig().set("debugMode", false);
         }
+        if (!isSet("githubApiToken")) {
+            getConfig().set("githubApiToken", "");
+        }
         getConfig().options().copyDefaults(true);
         dansPluginManager.saveConfig();
     }
@@ -50,6 +53,9 @@ public class ConfigService {
         sender.sendMessage(ChatColor.AQUA + "=== Config ===");
         sender.sendMessage(ChatColor.AQUA + "version: " + getConfig().getString("version"));
         sender.sendMessage(ChatColor.AQUA + "debugMode: " + getConfig().getBoolean("debugMode"));
+        String token = getConfig().getString("githubApiToken");
+        String tokenDisplay = (token != null && !token.isEmpty()) ? "(set)" : "(not set)";
+        sender.sendMessage(ChatColor.AQUA + "githubApiToken: " + tokenDisplay);
     }
 
     public boolean hasBeenAltered() {

--- a/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
+++ b/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
@@ -25,6 +25,10 @@ public class GitHubReleaseService {
         this.apiToken = token != null ? token : "";
     }
 
+    String getApiToken() {
+        return apiToken;
+    }
+
     /**
      * Returns a {@link ReleaseInfo} with the tag name and first .jar asset URL for the
      * latest release. Returns {@link ReleaseInfo#NO_RELEASE} when GitHub reports 404

--- a/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
+++ b/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
@@ -15,9 +15,14 @@ public class GitHubReleaseService {
     private static final String API_URL = "https://api.github.com/repos/%s/%s/releases/latest";
 
     private final Logger logger;
+    private String apiToken = "";
 
     public GitHubReleaseService(Logger logger) {
         this.logger = logger;
+    }
+
+    public void setApiToken(String token) {
+        this.apiToken = token != null ? token : "";
     }
 
     /**
@@ -61,6 +66,9 @@ public class GitHubReleaseService {
         HttpURLConnection connection = (HttpURLConnection) new URL(apiUrl).openConnection();
         connection.setRequestProperty("Accept", "application/vnd.github+json");
         connection.setRequestProperty("User-Agent", "Dans-Plugin-Manager");
+        if (!apiToken.isEmpty()) {
+            connection.setRequestProperty("Authorization", "Bearer " + apiToken);
+        }
         connection.setConnectTimeout(5000);
         connection.setReadTimeout(5000);
         return connection;

--- a/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
@@ -140,18 +140,27 @@ class GitHubReleaseServiceTest {
 
     @Test
     void setApiToken_nullTreatedAsEmpty() {
-        // Should not throw; null is coerced to empty string internally.
-        assertDoesNotThrow(() -> service.setApiToken(null));
+        service.setApiToken(null);
+        assertEquals("", service.getApiToken());
     }
 
     @Test
-    void setApiToken_emptyStringAccepted() {
-        assertDoesNotThrow(() -> service.setApiToken(""));
+    void setApiToken_emptyStringStoredAsEmpty() {
+        service.setApiToken("");
+        assertEquals("", service.getApiToken());
     }
 
     @Test
-    void setApiToken_validTokenAccepted() {
-        assertDoesNotThrow(() -> service.setApiToken("ghp_exampletoken123"));
+    void setApiToken_validTokenStored() {
+        service.setApiToken("ghp_exampletoken123");
+        assertEquals("ghp_exampletoken123", service.getApiToken());
+    }
+
+    @Test
+    void setApiToken_overwritesPreviousToken() {
+        service.setApiToken("first_token");
+        service.setApiToken("second_token");
+        assertEquals("second_token", service.getApiToken());
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
@@ -135,6 +135,26 @@ class GitHubReleaseServiceTest {
     }
 
     // -------------------------------------------------------------------------
+    // setApiToken()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void setApiToken_nullTreatedAsEmpty() {
+        // Should not throw; null is coerced to empty string internally.
+        assertDoesNotThrow(() -> service.setApiToken(null));
+    }
+
+    @Test
+    void setApiToken_emptyStringAccepted() {
+        assertDoesNotThrow(() -> service.setApiToken(""));
+    }
+
+    @Test
+    void setApiToken_validTokenAccepted() {
+        assertDoesNotThrow(() -> service.setApiToken("ghp_exampletoken123"));
+    }
+
+    // -------------------------------------------------------------------------
     // parseJarUrlFromAssets() — edge cases
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `githubToken` string config option (default: empty) to `config.yml`
- When set, `GitHubReleaseService` includes an `Authorization: Bearer <token>` header on every GitHub API request, raising the unauthenticated rate limit (60 req/hr) to 5 000 req/hr
- Token is never logged, even in debug mode
- `CONFIG.md` documents the new option with instructions for generating a token
- `sendConfigList()` in `ConfigService` updated to display `(set)` / `(not set)` rather than the raw token value — this will be surfaced once a config/reload command is added in #27

Closes #16

## Test plan

- [ ] Leave `githubToken` empty → requests succeed unauthenticated as before
- [ ] Set a valid PAT → requests include `Authorization: Bearer <token>` header (verify via GitHub API audit log or debug output)
- [ ] Invalid/expired token → GitHub returns 401; error logged to console, command reports failure gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_