### PR TITLE
Add /dpm reload and /dpm remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- `/dpm reload` — reloads `config.yml` and re-applies live settings (e.g. `githubToken`) without a server restart
+- `/dpm remove <plugin-name>` — deletes the managed JAR from the plugins folder and clears the stored version tag
+
 ## [0.4.0]
 
 ### Added

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -11,3 +11,5 @@ All commands use `/dpm` or `/danspluginmanager` as the base.
 | `/dpm stats` | View plugin statistics. | `dpm.stats` |
 | `/dpm update` | Update all installed managed plugins to their latest release. | `dpm.update` |
 | `/dpm info <plugin-name>` | Show GitHub owner, repo, latest release tag, publish date, and install status for a plugin. | `dpm.info` |
+| `/dpm reload` | Reload `config.yml` and re-apply settings (e.g. `githubToken`). | `dpm.reload` |
+| `/dpm remove <plugin-name>` | Remove an installed managed plugin from the plugins folder. | `dpm.remove` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -29,6 +29,8 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 | `dpm.clean` | `op` | Remove duplicate plugin JARs. |
 | `dpm.update` | `op` | Update all installed managed plugins. |
 | `dpm.info` | `true` | View release and install info for a plugin. |
+| `dpm.reload` | `op` | Reload the DPM config. |
+| `dpm.remove` | `op` | Remove an installed managed plugin. |
 
 ## Configuration
 
@@ -42,7 +44,7 @@ The most useful option for operators running frequent updates is `githubToken`. 
    ```yaml
    githubToken: "ghp_your_token_here"
    ```
-4. Restart the server (or use `/dpm reload` once that command is available).
+4. Run `/dpm reload` to apply the change without restarting the server.
 
 ## Support
 

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -41,6 +41,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     private final PluginFolderService pluginFolderService = new PluginFolderService();
     private VersionStore versionStore;
     private DownloadService downloadService;
