### PR TITLE
Require --confirm before destructive commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Added
-- `/dpm reload` — reloads `config.yml` and re-applies live settings (e.g. `githubToken`) without a server restart
-- `/dpm remove <plugin-name>` — deletes the managed JAR from the plugins folder and clears the stored version tag
+### Changed
+- `/dpm clean` now previews what would be deleted; pass `--confirm` to actually remove the files
+- `/dpm remove <plugin-name>` now previews what would be deleted; pass `--confirm` to actually remove the file
 
 ## [0.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - `/dpm reload` — reloads `config.yml` and re-applies live settings (e.g. `githubToken`) without a server restart
 - `/dpm remove <plugin-name> [--confirm]` — previews the JAR to be deleted; pass `--confirm` to actually remove it and clear the stored version tag
+- Tab-completion for `/dpm remove` offers installed plugin names at the first argument and `--confirm` at the second
+- Tab-completion for `/dpm clean` offers `--confirm` at the first argument
 
 ### Changed
 - `/dpm clean` now previews what would be deleted; pass `--confirm` to actually remove the files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- `/dpm reload` — reloads `config.yml` and re-applies live settings (e.g. `githubToken`) without a server restart
+- `/dpm remove <plugin-name> [--confirm]` — previews the JAR to be deleted; pass `--confirm` to actually remove it and clear the stored version tag
+
 ### Changed
 - `/dpm clean` now previews what would be deleted; pass `--confirm` to actually remove the files
-- `/dpm remove <plugin-name>` now previews what would be deleted; pass `--confirm` to actually remove the file
+- `/dpm clean --confirm` now distinguishes deletion failures (permission errors) from "no duplicates found"
 
 ## [0.4.0]
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -7,9 +7,9 @@ All commands use `/dpm` or `/danspluginmanager` as the base.
 | `/dpm help` | View a list of commands. | `dpm.help` |
 | `/dpm list` | List DPC plugins, showing which are installed (with version tag when known). | `dpm.list` |
 | `/dpm get <plugin-name>` | Download a DPC plugin to the server. | `dpm.get` |
-| `/dpm clean` | Remove duplicate plugin JARs from the plugins folder. | `dpm.clean` |
+| `/dpm clean [--confirm]` | Preview duplicate plugin JARs, or delete them when `--confirm` is passed. | `dpm.clean` |
 | `/dpm stats` | View plugin statistics. | `dpm.stats` |
 | `/dpm update` | Update all installed managed plugins to their latest release. | `dpm.update` |
 | `/dpm info <plugin-name>` | Show GitHub owner, repo, latest release tag, publish date, and install status for a plugin. | `dpm.info` |
 | `/dpm reload` | Reload `config.yml` and re-apply settings (e.g. `githubToken`). | `dpm.reload` |
-| `/dpm remove <plugin-name>` | Remove an installed managed plugin from the plugins folder. | `dpm.remove` |
+| `/dpm remove <plugin-name> [--confirm]` | Preview removal of an installed plugin, or delete it when `--confirm` is passed. | `dpm.remove` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -17,6 +17,8 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 3. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). If the plugin is already on the latest version, the download is skipped.
 4. Run `/dpm update` to check every installed managed plugin against its latest GitHub release and download any that are out of date.
 5. Restart the server to activate downloaded or updated plugins.
+6. Run `/dpm clean` to preview duplicate plugin JARs (e.g. versioned copies left over from manual installs). Add `--confirm` to delete them.
+7. Run `/dpm remove <plugin-name>` to preview which JAR would be deleted. Add `--confirm` to remove it and clear its stored version tag.
 
 ## Permissions
 
@@ -26,11 +28,11 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 | `dpm.list` | `true` | List DPC plugins with installed/version status. |
 | `dpm.stats` | `true` | View plugin statistics. |
 | `dpm.get` | `op` | Download a plugin to the server. |
-| `dpm.clean` | `op` | Remove duplicate plugin JARs. |
+| `dpm.clean` | `op` | Preview or remove duplicate plugin JARs. |
 | `dpm.update` | `op` | Update all installed managed plugins. |
 | `dpm.info` | `true` | View release and install info for a plugin. |
 | `dpm.reload` | `op` | Reload the DPM config. |
