### PR TITLE
Batch /dpm get and /dpm list filter flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Dependency declarations on `ProjectRecord` — hard (`depend`) and soft (`softdepend`) DPC-to-DPC relationships sourced from each plugin's `plugin.yml`
 - `/dpm info` shows each dependency and whether it is currently installed
 - `/dpm get` warns when a required hard dependency is not yet installed (download still proceeds)
+- `/dpm get` accepts multiple plugin names: `/dpm get plugin1 plugin2 ...` downloads all named plugins sequentially with per-plugin result lines and a summary
+- `/dpm list installed` shows only plugins whose JAR is present in the plugins folder
+- `/dpm list available` shows only plugins that are not currently installed
+- Tab-completion for `/dpm get` offers plugin names at every argument position
+- Tab-completion for `/dpm list` offers `installed` and `available`
 
 ### Changed
 - `/dpm clean` now previews what would be deleted; pass `--confirm` to actually remove the files

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -5,8 +5,8 @@ All commands use `/dpm` or `/danspluginmanager` as the base.
 | Command | Description | Permission |
 |---------|-------------|------------|
 | `/dpm help` | View a list of commands. | `dpm.help` |
-| `/dpm list` | List DPC plugins, showing which are installed (with version tag when known). | `dpm.list` |
-| `/dpm get <plugin-name>` | Download a DPC plugin to the server. | `dpm.get` |
+| `/dpm list [installed\|available]` | List DPC plugins. Pass `installed` or `available` to filter. | `dpm.list` |
+| `/dpm get <plugin-name> [plugin-name ...]` | Download one or more DPC plugins to the server. | `dpm.get` |
 | `/dpm clean [--confirm]` | Preview duplicate plugin JARs, or delete them when `--confirm` is passed. | `dpm.clean` |
 | `/dpm stats` | View plugin statistics. | `dpm.stats` |
 | `/dpm update` | Update all installed managed plugins to their latest release. | `dpm.update` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -25,9 +25,9 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 | Permission | Default | Description |
 |------------|---------|-------------|
 | `dpm.help` | `true` | View the help menu. |
-| `dpm.list` | `true` | List DPC plugins with installed/version status. |
+| `dpm.list` | `true` | List DPC plugins, optionally filtered by `installed` or `available`. |
 | `dpm.stats` | `true` | View plugin statistics. |
-| `dpm.get` | `op` | Download a plugin to the server. |
+| `dpm.get` | `op` | Download one or more plugins to the server. |
 | `dpm.clean` | `op` | Preview or remove duplicate plugin JARs. |
 | `dpm.update` | `op` | Update all installed managed plugins. |
 | `dpm.info` | `true` | View description, release info, install status, and dependencies for a plugin. |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -12,9 +12,9 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 
 ## Getting Started
 
-1. Run `/dpm list` to see all DPC plugins. Green entries are installed (with version tag when known); grey entries are not yet installed.
+1. Run `/dpm list` to see all DPC plugins. Green entries are installed (with version tag when known); grey entries are not yet installed. Pass `installed` or `available` to filter the list.
 2. Run `/dpm info <plugin-name>` to see a plugin's description, GitHub owner, repository, latest release tag, publish date, install status, and any required or optional dependencies.
-3. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). If the plugin is already on the latest version, the download is skipped. If required dependencies are not installed, a warning is shown before the download begins.
+3. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). Multiple names are accepted: `/dpm get plugin1 plugin2`. If a plugin is already on the latest version the download is skipped. If required dependencies are not installed, a warning is shown before the download begins.
 4. Run `/dpm update` to check every installed managed plugin against its latest GitHub release and download any that are out of date.
 5. Restart the server to activate downloaded or updated plugins.
 6. Run `/dpm clean` to preview duplicate plugin JARs (e.g. versioned copies left over from manual installs). Add `--confirm` to delete them.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -14,7 +14,7 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 
 1. Run `/dpm list` to see all DPC plugins. Green entries are installed (with version tag when known); grey entries are not yet installed. Pass `installed` or `available` to filter the list.
 2. Run `/dpm info <plugin-name>` to see a plugin's description, GitHub owner, repository, latest release tag, publish date, install status, and any required or optional dependencies.
