### PR TITLE
Add descriptions and dependency declarations to ProjectRecord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `/dpm remove <plugin-name> [--confirm]` — previews the JAR to be deleted; pass `--confirm` to actually remove it and clear the stored version tag
 - Tab-completion for `/dpm remove` offers installed plugin names at the first argument and `--confirm` at the second
 - Tab-completion for `/dpm clean` offers `--confirm` at the first argument
+- One-line descriptions added to all 28 registered plugins; shown by `/dpm info`
+- Dependency declarations on `ProjectRecord` — hard (`depend`) and soft (`softdepend`) DPC-to-DPC relationships sourced from each plugin's `plugin.yml`
+- `/dpm info` shows each dependency and whether it is currently installed
+- `/dpm get` warns when a required hard dependency is not yet installed (download still proceeds)
 
 ### Changed
 - `/dpm clean` now previews what would be deleted; pass `--confirm` to actually remove the files

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -10,6 +10,6 @@ All commands use `/dpm` or `/danspluginmanager` as the base.
 | `/dpm clean [--confirm]` | Preview duplicate plugin JARs, or delete them when `--confirm` is passed. | `dpm.clean` |
 | `/dpm stats` | View plugin statistics. | `dpm.stats` |
 | `/dpm update` | Update all installed managed plugins to their latest release. | `dpm.update` |
-| `/dpm info <plugin-name>` | Show GitHub owner, repo, latest release tag, publish date, and install status for a plugin. | `dpm.info` |
+| `/dpm info <plugin-name>` | Show description, GitHub owner, repo, latest release tag, publish date, install status, and dependency status for a plugin. | `dpm.info` |
 | `/dpm reload` | Reload `config.yml` and re-apply settings (e.g. `githubToken`). | `dpm.reload` |
 | `/dpm remove <plugin-name> [--confirm]` | Preview removal of an installed plugin, or delete it when `--confirm` is passed. | `dpm.remove` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -13,8 +13,8 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 ## Getting Started
 
 1. Run `/dpm list` to see all DPC plugins. Green entries are installed (with version tag when known); grey entries are not yet installed.
-2. Run `/dpm info <plugin-name>` to see the GitHub owner, repository, latest release tag, publish date, and install status for a specific plugin before downloading.
-3. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). If the plugin is already on the latest version, the download is skipped.
+2. Run `/dpm info <plugin-name>` to see a plugin's description, GitHub owner, repository, latest release tag, publish date, install status, and any required or optional dependencies.
+3. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). If the plugin is already on the latest version, the download is skipped. If required dependencies are not installed, a warning is shown before the download begins.
 4. Run `/dpm update` to check every installed managed plugin against its latest GitHub release and download any that are out of date.
 5. Restart the server to activate downloaded or updated plugins.
 6. Run `/dpm clean` to preview duplicate plugin JARs (e.g. versioned copies left over from manual installs). Add `--confirm` to delete them.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -30,7 +30,7 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 | `dpm.get` | `op` | Download a plugin to the server. |
 | `dpm.clean` | `op` | Preview or remove duplicate plugin JARs. |
 | `dpm.update` | `op` | Update all installed managed plugins. |