+    private RemoveCommand removeCommand;
 
     /**
      * This runs when the server starts.
@@ -74,7 +75,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     @Override
     public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, String[] args) {
         if (args.length == 1) {
-            return TabCompleter.filterByPrefix(Arrays.asList("help", "list", "get", "clean", "stats", "update", "info"), args[0]);
+            return TabCompleter.filterByPrefix(Arrays.asList("help", "list", "get", "clean", "stats", "update", "info", "reload", "remove"), args[0]);
         }
         if (args.length == 2 && (args[0].equalsIgnoreCase("get") || args[0].equalsIgnoreCase("info"))) {
             List<String> names = new ArrayList<>();
@@ -82,6 +83,9 @@ public final class DansPluginManager extends PonderBukkitPlugin {
                 names.add(record.getName());
             }
             return TabCompleter.filterByPrefix(names, args[1]);
+        }
+        if (args.length == 2 && args[0].equalsIgnoreCase("remove")) {
+            return TabCompleter.filterByPrefix(removeCommand.getInstalledPluginNames(), args[1]);
         }
         return Collections.emptyList();
     }
@@ -125,6 +129,11 @@ public final class DansPluginManager extends PonderBukkitPlugin {
         return configService.getBoolean("debugMode");
     }
 
+    public void reloadDpm() {
+        reloadConfig();
+        gitHubReleaseService.setApiToken(configService.getStringOrDefault("githubToken", ""));
+    }
+
     private void initializeConfig() {
         if (configFileExists()) {
             performCompatibilityChecks();
@@ -156,7 +165,9 @@ public final class DansPluginManager extends PonderBukkitPlugin {
                 new StatsCommand(ephemeralData),
                 new CleanCommand(ephemeralData, pluginFolderService, this),
                 new UpdateCommand(ephemeralData, downloadService, pluginFolderService, versionStore, this),
-                new InfoCommand(ephemeralData, gitHubReleaseService, pluginFolderService, versionStore, this)
+                new InfoCommand(ephemeralData, gitHubReleaseService, pluginFolderService, versionStore, this),
+                new ReloadCommand(this),
+                removeCommand = new RemoveCommand(ephemeralData, pluginFolderService, versionStore)
         ));
         commandService.initialize(commands, "That command wasn't found.");
     }

--- a/src/main/java/dansplugins/dpm/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/HelpCommand.java
@@ -26,6 +26,8 @@ public class HelpCommand extends AbstractPluginCommand {
         commandSender.sendMessage(ChatColor.AQUA + "/dpm stats - View plugin statistics.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm update - Update all installed plugins.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm info <plugin-name> - Show release and install info for a plugin.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm reload - Reload the DPM config.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm remove <plugin-name> - Remove an installed plugin.");
         return true;
     }
 

--- a/src/main/java/dansplugins/dpm/commands/ReloadCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/ReloadCommand.java
@@ -1,0 +1,30 @@
+package dansplugins.dpm.commands;
+
+import dansplugins.dpm.DansPluginManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ReloadCommand extends AbstractPluginCommand {
+    private final DansPluginManager plugin;
+
+    public ReloadCommand(DansPluginManager plugin) {
+        super(new ArrayList<>(List.of("reload")), new ArrayList<>(List.of("dpm.reload")));
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender) {
+        plugin.reloadDpm();
+        sender.sendMessage(ChatColor.GREEN + "DPM config reloaded.");
+        return true;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        return execute(sender);
+    }
+}

--- a/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
@@ -1,0 +1,66 @@
+package dansplugins.dpm.commands;
+
+import dansplugins.dpm.data.EphemeralData;
+import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.services.PluginFolderService;
+import dansplugins.dpm.services.VersionStore;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RemoveCommand extends AbstractPluginCommand {
+    private final EphemeralData ephemeralData;
+    private final PluginFolderService pluginFolderService;
+    private final VersionStore versionStore;
+
+    public RemoveCommand(EphemeralData ephemeralData, PluginFolderService pluginFolderService,
+                         VersionStore versionStore) {
+        super(new ArrayList<>(List.of("remove")), new ArrayList<>(List.of("dpm.remove")));
+        this.ephemeralData = ephemeralData;
+        this.pluginFolderService = pluginFolderService;
+        this.versionStore = versionStore;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender) {
+        sender.sendMessage(ChatColor.RED + "Usage: /dpm remove <plugin-name>");
+        return false;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        String name = args[0];
+        ProjectRecord record = ephemeralData.getProjectRecord(name);
+        if (record == null) {
+            sender.sendMessage(ChatColor.RED + "Plugin not found: " + name);
+            return false;
+        }
+        File jar = pluginFolderService.getInstalledFile(record);
+        if (jar == null) {
+            sender.sendMessage(ChatColor.YELLOW + record.getName() + " is not installed.");
+            return true;
+        }
+        if (jar.delete()) {
+            versionStore.removeTag(record.getName());
+            sender.sendMessage(ChatColor.GREEN + "Removed " + record.getName() + ".");
+            sender.sendMessage(ChatColor.YELLOW + "Restart the server for the removal to take effect.");
+        } else {
+            sender.sendMessage(ChatColor.RED + "Failed to delete " + jar.getName() + ". Check server file permissions.");
+        }
+        return true;
+    }
+
+    public List<String> getInstalledPluginNames() {
+        List<String> names = new ArrayList<>();
+        for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
+            if (pluginFolderService.isInstalled(record)) {
+                names.add(record.getName());
+            }
+        }
+        return names;
+    }
+}

--- a/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
@@ -56,10 +56,8 @@ public class RemoveCommand extends AbstractPluginCommand {
 
     public List<String> getInstalledPluginNames() {
         List<String> names = new ArrayList<>();
-        for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
-            if (pluginFolderService.isInstalled(record)) {
-                names.add(record.getName());
-            }
+        for (ProjectRecord record : pluginFolderService.filterInstalled(ephemeralData.getAllProjectRecords())) {
+            names.add(record.getName());
         }
         return names;
     }

--- a/src/main/java/dansplugins/dpm/services/PluginFolderService.java
+++ b/src/main/java/dansplugins/dpm/services/PluginFolderService.java
@@ -37,6 +37,21 @@ public class PluginFolderService {
     }
 
     /**
+     * Returns the installed JAR file for the record, or null if not found.
+     * Uses case-insensitive matching consistent with isInstalled().
+     */
+    public File getInstalledFile(ProjectRecord record) {
+        String managedFilename = record.getName() + ".jar";
+        File pluginsDir = new File(pluginsFolder);
+        File[] files = pluginsDir.listFiles();
+        if (files == null) return null;
+        for (File f : files) {
+            if (f.getName().equalsIgnoreCase(managedFilename)) return f;
+        }
+        return null;
+    }
+
+    /**
      * Returns all JARs in the plugins folder whose normalized name matches the record
      * but are not the managed file ({recordName}.jar).
      */