-3. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). Multiple names are accepted: `/dpm get plugin1 plugin2`. If a plugin is already on the latest version the download is skipped. If required dependencies are not installed, a warning is shown before the download begins.
+3. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). Multiple names are accepted: `/dpm get plugin1 plugin2`. If a plugin is already on the latest version, the download is skipped. If required dependencies are not installed, a warning is shown before the download begins.
 4. Run `/dpm update` to check every installed managed plugin against its latest GitHub release and download any that are out of date.
 5. Restart the server to activate downloaded or updated plugins.
 6. Run `/dpm clean` to preview duplicate plugin JARs (e.g. versioned copies left over from manual installs). Add `--confirm` to delete them.

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -79,12 +79,22 @@ public final class DansPluginManager extends PonderBukkitPlugin {
         if (args.length == 1) {
             return TabCompleter.filterByPrefix(Arrays.asList("help", "list", "get", "clean", "stats", "update", "info", "reload", "remove"), args[0]);
         }
-        if (args.length == 2 && (args[0].equalsIgnoreCase("get") || args[0].equalsIgnoreCase("info"))) {
+        if (args.length >= 2 && args[0].equalsIgnoreCase("get")) {
+            List<String> names = new ArrayList<>();
+            for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
+                names.add(record.getName());
+            }
+            return TabCompleter.filterByPrefix(names, args[args.length - 1]);
+        }
+        if (args.length == 2 && args[0].equalsIgnoreCase("info")) {
             List<String> names = new ArrayList<>();
             for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
                 names.add(record.getName());
             }
             return TabCompleter.filterByPrefix(names, args[1]);
+        }
+        if (args.length == 2 && args[0].equalsIgnoreCase("list")) {
+            return TabCompleter.filterByPrefix(List.of("installed", "available"), args[1]);
         }
         if (args.length == 2 && args[0].equalsIgnoreCase("remove")) {
             return TabCompleter.filterByPrefix(removeCommand.getInstalledPluginNames(), args[1]);

--- a/src/main/java/dansplugins/dpm/commands/GetCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/GetCommand.java
@@ -12,7 +12,10 @@ import org.bukkit.plugin.Plugin;
 import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class GetCommand extends AbstractPluginCommand {
     private final EphemeralData ephemeralData;
@@ -51,7 +54,7 @@ public class GetCommand extends AbstractPluginCommand {
             sender.sendMessage(ChatColor.RED + "Plugin not found: " + name);
             return false;
         }
-        warnMissingDependencies(sender, record);
+        warnMissingDependencies(sender, record, Collections.emptySet());
         sender.sendMessage(ChatColor.AQUA + "Fetching " + record.getName() + "...");
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             int result = downloadService.downloadLatest(record);
@@ -61,23 +64,34 @@ public class GetCommand extends AbstractPluginCommand {
     }
 
     private boolean executeBatch(CommandSender sender, String[] args) {
+        // First pass: resolve all names so the full batch set is known before warnings fire.
         List<ProjectRecord> records = new ArrayList<>();
+        int notFound = 0;
         for (String name : args) {
             ProjectRecord record = ephemeralData.getProjectRecord(name);
             if (record == null) {
                 sender.sendMessage(ChatColor.RED + "Plugin not found: " + name + " — skipping.");
+                notFound++;
             } else {
-                warnMissingDependencies(sender, record);
                 records.add(record);
             }
         }
+
+        // Warn about missing deps, suppressing warnings for deps already in this batch.
+        Set<String> batchNames = new HashSet<>();
+        for (ProjectRecord r : records) batchNames.add(r.getName());
+        for (ProjectRecord record : records) {
+            warnMissingDependencies(sender, record, batchNames);
+        }
+
         if (records.isEmpty()) return false;
         sender.sendMessage(ChatColor.AQUA + "Fetching " + records.size() + " plugin(s)...");
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> runBatch(sender, records));
+        final int fn = notFound;
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> runBatch(sender, records, fn));
         return true;
     }
 