-| `dpm.remove` | `op` | Remove an installed managed plugin. |
+| `dpm.remove` | `op` | Preview or remove an installed managed plugin. |
 
 ## Configuration
 

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -87,6 +87,12 @@ public final class DansPluginManager extends PonderBukkitPlugin {
         if (args.length == 2 && args[0].equalsIgnoreCase("remove")) {
             return TabCompleter.filterByPrefix(removeCommand.getInstalledPluginNames(), args[1]);
         }
+        if (args.length == 2 && args[0].equalsIgnoreCase("clean")) {
+            return TabCompleter.filterByPrefix(List.of("--confirm"), args[1]);
+        }
+        if (args.length == 3 && args[0].equalsIgnoreCase("remove")) {
+            return TabCompleter.filterByPrefix(List.of("--confirm"), args[2]);
+        }
         return Collections.emptyList();
     }
 

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -29,6 +29,8 @@ import java.util.List;
  * @author Daniel McCoy Stephenson
  */
 public final class DansPluginManager extends PonderBukkitPlugin {
+    private static final List<String> CONFIRM_COMPLETION = List.of("--confirm");
+
     private final String pluginVersion = "v" + getDescription().getVersion();
 
     private final CommandService commandService = new CommandService(getPonder());
@@ -88,10 +90,10 @@ public final class DansPluginManager extends PonderBukkitPlugin {
             return TabCompleter.filterByPrefix(removeCommand.getInstalledPluginNames(), args[1]);
         }
         if (args.length == 2 && args[0].equalsIgnoreCase("clean")) {
-            return TabCompleter.filterByPrefix(List.of("--confirm"), args[1]);
+            return TabCompleter.filterByPrefix(CONFIRM_COMPLETION, args[1]);
         }
         if (args.length == 3 && args[0].equalsIgnoreCase("remove")) {
-            return TabCompleter.filterByPrefix(List.of("--confirm"), args[2]);
+            return TabCompleter.filterByPrefix(CONFIRM_COMPLETION, args[2]);
         }
         return Collections.emptyList();
     }

--- a/src/main/java/dansplugins/dpm/commands/CleanCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/CleanCommand.java
@@ -59,22 +59,34 @@ public class CleanCommand extends AbstractPluginCommand {
             sender.sendMessage(ChatColor.AQUA + "Removing duplicate plugin JARs...");
             Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
                 List<String> removed = new ArrayList<>();
+                List<String> failed = new ArrayList<>();
                 for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
                     for (File conflict : pluginFolderService.findConflictingJars(record)) {
+                        String label = conflict.getName() + " (" + record.getName() + ")";
                         if (conflict.delete()) {
-                            removed.add(conflict.getName() + " (" + record.getName() + ")");
+                            removed.add(label);
+                        } else {
+                            failed.add(label);
                         }
                     }
                 }
                 Bukkit.getScheduler().runTask(plugin, () -> {
-                    if (removed.isEmpty()) {
+                    if (removed.isEmpty() && failed.isEmpty()) {
                         sender.sendMessage(ChatColor.GREEN + "No duplicate JARs found.");
-                    } else {
+                        return;
+                    }
+                    if (!removed.isEmpty()) {
                         sender.sendMessage(ChatColor.GREEN + "Removed " + removed.size() + " duplicate JAR(s):");
                         for (String entry : removed) {
                             sender.sendMessage(ChatColor.AQUA + "  - " + entry);
                         }
                         sender.sendMessage(ChatColor.YELLOW + "Restart the server to apply changes.");
+                    }
+                    if (!failed.isEmpty()) {
+                        sender.sendMessage(ChatColor.RED + "Failed to delete " + failed.size() + " JAR(s) — check server file permissions:");
+                        for (String entry : failed) {
+                            sender.sendMessage(ChatColor.RED + "  - " + entry);
+                        }
                     }
                 });
             });

--- a/src/main/java/dansplugins/dpm/commands/CleanCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/CleanCommand.java
@@ -29,26 +29,24 @@ public class CleanCommand extends AbstractPluginCommand {
     }
 
     @Override
-    public boolean execute(CommandSender commandSender) {
-        commandSender.sendMessage(ChatColor.AQUA + "Scanning for duplicate plugin JARs...");
+    public boolean execute(CommandSender sender) {
+        sender.sendMessage(ChatColor.AQUA + "Scanning for duplicate plugin JARs...");
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            List<String> removed = new ArrayList<>();
+            List<String> conflicts = new ArrayList<>();
             for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
                 for (File conflict : pluginFolderService.findConflictingJars(record)) {
-                    if (conflict.delete()) {
-                        removed.add(conflict.getName() + " (" + record.getName() + ")");
-                    }
+                    conflicts.add(conflict.getName() + " (" + record.getName() + ")");
                 }
             }
             Bukkit.getScheduler().runTask(plugin, () -> {
-                if (removed.isEmpty()) {
-                    commandSender.sendMessage(ChatColor.GREEN + "No duplicate JARs found.");
+                if (conflicts.isEmpty()) {
+                    sender.sendMessage(ChatColor.GREEN + "No duplicate JARs found.");
                 } else {
-                    commandSender.sendMessage(ChatColor.GREEN + "Removed " + removed.size() + " duplicate JAR(s):");
-                    for (String entry : removed) {
-                        commandSender.sendMessage(ChatColor.AQUA + "  - " + entry);
+                    sender.sendMessage(ChatColor.YELLOW + "Found " + conflicts.size() + " duplicate JAR(s) to remove:");
+                    for (String entry : conflicts) {
+                        sender.sendMessage(ChatColor.AQUA + "  - " + entry);
                     }
-                    commandSender.sendMessage(ChatColor.YELLOW + "Restart the server to apply changes.");
+                    sender.sendMessage(ChatColor.YELLOW + "Run " + ChatColor.WHITE + "/dpm clean --confirm" + ChatColor.YELLOW + " to delete them.");
                 }
             });
         });
@@ -56,7 +54,32 @@ public class CleanCommand extends AbstractPluginCommand {
     }
 
     @Override
-    public boolean execute(CommandSender commandSender, String[] args) {
-        return execute(commandSender);
+    public boolean execute(CommandSender sender, String[] args) {
+        if (args.length > 0 && args[0].equalsIgnoreCase("--confirm")) {
+            sender.sendMessage(ChatColor.AQUA + "Removing duplicate plugin JARs...");
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+                List<String> removed = new ArrayList<>();
+                for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
+                    for (File conflict : pluginFolderService.findConflictingJars(record)) {
+                        if (conflict.delete()) {
+                            removed.add(conflict.getName() + " (" + record.getName() + ")");
+                        }
+                    }
+                }
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    if (removed.isEmpty()) {
+                        sender.sendMessage(ChatColor.GREEN + "No duplicate JARs found.");
+                    } else {
+                        sender.sendMessage(ChatColor.GREEN + "Removed " + removed.size() + " duplicate JAR(s):");
+                        for (String entry : removed) {
+                            sender.sendMessage(ChatColor.AQUA + "  - " + entry);
+                        }
+                        sender.sendMessage(ChatColor.YELLOW + "Restart the server to apply changes.");
+                    }
+                });
+            });
+            return true;
+        }
+        return execute(sender);
     }
 }

