### PR TITLE
Fix UpdateCommand O(N×M) scan and enrich /dpm stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- `/dpm stats` now shows installed plugin count alongside the total registered count
 - `/dpm reload` — reloads `config.yml` and re-applies live settings (e.g. `githubToken`) without a server restart
 - `/dpm remove <plugin-name> [--confirm]` — previews the JAR to be deleted; pass `--confirm` to actually remove it and clear the stored version tag
 - Tab-completion for `/dpm remove` offers installed plugin names at the first argument and `--confirm` at the second
@@ -22,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Tab-completion for `/dpm list` offers `installed` and `available`
 
 ### Changed
+- `UpdateCommand` replaced O(N×M) per-record `isInstalled()` loop with a single `filterInstalled()` call
 - `/dpm clean` now previews what would be deleted; pass `--confirm` to actually remove the files
 - `/dpm clean --confirm` now distinguishes deletion failures (permission errors) from "no duplicates found"
 

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -180,7 +180,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
                 new HelpCommand(),
                 new GetCommand(ephemeralData, downloadService, pluginFolderService, versionStore, this),
                 new ListCommand(ephemeralData, pluginFolderService, versionStore),
-                new StatsCommand(ephemeralData),
+                new StatsCommand(ephemeralData, pluginFolderService),
                 new CleanCommand(ephemeralData, pluginFolderService, this),
                 new UpdateCommand(ephemeralData, downloadService, pluginFolderService, versionStore, this),
                 new InfoCommand(ephemeralData, gitHubReleaseService, pluginFolderService, versionStore, this),

--- a/src/main/java/dansplugins/dpm/commands/StatsCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/StatsCommand.java
@@ -1,6 +1,7 @@
 package dansplugins.dpm.commands;
 
 import dansplugins.dpm.data.EphemeralData;
+import dansplugins.dpm.services.PluginFolderService;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
@@ -13,16 +14,20 @@ import java.util.List;
  */
 public class StatsCommand extends AbstractPluginCommand {
     private final EphemeralData ephemeralData;
+    private final PluginFolderService pluginFolderService;
 
-    public StatsCommand(EphemeralData ephemeralData) {
+    public StatsCommand(EphemeralData ephemeralData, PluginFolderService pluginFolderService) {
         super(new ArrayList<>(List.of("stats")), new ArrayList<>(List.of("dpm.stats")));
         this.ephemeralData = ephemeralData;
+        this.pluginFolderService = pluginFolderService;
     }
 
     @Override
     public boolean execute(CommandSender commandSender) {
+        int installed = pluginFolderService.filterInstalled(ephemeralData.getAllProjectRecords()).size();
         commandSender.sendMessage(ChatColor.AQUA + "=== DPM Stats ===");
         commandSender.sendMessage(ChatColor.AQUA + "Registered plugins: " + ephemeralData.getNumProjectRecords());
+        commandSender.sendMessage(ChatColor.AQUA + "Installed plugins: " + installed);
         return true;
     }
 

--- a/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
@@ -50,13 +50,7 @@ public class UpdateCommand extends AbstractPluginCommand {
     }
 
     private List<ProjectRecord> getInstalledPlugins() {
-        List<ProjectRecord> installed = new ArrayList<>();
-        for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
-            if (pluginFolderService.isInstalled(record)) {
-                installed.add(record);
-            }
-        }
-        return installed;
+        return pluginFolderService.filterInstalled(ephemeralData.getAllProjectRecords());
     }
 
     private void runUpdates(CommandSender sender, List<ProjectRecord> records) {

--- a/src/test/java/dansplugins/dpm/services/PluginFolderServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/PluginFolderServiceTest.java
@@ -211,6 +211,70 @@ class PluginFolderServiceTest {
     }
 
     // -------------------------------------------------------------------------
+    // filterInstalled()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void filterInstalled_returnsOnlyInstalledRecords(@TempDir Path tempDir) throws IOException {
+        createFile(tempDir, "medievalfactions.jar");
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        List<ProjectRecord> records = List.of(
+                ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions"),
+                ProjectRecord.forGitHub("currencies", "Dans-Plugins", "Currencies")
+        );
+        List<ProjectRecord> result = svc.filterInstalled(records);
+        assertEquals(1, result.size());
+        assertEquals("medievalfactions", result.get(0).getName());
+    }
+
+    @Test
+    void filterInstalled_returnsAllWhenAllInstalled(@TempDir Path tempDir) throws IOException {
+        createFile(tempDir, "medievalfactions.jar");
+        createFile(tempDir, "currencies.jar");
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        List<ProjectRecord> records = List.of(
+                ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions"),
+                ProjectRecord.forGitHub("currencies", "Dans-Plugins", "Currencies")
+        );
+        assertEquals(2, svc.filterInstalled(records).size());
+    }
+
+    @Test
+    void filterInstalled_returnsEmptyWhenNoneInstalled(@TempDir Path tempDir) {
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        List<ProjectRecord> records = List.of(
+                ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions")
+        );
+        assertTrue(svc.filterInstalled(records).isEmpty());
+    }
+
+    @Test
+    void filterInstalled_returnsEmptyForEmptyInput(@TempDir Path tempDir) throws IOException {
+        createFile(tempDir, "medievalfactions.jar");
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        assertTrue(svc.filterInstalled(List.of()).isEmpty());
+    }
+
+    @Test
+    void filterInstalled_isCaseInsensitive(@TempDir Path tempDir) throws IOException {
+        createFile(tempDir, "MedievalFactions.jar");
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        List<ProjectRecord> records = List.of(
+                ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions")
+        );
+        assertEquals(1, svc.filterInstalled(records).size());
+    }
+
+    @Test
+    void filterInstalled_nonExistentFolderReturnsEmpty() {
+        PluginFolderService svc = new PluginFolderService("/this/path/does/not/exist");
+        List<ProjectRecord> records = List.of(
+                ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions")
+        );
+        assertTrue(svc.filterInstalled(records).isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
     // getInstalledFile()
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **#37** — `UpdateCommand.getInstalledPlugins()` replaced O(N×M) per-record `isInstalled()` loop with a single `filterInstalled()` call (one directory scan for the whole batch, matching the fix already applied to `RemoveCommand`)
- **#38** — `/dpm stats` now injects `PluginFolderService` and emits an "Installed plugins: N" line alongside the existing registered count

## Tests

- Added 6 tests for `PluginFolderService.filterInstalled()` which had no coverage: happy path, all installed, none installed, empty input, case-insensitive match, non-existent folder

## Test plan
- [ ] `mvn test` passes
- [ ] `/dpm stats` in-game shows both registered and installed counts
- [ ] `/dpm update` with multiple managed plugins installed produces correct results (single scan)

Closes #37, #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_