-    private void runBatch(CommandSender sender, List<ProjectRecord> records) {
+    private void runBatch(CommandSender sender, List<ProjectRecord> records, int notFound) {
         int downloaded = 0, upToDate = 0, skipped = 0, failed = 0;
         for (ProjectRecord record : records) {
             int result = downloadService.downloadLatest(record);
@@ -108,6 +122,7 @@ public class GetCommand extends AbstractPluginCommand {
                    .append(ChatColor.AQUA).append(", ").append(fu).append(" already up to date");
             if (fs > 0) summary.append(ChatColor.AQUA).append(", ").append(fs).append(" skipped (no release)");
             if (ff > 0) summary.append(ChatColor.RED).append(", ").append(ff).append(" failed");
+            if (notFound > 0) summary.append(ChatColor.RED).append(", ").append(notFound).append(" not found");
             summary.append(ChatColor.AQUA).append(".");
             sender.sendMessage(summary.toString());
             if (fd > 0) {
@@ -132,8 +147,9 @@ public class GetCommand extends AbstractPluginCommand {
         }
     }
 
-    private void warnMissingDependencies(CommandSender sender, ProjectRecord record) {
+    private void warnMissingDependencies(CommandSender sender, ProjectRecord record, Set<String> batchNames) {
         for (String dep : record.getHardDependencies()) {
+            if (batchNames.contains(dep)) continue;
             ProjectRecord depRecord = ephemeralData.getProjectRecord(dep);
             if (depRecord == null || !pluginFolderService.isInstalled(depRecord)) {
                 sender.sendMessage(ChatColor.YELLOW + "Warning: " + record.getName()

--- a/src/main/java/dansplugins/dpm/commands/GetCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/GetCommand.java
@@ -32,9 +32,104 @@ public class GetCommand extends AbstractPluginCommand {
     }
 
     @Override
-    public boolean execute(CommandSender commandSender) {
-        commandSender.sendMessage(ChatColor.RED + "Usage: /dpm get <plugin-name>");
+    public boolean execute(CommandSender sender) {
+        sender.sendMessage(ChatColor.RED + "Usage: /dpm get <plugin-name> [plugin-name ...]");
         return false;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        if (args.length == 1) {
+            return executeSingle(sender, args[0]);
+        }
+        return executeBatch(sender, args);
+    }
+
+    private boolean executeSingle(CommandSender sender, String name) {
+        ProjectRecord record = ephemeralData.getProjectRecord(name);
+        if (record == null) {
+            sender.sendMessage(ChatColor.RED + "Plugin not found: " + name);
+            return false;
+        }
+        warnMissingDependencies(sender, record);
+        sender.sendMessage(ChatColor.AQUA + "Fetching " + record.getName() + "...");
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            int result = downloadService.downloadLatest(record);
+            Bukkit.getScheduler().runTask(plugin, () -> reportSingleResult(sender, record, result));
+        });
+        return true;
+    }
+
+    private boolean executeBatch(CommandSender sender, String[] args) {
+        List<ProjectRecord> records = new ArrayList<>();
+        for (String name : args) {
+            ProjectRecord record = ephemeralData.getProjectRecord(name);
+            if (record == null) {
+                sender.sendMessage(ChatColor.RED + "Plugin not found: " + name + " — skipping.");
+            } else {
+                warnMissingDependencies(sender, record);
+                records.add(record);
+            }
+        }
+        if (records.isEmpty()) return false;
+        sender.sendMessage(ChatColor.AQUA + "Fetching " + records.size() + " plugin(s)...");
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> runBatch(sender, records));
+        return true;
+    }
+
+    private void runBatch(CommandSender sender, List<ProjectRecord> records) {
+        int downloaded = 0, upToDate = 0, skipped = 0, failed = 0;
+        for (ProjectRecord record : records) {
+            int result = downloadService.downloadLatest(record);
+            final String msg;
+            if (result == DownloadService.NO_RELEASE) {
+                skipped++;
+                msg = ChatColor.YELLOW + record.getName() + " has no published release yet.";
+            } else if (result == DownloadService.ALREADY_UP_TO_DATE) {
+                upToDate++;
+                String tag = versionStore.getStoredTag(record.getName());
+                msg = ChatColor.GREEN + record.getName() + (tag != null ? " " + tag : "") + " already up to date.";
+            } else if (result <= 0) {
+                failed++;
+                msg = ChatColor.RED + "Failed to download " + record.getName() + ".";
+            } else {
+                downloaded++;
+                String tag = versionStore.getStoredTag(record.getName());
+                String version = tag != null ? " " + tag : "";
+                msg = ChatColor.GREEN + "Downloaded " + record.getName() + version + " (" + (result / 1024) + " KB).";
+            }
+            Bukkit.getScheduler().runTask(plugin, () -> sender.sendMessage(msg));
+        }
+        final int fd = downloaded, fu = upToDate, fs = skipped, ff = failed;
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            StringBuilder summary = new StringBuilder();
+            summary.append(ChatColor.AQUA).append("Done: ")
+                   .append(ChatColor.GREEN).append(fd).append(" downloaded")
+                   .append(ChatColor.AQUA).append(", ").append(fu).append(" already up to date");
+            if (fs > 0) summary.append(ChatColor.AQUA).append(", ").append(fs).append(" skipped (no release)");
+            if (ff > 0) summary.append(ChatColor.RED).append(", ").append(ff).append(" failed");
+            summary.append(ChatColor.AQUA).append(".");
+            sender.sendMessage(summary.toString());
+            if (fd > 0) {
+                sender.sendMessage(ChatColor.YELLOW + "Restart the server to enable downloaded plugins.");
+            }
+        });
+    }
+
+    private void reportSingleResult(CommandSender sender, ProjectRecord record, int result) {
+        if (result == DownloadService.NO_RELEASE) {
+            sender.sendMessage(ChatColor.YELLOW + record.getName() + " has no published release yet. Try again later.");
+        } else if (result == DownloadService.ALREADY_UP_TO_DATE) {
+            String tag = versionStore.getStoredTag(record.getName());
+            String version = tag != null ? " (" + tag + ")" : "";
+            sender.sendMessage(ChatColor.GREEN + record.getName() + " is already up to date" + version + ".");
+        } else if (result <= 0) {
+            sender.sendMessage(ChatColor.RED + "Something went wrong downloading " + record.getName() + ".");
+        } else {
+            String tag = versionStore.getStoredTag(record.getName());
+            String version = tag != null ? " " + tag : "";
+            sender.sendMessage(ChatColor.GREEN + "Downloaded" + version + " (" + (result / 1024) + " KB). Restart the server to enable " + record.getName() + ".");
+        }
     }
 
     private void warnMissingDependencies(CommandSender sender, ProjectRecord record) {
@@ -45,36 +140,5 @@ public class GetCommand extends AbstractPluginCommand {
                         + " requires " + dep + ", which is not installed. Run /dpm get " + dep + " first.");
             }
         }
-    }
-
-    @Override
-    public boolean execute(CommandSender commandSender, String[] args) {
-        String name = args[0];
-        ProjectRecord projectRecord = ephemeralData.getProjectRecord(name);
-        if (projectRecord == null) {
-            commandSender.sendMessage(ChatColor.RED + "Plugin not found: " + name);
-            return false;
-        }
-        warnMissingDependencies(commandSender, projectRecord);
-        commandSender.sendMessage(ChatColor.AQUA + "Fetching " + projectRecord.getName() + "...");
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            int result = downloadService.downloadLatest(projectRecord);
-            Bukkit.getScheduler().runTask(plugin, () -> {
-                if (result == DownloadService.NO_RELEASE) {
-                    commandSender.sendMessage(ChatColor.YELLOW + projectRecord.getName() + " has no published release yet. Try again later.");
-                } else if (result == DownloadService.ALREADY_UP_TO_DATE) {
-                    String tag = versionStore.getStoredTag(projectRecord.getName());
-                    String version = tag != null ? " (" + tag + ")" : "";
-                    commandSender.sendMessage(ChatColor.GREEN + projectRecord.getName() + " is already up to date" + version + ".");
-                } else if (result <= 0) {
-                    commandSender.sendMessage(ChatColor.RED + "Something went wrong downloading " + projectRecord.getName() + ".");
-                } else {
-                    String tag = versionStore.getStoredTag(projectRecord.getName());
-                    String version = tag != null ? " " + tag : "";
-                    commandSender.sendMessage(ChatColor.GREEN + "Downloaded" + version + " (" + (result / 1024) + " KB). Restart the server to enable " + projectRecord.getName() + ".");
-                }
-            });
-        });
-        return true;
     }
 }