--- a/src/main/java/dansplugins/dpm/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/HelpCommand.java
@@ -22,12 +22,12 @@ public class HelpCommand extends AbstractPluginCommand {
         commandSender.sendMessage(ChatColor.AQUA + "/dpm help - View this list of commands.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm list - List plugins with install status.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm get <plugin-name> - Download a plugin.");
-        commandSender.sendMessage(ChatColor.AQUA + "/dpm clean - Remove duplicate plugin JARs.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm clean [--confirm] - Preview or remove duplicate plugin JARs.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm stats - View plugin statistics.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm update - Update all installed plugins.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm info <plugin-name> - Show release and install info for a plugin.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm reload - Reload the DPM config.");
-        commandSender.sendMessage(ChatColor.AQUA + "/dpm remove <plugin-name> - Remove an installed plugin.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm remove <plugin-name> [--confirm] - Preview or remove an installed plugin.");
         return true;
     }
 

--- a/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
@@ -27,7 +27,7 @@ public class RemoveCommand extends AbstractPluginCommand {
 
     @Override
     public boolean execute(CommandSender sender) {
-        sender.sendMessage(ChatColor.RED + "Usage: /dpm remove <plugin-name>");
+        sender.sendMessage(ChatColor.RED + "Usage: /dpm remove <plugin-name> [--confirm]");
         return false;
     }
 

--- a/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
@@ -44,6 +44,12 @@ public class RemoveCommand extends AbstractPluginCommand {
             sender.sendMessage(ChatColor.YELLOW + record.getName() + " is not installed.");
             return true;
         }
+        boolean confirmed = args.length >= 2 && args[1].equalsIgnoreCase("--confirm");
+        if (!confirmed) {
+            sender.sendMessage(ChatColor.YELLOW + "This will delete " + ChatColor.WHITE + jar.getName() + ChatColor.YELLOW + " from the plugins folder.");
+            sender.sendMessage(ChatColor.YELLOW + "Run " + ChatColor.WHITE + "/dpm remove " + name + " --confirm" + ChatColor.YELLOW + " to proceed.");
+            return true;
+        }
         if (jar.delete()) {
             versionStore.removeTag(record.getName());
             sender.sendMessage(ChatColor.GREEN + "Removed " + record.getName() + ".");


### PR DESCRIPTION
## Summary
- `/dpm clean` without arguments now previews what would be deleted and prompts the operator to re-run with `--confirm`
- `/dpm clean --confirm` performs the actual deletion (previous behavior)
- `/dpm remove <name>` without `--confirm` now shows which file would be deleted and prompts for confirmation
- `/dpm remove <name> --confirm` performs the actual deletion (previous behavior)
- Tab completion offers `--confirm` at the correct arg position for both sub-commands

Closes #26

## Test plan
- [ ] `/dpm clean` on a server with duplicate JARs: shows preview list + confirmation hint, deletes nothing
- [ ] `/dpm clean --confirm` on same server: deletes duplicates, reports count
- [ ] `/dpm clean` with no duplicates: "No duplicate JARs found."
- [ ] `/dpm remove medievalfactions` when installed: shows filename + confirmation hint, deletes nothing
- [ ] `/dpm remove medievalfactions --confirm`: deletes the JAR, clears version tag
- [ ] `/dpm remove medievalfactions` when not installed: "not installed" message (unchanged)
- [ ] Tab-complete `/dpm clean ` → suggests `--confirm`
- [ ] Tab-complete `/dpm remove medievalfactions ` → suggests `--confirm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_