-| `dpm.info` | `true` | View release and install info for a plugin. |
+| `dpm.info` | `true` | View description, release info, install status, and dependencies for a plugin. |
 | `dpm.reload` | `op` | Reload the DPM config. |
 | `dpm.remove` | `op` | Preview or remove an installed managed plugin. |
 

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -168,7 +168,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     private void initializeCommandService() {
         ArrayList<AbstractPluginCommand> commands = new ArrayList<>(Arrays.asList(
                 new HelpCommand(),
-                new GetCommand(ephemeralData, downloadService, versionStore, this),
+                new GetCommand(ephemeralData, downloadService, pluginFolderService, versionStore, this),
                 new ListCommand(ephemeralData, pluginFolderService, versionStore),
                 new StatsCommand(ephemeralData),
                 new CleanCommand(ephemeralData, pluginFolderService, this),

--- a/src/main/java/dansplugins/dpm/commands/GetCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/GetCommand.java
@@ -3,6 +3,7 @@ package dansplugins.dpm.commands;
 import dansplugins.dpm.data.EphemeralData;
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.services.DownloadService;
+import dansplugins.dpm.services.PluginFolderService;
 import dansplugins.dpm.services.VersionStore;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -16,14 +17,16 @@ import java.util.List;
 public class GetCommand extends AbstractPluginCommand {
     private final EphemeralData ephemeralData;
     private final DownloadService downloadService;
+    private final PluginFolderService pluginFolderService;
     private final VersionStore versionStore;
     private final Plugin plugin;
 
     public GetCommand(EphemeralData ephemeralData, DownloadService downloadService,
-                      VersionStore versionStore, Plugin plugin) {
+                      PluginFolderService pluginFolderService, VersionStore versionStore, Plugin plugin) {
         super(new ArrayList<>(List.of("get")), new ArrayList<>(List.of("dpm.get")));
         this.ephemeralData = ephemeralData;
         this.downloadService = downloadService;
+        this.pluginFolderService = pluginFolderService;
         this.versionStore = versionStore;
         this.plugin = plugin;
     }
@@ -34,6 +37,16 @@ public class GetCommand extends AbstractPluginCommand {
         return false;
     }
 
+    private void warnMissingDependencies(CommandSender sender, ProjectRecord record) {
+        for (String dep : record.getHardDependencies()) {
+            ProjectRecord depRecord = ephemeralData.getProjectRecord(dep);
+            if (depRecord == null || !pluginFolderService.isInstalled(depRecord)) {
+                sender.sendMessage(ChatColor.YELLOW + "Warning: " + record.getName()
+                        + " requires " + dep + ", which is not installed. Run /dpm get " + dep + " first.");
+            }
+        }
+    }
+
     @Override
     public boolean execute(CommandSender commandSender, String[] args) {
         String name = args[0];
@@ -42,6 +55,7 @@ public class GetCommand extends AbstractPluginCommand {
             commandSender.sendMessage(ChatColor.RED + "Plugin not found: " + name);
             return false;
         }
+        warnMissingDependencies(commandSender, projectRecord);
         commandSender.sendMessage(ChatColor.AQUA + "Fetching " + projectRecord.getName() + "...");
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             int result = downloadService.downloadLatest(projectRecord);

--- a/src/main/java/dansplugins/dpm/commands/InfoCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/InfoCommand.java
@@ -57,6 +57,11 @@ public class InfoCommand extends AbstractPluginCommand {
 
     private void showInfo(CommandSender sender, ProjectRecord record, ReleaseInfo release) {
         sender.sendMessage(ChatColor.AQUA + "=== " + record.getName() + " ===");
+
+        if (record.getDescription() != null) {
+            sender.sendMessage(ChatColor.WHITE + record.getDescription());
+        }
+
         sender.sendMessage(ChatColor.WHITE + "Owner: " + ChatColor.AQUA + record.getOwner());
         sender.sendMessage(ChatColor.WHITE + "Repository: " + ChatColor.AQUA + record.getRepo());
 
@@ -86,6 +91,21 @@ public class InfoCommand extends AbstractPluginCommand {
             }
         } else {
             sender.sendMessage(ChatColor.WHITE + "Installed: " + ChatColor.GRAY + "No");
+        }
+
+        showDependencies(sender, record.getHardDependencies(), "Requires");
+        showDependencies(sender, record.getSoftDependencies(), "Integrates with");
+    }
+
+    private void showDependencies(CommandSender sender, List<String> deps, String label) {
+        if (deps.isEmpty()) return;
+        for (String dep : deps) {
+            ProjectRecord depRecord = ephemeralData.getProjectRecord(dep);
+            boolean depInstalled = depRecord != null && pluginFolderService.isInstalled(depRecord);
+            String status = depInstalled
+                    ? ChatColor.GREEN + dep + " (installed)"
+                    : ChatColor.RED + dep + " (not installed)";
+            sender.sendMessage(ChatColor.WHITE + label + ": " + status);
         }
     }
 

--- a/src/main/java/dansplugins/dpm/factories/ProjectRecordFactory.java
+++ b/src/main/java/dansplugins/dpm/factories/ProjectRecordFactory.java
@@ -13,4 +13,8 @@ public class ProjectRecordFactory {
     public void createGitHubRecord(String name, String owner, String repo) {
         ephemeralData.addProjectRecord(ProjectRecord.forGitHub(name, owner, repo));
     }
+
+    public void register(ProjectRecord record) {
+        ephemeralData.addProjectRecord(record);
+    }
 }

--- a/src/main/java/dansplugins/dpm/objects/ProjectRecord.java
+++ b/src/main/java/dansplugins/dpm/objects/ProjectRecord.java
@@ -1,29 +1,71 @@
 package dansplugins.dpm.objects;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class ProjectRecord {
     private final String name;
     private final String owner;
     private final String repo;
+    private final String description;
+    private final List<String> hardDependencies;
+    private final List<String> softDependencies;
 
-    private ProjectRecord(String name, String owner, String repo) {
-        this.name = name;
-        this.owner = owner;
-        this.repo = repo;
+    private ProjectRecord(Builder builder) {
+        this.name = builder.name;
+        this.owner = builder.owner;
+        this.repo = builder.repo;
+        this.description = builder.description;
+        this.hardDependencies = List.copyOf(builder.hardDependencies);
+        this.softDependencies = List.copyOf(builder.softDependencies);
     }
 
     public static ProjectRecord forGitHub(String name, String owner, String repo) {
-        return new ProjectRecord(name, owner, repo);
+        return new Builder(name, owner, repo).build();
     }
 
-    public String getName() {
-        return name;
+    public static Builder builder(String name, String owner, String repo) {
+        return new Builder(name, owner, repo);
     }
 
-    public String getOwner() {
-        return owner;
-    }
+    public String getName() { return name; }
+    public String getOwner() { return owner; }
+    public String getRepo() { return repo; }
+    public String getDescription() { return description; }
+    public List<String> getHardDependencies() { return hardDependencies; }
+    public List<String> getSoftDependencies() { return softDependencies; }
 
-    public String getRepo() {
-        return repo;
+    public static final class Builder {
+        private final String name;
+        private final String owner;
+        private final String repo;
+        private String description;
+        private List<String> hardDependencies = new ArrayList<>();
+        private List<String> softDependencies = new ArrayList<>();
+
+        private Builder(String name, String owner, String repo) {
+            this.name = name;
+            this.owner = owner;
+            this.repo = repo;
+        }
+
+        public Builder description(String d) {
+            this.description = d;
+            return this;
+        }
+
+        public Builder hardDependencies(List<String> deps) {
+            this.hardDependencies = new ArrayList<>(deps);
+            return this;
+        }
+
+        public Builder softDependencies(List<String> deps) {
+            this.softDependencies = new ArrayList<>(deps);
+            return this;
+        }
+
+        public ProjectRecord build() {
+            return new ProjectRecord(this);
+        }
     }
 }

--- a/src/main/java/dansplugins/dpm/utils/ProjectRecordInitializer.java
+++ b/src/main/java/dansplugins/dpm/utils/ProjectRecordInitializer.java
@@ -1,6 +1,9 @@
 package dansplugins.dpm.utils;
 
 import dansplugins.dpm.factories.ProjectRecordFactory;
+import dansplugins.dpm.objects.ProjectRecord;
+
+import java.util.List;
 
 public class ProjectRecordInitializer {
     private static final String DANS_PLUGINS = "Dans-Plugins";
@@ -12,37 +15,58 @@ public class ProjectRecordInitializer {
     }
 
     public void initializeProjectRecords() {
-        gh("activitytracker",          "Activity-Tracker");
-        gh("alternateaccountfinder",   "AlternateAccountFinder");
-        gh("bluemapmedievalfactions",  "Bluemap_MedievalFactions");
-        gh("bookshelvesyoucanuse",     "Bookshelves-You-Can-Use");
-        gh("conquestrecipes",          "Conquest-Recipes");
-        gh("currencies",               "Currencies");
-        gh("dansessentials",           "Dans-Essentials");
-        gh("danssethome",              "Dans-Set-Home");
-        gh("dansspawnsystem",          "Dans-Spawn-System");
-        gh("democracy",                "Democracy");
-        gh("easylinks",                "Easy-Links");
-        gh("fiefs",                    "Fiefs");
-        gh("flycommand",               "FlyCommand");
-        gh("foodspoilage",             "FoodSpoilage");
-        gh("herald",                   "Herald");
-        gh("kdrtracker",               "KDRTracker");
-        gh("mailboxes",                "Mailboxes");
-        gh("medievalcookery",          "Medieval-Cookery");
-        gh("medievaleconomy",          "Medieval-Economy");
-        gh("medievalfactions",         "Medieval-Factions");
-        gh("medievalroleplayengine",   "Medieval-Roleplay-Engine");
-        gh("minifactions",             "MiniFactions");
-        gh("morerecipes",              "More-Recipes");
-        gh("netheraccesscontroller",   "Nether-Access-Controller");
-        gh("nomorecreepers",           "NoMoreCreepers");
-        gh("playerlore",               "PlayerLore");
-        gh("simpleskills",             "SimpleSkills");
-        gh("wildpets",                 "Wild-Pets");
+        gh("activitytracker",         "Activity-Tracker",          "Logs player activity including logins, logouts, kills, and deaths.");
+        gh("alternateaccountfinder",  "AlternateAccountFinder",    "Detects players using alternate accounts by comparing IP addresses.");
+        gh("bluemapmedievalfactions", "Bluemap_MedievalFactions",  "Renders Medieval Factions territory and claims on BlueMap.",
+                List.of("medievalfactions"), List.of());
+        gh("bookshelvesyoucanuse",    "Bookshelves-You-Can-Use",   "Turns bookshelves into functional storage containers.");
+        gh("conquestrecipes",         "Conquest-Recipes",          "Adds conquest-themed crafting recipes.");
+        gh("currencies",              "Currencies",                "Adds configurable in-game currencies.",
+                List.of("medievalfactions"), List.of());
+        gh("dansessentials",          "Dans-Essentials",           "A collection of essential server administration commands.");
+        gh("danssethome",             "Dans-Set-Home",             "Lets players set and teleport to personal home locations.");
+        gh("dansspawnsystem",         "Dans-Spawn-System",         "Manages server spawn points and first-join spawn assignment.");
+        gh("democracy",               "Democracy",                 "Adds in-game voting and democratic governance mechanics.",
+                List.of("medievalfactions"), List.of());
+        gh("easylinks",               "Easy-Links",                "Posts clickable URLs in chat.");
+        gh("fiefs",                   "Fiefs",                     "Adds a land ownership and fiefs system.",
+                List.of("medievalfactions"), List.of());
+        gh("flycommand",              "FlyCommand",                "Allows operators and permitted players to toggle flight mode.");
+        gh("foodspoilage",            "FoodSpoilage",              "Makes food items spoil over time, adding survival challenge.");
+        gh("herald",                  "Herald",                    "Announces custom messages on player join and leave.");
+        gh("kdrtracker",              "KDRTracker",                "Tracks and displays kill/death ratios for players.");
+        gh("mailboxes",               "Mailboxes",                 "Adds physical in-world mailboxes so players can send each other items and messages.");
+        gh("medievalcookery",         "Medieval-Cookery",          "Adds medieval-themed cooking recipes and food items.");
+        gh("medievaleconomy",         "Medieval-Economy",          "A player-driven economy system with shops and trading.");
+        gh("medievalfactions",        "Medieval-Factions",         "A comprehensive factions plugin built for medieval roleplay servers.",
+                List.of(), List.of("mailboxes"));
+        gh("medievalroleplayengine",  "Medieval-Roleplay-Engine",  "A roleplay engine that ties together DPC plugins for immersive medieval servers.",
+                List.of(), List.of("medievalfactions", "mailboxes"));
+        gh("minifactions",            "MiniFactions",              "A lightweight factions plugin for servers that want simple territory control.");
+        gh("morerecipes",             "More-Recipes",              "Adds a variety of additional crafting recipes.");
+        gh("netheraccesscontroller",  "Nether-Access-Controller",  "Controls which players or groups can access the Nether.");
+        gh("nomorecreepers",          "NoMoreCreepers",            "Prevents creepers from spawning or dealing explosion damage.");
+        gh("playerlore",              "PlayerLore",                "Lets players write and share their character backstory as in-game lore.");
+        gh("simpleskills",            "SimpleSkills",              "Adds a skill progression system with levelling for common activities.");
+        gh("wildpets",                "Wild-Pets",                 "Lets players tame wild animals and keep them as persistent pets.");
     }
 
-    private void gh(String name, String repo) {
-        projectRecordFactory.createGitHubRecord(name, DANS_PLUGINS, repo);
+    private void gh(String name, String repo, String description) {
+        projectRecordFactory.register(
+                ProjectRecord.builder(name, DANS_PLUGINS, repo)
+                        .description(description)
+                        .build()
+        );
+    }
+
+    private void gh(String name, String repo, String description,
+                    List<String> hardDeps, List<String> softDeps) {
+        projectRecordFactory.register(
+                ProjectRecord.builder(name, DANS_PLUGINS, repo)
+                        .description(description)
+                        .hardDependencies(hardDeps)
+                        .softDependencies(softDeps)
+                        .build()
+        );
     }
 }

--- a/src/test/java/dansplugins/dpm/objects/ProjectRecordTest.java
+++ b/src/test/java/dansplugins/dpm/objects/ProjectRecordTest.java
@@ -2,6 +2,8 @@ package dansplugins.dpm.objects;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class ProjectRecordTest {
@@ -31,5 +33,70 @@ class ProjectRecordTest {
         assertNotEquals(a.getName(), b.getName());
         assertNotEquals(a.getOwner(), b.getOwner());
         assertNotEquals(a.getRepo(), b.getRepo());
+    }
+
+    // -------------------------------------------------------------------------
+    // forGitHub() defaults
+    // -------------------------------------------------------------------------
+
+    @Test
+    void forGitHub_descriptionIsNullByDefault() {
+        assertNull(ProjectRecord.forGitHub("x", "o", "r").getDescription());
+    }
+
+    @Test
+    void forGitHub_hardDependenciesEmptyByDefault() {
+        assertTrue(ProjectRecord.forGitHub("x", "o", "r").getHardDependencies().isEmpty());
+    }
+
+    @Test
+    void forGitHub_softDependenciesEmptyByDefault() {
+        assertTrue(ProjectRecord.forGitHub("x", "o", "r").getSoftDependencies().isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // Builder
+    // -------------------------------------------------------------------------
+
+    @Test
+    void builder_setsDescription() {
+        ProjectRecord r = ProjectRecord.builder("currencies", "Dans-Plugins", "Currencies")
+                .description("Adds configurable in-game currencies.")
+                .build();
+        assertEquals("Adds configurable in-game currencies.", r.getDescription());
+    }
+
+    @Test
+    void builder_setsHardDependencies() {
+        ProjectRecord r = ProjectRecord.builder("currencies", "Dans-Plugins", "Currencies")
+                .hardDependencies(List.of("medievalfactions"))
+                .build();
+        assertEquals(List.of("medievalfactions"), r.getHardDependencies());
+    }
+
+    @Test
+    void builder_setsSoftDependencies() {
+        ProjectRecord r = ProjectRecord.builder("medievalfactions", "Dans-Plugins", "Medieval-Factions")
+                .softDependencies(List.of("mailboxes"))
+                .build();
+        assertEquals(List.of("mailboxes"), r.getSoftDependencies());
+    }
+
+    @Test
+    void builder_hardDependenciesAreImmutable() {
+        ProjectRecord r = ProjectRecord.builder("currencies", "Dans-Plugins", "Currencies")
+                .hardDependencies(List.of("medievalfactions"))
+                .build();
+        assertThrows(UnsupportedOperationException.class, () -> r.getHardDependencies().add("other"));
+    }
+
+    @Test
+    void builder_preservesCoreFields() {
+        ProjectRecord r = ProjectRecord.builder("currencies", "Dans-Plugins", "Currencies")
+                .description("desc")
+                .build();
+        assertEquals("currencies", r.getName());
+        assertEquals("Dans-Plugins", r.getOwner());
+        assertEquals("Currencies", r.getRepo());
     }
 }


### PR DESCRIPTION
Closes #28, Closes #29

## Summary
- ProjectRecord gains description, hardDependencies, softDependencies via an inner Builder; forGitHub() convenience factory preserved so existing tests need no changes
- ProjectRecordFactory.register() added for builder-constructed records
- All 28 plugins rewritten in ProjectRecordInitializer with one-line descriptions and DPC-to-DPC dependency relationships sourced from each plugin's plugin.yml
- /dpm info shows description and each dependency with install status (hard deps: 'Requires', soft deps: 'Integrates with')
- /dpm get warns when a hard dependency is not installed before starting the download (does not block)
- ProjectRecordTest extended with builder and default-field coverage

## Test plan
- /dpm info currencies: shows description, 'Requires: medievalfactions (installed/not installed)'
- /dpm info medievalfactions: shows 'Integrates with: mailboxes'
- /dpm info wildpets: shows description, no dependency lines
- /dpm get currencies without medievalfactions: warning shown, download proceeds
- /dpm get wildpets: no warning, proceeds normally
- All existing tests pass

Generated with Claude Code

---

_drafted by Claude on behalf of Daniel Stephenson_