--- a/src/main/java/dansplugins/dpm/services/PluginFolderService.java
+++ b/src/main/java/dansplugins/dpm/services/PluginFolderService.java
@@ -4,7 +4,9 @@ import dansplugins.dpm.objects.ProjectRecord;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class PluginFolderService {
     private final String pluginsFolder;
@@ -21,24 +23,13 @@ public class PluginFolderService {
         return pluginsFolder;
     }
 
-    /**
-     * Returns true if any file in the plugins folder matches {recordName}.jar
-     * case-insensitively (mirrors the equalsIgnoreCase logic in findConflictingJars).
-     */
     public boolean isInstalled(ProjectRecord record) {
-        String managedFilename = record.getName() + ".jar";
-        File pluginsDir = new File(pluginsFolder);
-        File[] files = pluginsDir.listFiles();
-        if (files == null) return false;
-        for (File f : files) {
-            if (f.getName().equalsIgnoreCase(managedFilename)) return true;
-        }
-        return false;
+        return getInstalledFile(record) != null;
     }
 
     /**
      * Returns the installed JAR file for the record, or null if not found.
-     * Uses case-insensitive matching consistent with isInstalled().
+     * Case-insensitive — all isInstalled() calls delegate here.
      */
     public File getInstalledFile(ProjectRecord record) {
         String managedFilename = record.getName() + ".jar";
@@ -49,6 +40,27 @@ public class PluginFolderService {
             if (f.getName().equalsIgnoreCase(managedFilename)) return f;
         }
         return null;
+    }
+
+    /**
+     * Returns the subset of records whose managed JAR is present in the plugins folder.
+     * Scans the directory once regardless of how many records are provided.
+     */
+    public List<ProjectRecord> filterInstalled(List<ProjectRecord> records) {
+        File pluginsDir = new File(pluginsFolder);
+        File[] files = pluginsDir.listFiles();
+        if (files == null) return new ArrayList<>();
+        Set<String> presentLower = new HashSet<>();
+        for (File f : files) {
+            presentLower.add(f.getName().toLowerCase());
+        }
+        List<ProjectRecord> installed = new ArrayList<>();
+        for (ProjectRecord record : records) {
+            if (presentLower.contains(record.getName().toLowerCase() + ".jar")) {
+                installed.add(record);
+            }
+        }
+        return installed;
     }
 
     /**

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -22,3 +22,7 @@ permissions:
     default: op
   dpm.info:
     default: true
+  dpm.reload:
+    default: op
+  dpm.remove:
+    default: op

--- a/src/test/java/dansplugins/dpm/TabCompletionTest.java
+++ b/src/test/java/dansplugins/dpm/TabCompletionTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class TabCompletionTest {
 
     private static final List<String> SUBCOMMANDS =
-            Arrays.asList("help", "list", "get", "clean", "stats", "update", "info");
+            Arrays.asList("help", "list", "get", "clean", "stats", "update", "info", "reload", "remove");
 
     // -------------------------------------------------------------------------
     // sub-command completion
@@ -51,6 +51,13 @@ class TabCompletionTest {
     @Test
     void filterByPrefix_infoPrefixMatchesOnlyInfo() {
         assertEquals(List.of("info"), TabCompleter.filterByPrefix(SUBCOMMANDS, "i"));
+    }
+
+    @Test
+    void filterByPrefix_rePrefixMatchesReloadAndRemove() {
+        List<String> result = TabCompleter.filterByPrefix(SUBCOMMANDS, "re");
+        assertEquals(2, result.size());
+        assertTrue(result.containsAll(List.of("reload", "remove")));
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/dansplugins/dpm/services/PluginFolderServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/PluginFolderServiceTest.java
@@ -210,6 +210,35 @@ class PluginFolderServiceTest {
         assertFalse(svc.isInstalled(record));
     }
 
+    // -------------------------------------------------------------------------
+    // getInstalledFile()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getInstalledFile_returnsFileWhenPresent(@TempDir Path tempDir) throws IOException {
+        createFile(tempDir, "medievalfactions.jar");
+        PluginFolderService svc = new PluginFolderService(tempDir.toString() + "/");
+        ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
+        File result = svc.getInstalledFile(record);
+        assertNotNull(result);
+        assertEquals("medievalfactions.jar", result.getName());
+    }
+
+    @Test
+    void getInstalledFile_returnsNullWhenAbsent(@TempDir Path tempDir) {
+        PluginFolderService svc = new PluginFolderService(tempDir.toString() + "/");
+        ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
+        assertNull(svc.getInstalledFile(record));
+    }
+
+    @Test
+    void getInstalledFile_caseInsensitiveMatch(@TempDir Path tempDir) throws IOException {
+        createFile(tempDir, "MedievalFactions.jar");
+        PluginFolderService svc = new PluginFolderService(tempDir.toString() + "/");
+        ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
+        assertNotNull(svc.getInstalledFile(record));
+    }
+
     private void createFile(Path dir, String name) throws IOException {
         new File(dir.toFile(), name).createNewFile();
     }


### PR DESCRIPTION
## Summary

- **`/dpm reload`** — re-reads `config.yml` and re-applies live settings (`githubToken`, `debugMode`) without a server restart. Closes #27.
- **`/dpm remove <plugin>`** — deletes the managed JAR from the plugins folder and clears the stored version tag from `dpm-versions.properties`. Tab-completion filters to installed plugins only. Closes #25.
- Both commands wired into tab-completion sub-command list
- `dpm.reload` and `dpm.remove` permissions added (both default: `op`)
- `PluginFolderService.getInstalledFile()` added for case-insensitive file lookup
- Docs updated: `HelpCommand`, `COMMANDS.md`, `USER_GUIDE.md`, `CHANGELOG.md`

## Test plan

- [ ] `/dpm reload` after updating `githubToken` in `config.yml` → new token takes effect without restart
- [ ] `/dpm remove medievalfactions` when installed → JAR deleted, version tag cleared, restart warning shown
- [ ] `/dpm remove medievalfactions` when not installed → "not installed" message
- [ ] `/dpm remove unknownplugin` → "Plugin not found" message
- [ ] Tab-complete `/dpm rem<TAB>` → offers `reload` and `remove`
- [ ] Tab-complete `/dpm remove <TAB>` → only lists installed plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_