--- a/src/main/java/dansplugins/dpm/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/HelpCommand.java
@@ -20,8 +20,8 @@ public class HelpCommand extends AbstractPluginCommand {
     public boolean execute(CommandSender commandSender) {
         commandSender.sendMessage(ChatColor.AQUA + "=== DPM Commands ===");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm help - View this list of commands.");
-        commandSender.sendMessage(ChatColor.AQUA + "/dpm list - List plugins with install status.");
-        commandSender.sendMessage(ChatColor.AQUA + "/dpm get <plugin-name> - Download a plugin.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm list [installed|available] - List plugins, optionally filtered.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm get <plugin-name> [plugin-name ...] - Download one or more plugins.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm clean [--confirm] - Preview or remove duplicate plugin JARs.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm stats - View plugin statistics.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm update - Update all installed plugins.");

--- a/src/main/java/dansplugins/dpm/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/HelpCommand.java
@@ -25,7 +25,7 @@ public class HelpCommand extends AbstractPluginCommand {
         commandSender.sendMessage(ChatColor.AQUA + "/dpm clean [--confirm] - Preview or remove duplicate plugin JARs.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm stats - View plugin statistics.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm update - Update all installed plugins.");
-        commandSender.sendMessage(ChatColor.AQUA + "/dpm info <plugin-name> - Show release and install info for a plugin.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm info <plugin-name> - Show description, release info, install status, and dependencies for a plugin.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm reload - Reload the DPM config.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm remove <plugin-name> [--confirm] - Preview or remove an installed plugin.");
         return true;

--- a/src/main/java/dansplugins/dpm/commands/ListCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/ListCommand.java
@@ -9,7 +9,9 @@ import org.bukkit.command.CommandSender;
 import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class ListCommand extends AbstractPluginCommand {
     private final EphemeralData ephemeralData;
@@ -43,6 +45,42 @@ public class ListCommand extends AbstractPluginCommand {
 
     @Override
     public boolean execute(CommandSender sender, String[] args) {
-        return execute(sender);
+        String filter = args[0];
+        if (filter.equalsIgnoreCase("installed")) {
+            return executeInstalled(sender);
+        }
+        if (filter.equalsIgnoreCase("available")) {
+            return executeAvailable(sender);
+        }
+        sender.sendMessage(ChatColor.RED + "Unknown filter: " + filter + ". Use 'installed' or 'available'.");
+        return false;
+    }
+
+    private boolean executeInstalled(CommandSender sender) {
+        List<ProjectRecord> installed = pluginFolderService.filterInstalled(ephemeralData.getAllProjectRecords());
+        sender.sendMessage(ChatColor.AQUA + "=== Installed Plugins (" + installed.size() + ") ===");
+        for (ProjectRecord record : installed) {
+            String tag = versionStore.getStoredTag(record.getName());
+            String version = tag != null ? " " + tag : "";
+            sender.sendMessage(ChatColor.GREEN + record.getName() + version);
+        }
+        return true;
+    }
+
+    private boolean executeAvailable(CommandSender sender) {
+        List<ProjectRecord> all = ephemeralData.getAllProjectRecords();
+        Set<String> installedNames = new HashSet<>();
+        for (ProjectRecord r : pluginFolderService.filterInstalled(all)) {
+            installedNames.add(r.getName());
+        }
+        List<ProjectRecord> available = new ArrayList<>();
+        for (ProjectRecord r : all) {
+            if (!installedNames.contains(r.getName())) available.add(r);
+        }
+        sender.sendMessage(ChatColor.AQUA + "=== Available Plugins (" + available.size() + ") ===");
+        for (ProjectRecord record : available) {
+            sender.sendMessage(ChatColor.GRAY + record.getName());
+        }
+        return true;
     }
 }


### PR DESCRIPTION
Closes #30, Closes #31

## Summary

**Batch get (#30)**
- `/dpm get plugin1 plugin2 ...` downloads all named plugins sequentially in one async task
- Per-plugin result lines printed as each completes; summary line at the end (N downloaded, N already up to date, N skipped, N failed)
- Single-name form is unchanged
- Tab-completion offers plugin names at every argument position

**List filters (#31)**
- `/dpm list installed` — only plugins whose JAR is present in plugins/
- `/dpm list available` — only plugins not yet installed
- `/dpm list` (no arg) — unchanged
- Both filters use `filterInstalled()` for a single directory scan
- Tab-completion offers `installed` and `available` at the second argument

## Test plan
- [ ] `/dpm get medievalfactions currencies`: both download, summary shown at end
- [ ] `/dpm get medievalfactions badname`: badname skipped, medievalfactions downloads
- [ ] `/dpm get medievalfactions` (single): existing behaviour, no summary line
- [ ] `/dpm list`: full 28-entry list unchanged
- [ ] `/dpm list installed`: only green installed entries shown
- [ ] `/dpm list available`: only grey uninstalled entries shown
- [ ] Tab-complete `/dpm get medievalfactions `: still offers plugin names
- [ ] Tab-complete `/dpm list `: offers installed, available
- [ ] All existing tests pass

Generated with Claude Code

---

_drafted by Claude on behalf of Daniel Stephenson_