### PR TITLE
Add /dpm update per-plugin progress and GitHub release cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - `UpdateCommand` replaced O(N×M) per-record `isInstalled()` loop with a single `filterInstalled()` call
+- `/dpm update` now emits a per-plugin result line for every outcome including already-up-to-date and no-release, consistent with `/dpm get` batch mode
+- `GitHubReleaseService` caches release responses for the session; repeated calls for the same repo make only one HTTP request. `/dpm reload` clears the cache
 - `/dpm clean` now previews what would be deleted; pass `--confirm` to actually remove the files
 - `/dpm clean --confirm` now distinguishes deletion failures (permission errors) from "no duplicates found"
 

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -150,6 +150,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     public void reloadDpm() {
         reloadConfig();
         gitHubReleaseService.setApiToken(configService.getStringOrDefault("githubToken", ""));
+        gitHubReleaseService.clearCache();
     }
 
     private void initializeConfig() {

--- a/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
@@ -61,21 +61,24 @@ public class UpdateCommand extends AbstractPluginCommand {
 
         for (ProjectRecord record : records) {
             int result = downloadService.downloadLatest(record);
+            final String msg;
             if (result == DownloadService.ALREADY_UP_TO_DATE) {
                 upToDate++;
+                String tag = versionStore.getStoredTag(record.getName());
+                msg = ChatColor.GREEN + record.getName() + (tag != null ? " " + tag : "") + " already up to date.";
             } else if (result == DownloadService.NO_RELEASE) {
                 skipped++;
+                msg = ChatColor.YELLOW + record.getName() + " has no published release yet.";
             } else if (result > 0) {
                 updated++;
                 String tag = versionStore.getStoredTag(record.getName());
                 String version = tag != null ? " " + tag : "";
-                final String msg = ChatColor.GREEN + "Updated " + record.getName() + version + ".";
-                Bukkit.getScheduler().runTask(plugin, () -> sender.sendMessage(msg));
+                msg = ChatColor.GREEN + "Updated " + record.getName() + version + ".";
             } else {
                 failed++;
-                final String msg = ChatColor.RED + "Failed to update " + record.getName() + ".";
-                Bukkit.getScheduler().runTask(plugin, () -> sender.sendMessage(msg));
+                msg = ChatColor.RED + "Failed to update " + record.getName() + ".";
             }
+            Bukkit.getScheduler().runTask(plugin, () -> sender.sendMessage(msg));
         }
 
         final int finalUpdated = updated;

--- a/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
+++ b/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
@@ -10,12 +10,15 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
 public class GitHubReleaseService {
     private static final String API_URL = "https://api.github.com/repos/%s/%s/releases/latest";
 
     private final Logger logger;
     private String apiToken = "";
+    private final Map<String, ReleaseInfo> releaseCache = new HashMap<>();
 
     public GitHubReleaseService(Logger logger) {
         this.logger = logger;
@@ -25,6 +28,10 @@ public class GitHubReleaseService {
         this.apiToken = token != null ? token : "";
     }
 
+    public void clearCache() {
+        releaseCache.clear();
+    }
+
     String getApiToken() {
         return apiToken;
     }
@@ -32,38 +39,17 @@ public class GitHubReleaseService {
     /**
      * Returns a {@link ReleaseInfo} with the tag name and first .jar asset URL for the
      * latest release. Returns {@link ReleaseInfo#NO_RELEASE} when GitHub reports 404
-     * (no releases published yet). Returns null on network or other errors.
+     * (no releases published yet). Returns null when no .jar asset exists or on network errors.
+     * Results are cached for the session; call {@link #clearCache()} to force a fresh fetch.
      */
     public ReleaseInfo getLatestRelease(String owner, String repo) {
-        String apiUrl = String.format(API_URL, owner, repo);
-        HttpURLConnection connection = null;
-        try {
-            connection = openConnection(apiUrl);
-            int responseCode = connection.getResponseCode();
-            if (responseCode == 404) {
-                return ReleaseInfo.NO_RELEASE;
-            }
-            if (responseCode != 200) {
-                String errorBody = readStream(connection.getErrorStream());
-                logger.log("GitHub API returned HTTP " + responseCode + " for " + owner + "/" + repo + ": " + errorBody);
-                return null;
-            }
-            String json = readStream(connection.getInputStream());
-            String tagName = parseTagName(json);
-            String jarUrl = parseJarUrlFromAssets(json);
-            if (jarUrl == null) {
-                logger.log("Release " + tagName + " for " + owner + "/" + repo + " has no .jar asset.");
-                return null;
-            }
-            return new ReleaseInfo(tagName, jarUrl);
-        } catch (IOException e) {
-            logger.log("Failed to reach GitHub API for " + owner + "/" + repo + ": " + e.getMessage());
+        ReleaseInfo release = fetchRelease(owner, repo);
+        if (release == null || release == ReleaseInfo.NO_RELEASE) return release;
+        if (release.getJarUrl() == null) {
+            logger.log("Release " + release.getTagName() + " for " + owner + "/" + repo + " has no .jar asset.");
             return null;
-        } finally {
-            if (connection != null) {
-                connection.disconnect();
-            }
         }
+        return release;
     }
 
     private HttpURLConnection openConnection(String apiUrl) throws IOException {
@@ -94,14 +80,29 @@ public class GitHubReleaseService {
      * Returns a {@link ReleaseInfo} with tag name and publish date for the latest release,
      * without requiring a downloadable .jar asset. Returns {@link ReleaseInfo#NO_RELEASE}
      * on 404, or null on network/other errors.
+     * Results are cached for the session; call {@link #clearCache()} to force a fresh fetch.
      */
     public ReleaseInfo getLatestReleaseMetadata(String owner, String repo) {
+        return fetchRelease(owner, repo);
+    }
+
+    /**
+     * Fetches and caches the full release info (tag, jar URL, publish date) for the given repo.
+     * On 404 caches and returns {@link ReleaseInfo#NO_RELEASE}. Network errors return null and
+     * are not cached so the next call can retry.
+     */
+    private ReleaseInfo fetchRelease(String owner, String repo) {
+        String key = owner + "/" + repo;
+        ReleaseInfo cached = releaseCache.get(key);
+        if (cached != null) return cached;
+
         String apiUrl = String.format(API_URL, owner, repo);
         HttpURLConnection connection = null;
         try {
             connection = openConnection(apiUrl);
             int responseCode = connection.getResponseCode();
             if (responseCode == 404) {
+                releaseCache.put(key, ReleaseInfo.NO_RELEASE);
                 return ReleaseInfo.NO_RELEASE;
             }
             if (responseCode != 200) {
@@ -110,9 +111,9 @@ public class GitHubReleaseService {
                 return null;
             }
             String json = readStream(connection.getInputStream());
-            String tagName = parseTagName(json);
-            String publishedAt = parsePublishedAt(json);
-            return new ReleaseInfo(tagName, null, publishedAt);
+            ReleaseInfo release = new ReleaseInfo(parseTagName(json), parseJarUrlFromAssets(json), parsePublishedAt(json));
+            releaseCache.put(key, release);
+            return release;
         } catch (IOException e) {
             logger.log("Failed to reach GitHub API for " + owner + "/" + repo + ": " + e.getMessage());
             return null;

--- a/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
+++ b/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
@@ -10,15 +10,16 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class GitHubReleaseService {
     private static final String API_URL = "https://api.github.com/repos/%s/%s/releases/latest";
 
     private final Logger logger;
     private String apiToken = "";
-    private final Map<String, ReleaseInfo> releaseCache = new HashMap<>();
+    private final ConcurrentHashMap<String, ReleaseInfo> releaseCache = new ConcurrentHashMap<>();
+    private final AtomicInteger cacheGeneration = new AtomicInteger(0);
 
     public GitHubReleaseService(Logger logger) {
         this.logger = logger;
@@ -29,6 +30,7 @@ public class GitHubReleaseService {
     }
 
     public void clearCache() {
+        cacheGeneration.incrementAndGet();
         releaseCache.clear();
     }
 
@@ -87,22 +89,35 @@ public class GitHubReleaseService {
     }
 
     /**
-     * Fetches and caches the full release info (tag, jar URL, publish date) for the given repo.
-     * On 404 caches and returns {@link ReleaseInfo#NO_RELEASE}. Network errors return null and
-     * are not cached so the next call can retry.
+     * Returns the cached entry or fetches it. Network errors (null) are never cached so
+     * the next call can retry. The generation counter prevents a fetch that started before
+     * a {@link #clearCache()} from repopulating the cache with pre-reload data.
      */
     private ReleaseInfo fetchRelease(String owner, String repo) {
         String key = owner + "/" + repo;
         ReleaseInfo cached = releaseCache.get(key);
         if (cached != null) return cached;
 
+        int generation = cacheGeneration.get();
+        ReleaseInfo fetched = doFetch(owner, repo);
+        if (fetched != null && cacheGeneration.get() == generation) {
+            releaseCache.putIfAbsent(key, fetched);
+        }
+        return fetched;
+    }
+
+    /**
+     * Makes the HTTP request and parses the response. Returns {@link ReleaseInfo#NO_RELEASE}
+     * on 404, null on network/other errors, and a fully-populated {@link ReleaseInfo} on success.
+     * Package-private so tests can override it via anonymous subclass.
+     */
+    ReleaseInfo doFetch(String owner, String repo) {
         String apiUrl = String.format(API_URL, owner, repo);
         HttpURLConnection connection = null;
         try {
             connection = openConnection(apiUrl);
             int responseCode = connection.getResponseCode();
             if (responseCode == 404) {
-                releaseCache.put(key, ReleaseInfo.NO_RELEASE);
                 return ReleaseInfo.NO_RELEASE;
             }
             if (responseCode != 200) {
@@ -111,9 +126,7 @@ public class GitHubReleaseService {
                 return null;
             }
             String json = readStream(connection.getInputStream());
-            ReleaseInfo release = new ReleaseInfo(parseTagName(json), parseJarUrlFromAssets(json), parsePublishedAt(json));
-            releaseCache.put(key, release);
-            return release;
+            return new ReleaseInfo(parseTagName(json), parseJarUrlFromAssets(json), parsePublishedAt(json));
         } catch (IOException e) {
             logger.log("Failed to reach GitHub API for " + owner + "/" + repo + ": " + e.getMessage());
             return null;

--- a/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
@@ -135,6 +135,23 @@ class GitHubReleaseServiceTest {
     }
 
     // -------------------------------------------------------------------------
+    // clearCache()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void clearCache_doesNotThrowWhenCacheIsEmpty() {
+        assertDoesNotThrow(() -> service.clearCache());
+    }
+
+    @Test
+    void clearCache_doesNotThrowWhenCalledRepeatedly() {
+        assertDoesNotThrow(() -> {
+            service.clearCache();
+            service.clearCache();
+        });
+    }
+
+    // -------------------------------------------------------------------------
     // setApiToken()
     // -------------------------------------------------------------------------
 

--- a/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
@@ -1,6 +1,9 @@
 package dansplugins.dpm.services;
 
+import dansplugins.dpm.objects.ReleaseInfo;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -135,20 +138,85 @@ class GitHubReleaseServiceTest {
     }
 
     // -------------------------------------------------------------------------
-    // clearCache()
+    // cache behaviour (via doFetch override)
     // -------------------------------------------------------------------------
 
     @Test
-    void clearCache_doesNotThrowWhenCacheIsEmpty() {
-        assertDoesNotThrow(() -> service.clearCache());
+    void getLatestRelease_returnsCachedResultOnSecondCall() {
+        AtomicInteger fetchCount = new AtomicInteger(0);
+        GitHubReleaseService svc = new GitHubReleaseService(null) {
+            @Override
+            ReleaseInfo doFetch(String owner, String repo) {
+                fetchCount.incrementAndGet();
+                return new ReleaseInfo("v1.0", "https://example.com/plugin.jar", "2024-01-01T00:00:00Z");
+            }
+        };
+        svc.getLatestRelease("org", "repo");
+        svc.getLatestRelease("org", "repo");
+        assertEquals(1, fetchCount.get(), "Second call for same repo should use cache");
     }
 
     @Test
-    void clearCache_doesNotThrowWhenCalledRepeatedly() {
-        assertDoesNotThrow(() -> {
-            service.clearCache();
-            service.clearCache();
-        });
+    void clearCache_causesRefetchOnNextCall() {
+        AtomicInteger fetchCount = new AtomicInteger(0);
+        GitHubReleaseService svc = new GitHubReleaseService(null) {
+            @Override
+            ReleaseInfo doFetch(String owner, String repo) {
+                fetchCount.incrementAndGet();
+                return new ReleaseInfo("v1.0", "https://example.com/plugin.jar", "2024-01-01T00:00:00Z");
+            }
+        };
+        svc.getLatestRelease("org", "repo");
+        svc.clearCache();
+        svc.getLatestRelease("org", "repo");
+        assertEquals(2, fetchCount.get(), "Call after clearCache should refetch");
+    }
+
+    @Test
+    void differentRepos_eachFetchedOnce() {
+        AtomicInteger fetchCount = new AtomicInteger(0);
+        GitHubReleaseService svc = new GitHubReleaseService(null) {
+            @Override
+            ReleaseInfo doFetch(String owner, String repo) {
+                fetchCount.incrementAndGet();
+                return new ReleaseInfo("v1.0", "https://example.com/" + repo + ".jar", null);
+            }
+        };
+        svc.getLatestRelease("org", "repo-a");
+        svc.getLatestRelease("org", "repo-a");
+        svc.getLatestRelease("org", "repo-b");
+        svc.getLatestRelease("org", "repo-b");
+        assertEquals(2, fetchCount.get(), "Each distinct repo should be fetched once");
+    }
+
+    @Test
+    void noRelease_isCached() {
+        AtomicInteger fetchCount = new AtomicInteger(0);
+        GitHubReleaseService svc = new GitHubReleaseService(null) {
+            @Override
+            ReleaseInfo doFetch(String owner, String repo) {
+                fetchCount.incrementAndGet();
+                return ReleaseInfo.NO_RELEASE;
+            }
+        };
+        svc.getLatestReleaseMetadata("org", "repo");
+        svc.getLatestReleaseMetadata("org", "repo");
+        assertEquals(1, fetchCount.get(), "NO_RELEASE should be cached to avoid repeated 404 requests");
+    }
+
+    @Test
+    void networkError_isNotCached() {
+        AtomicInteger fetchCount = new AtomicInteger(0);
+        GitHubReleaseService svc = new GitHubReleaseService(null) {
+            @Override
+            ReleaseInfo doFetch(String owner, String repo) {
+                fetchCount.incrementAndGet();
+                return null;
+            }
+        };
+        svc.getLatestReleaseMetadata("org", "repo");
+        svc.getLatestReleaseMetadata("org", "repo");
+        assertEquals(2, fetchCount.get(), "Network errors must not be cached so the next call can retry");
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#40** — `/dpm update` now emits a result line for every plugin checked, including already-up-to-date (`green`) and no-release (`yellow`) cases. Previously only updated and failed plugins produced output, leaving the console silent during long scans.
- **#39** — `GitHubReleaseService` caches release responses per session. Both `getLatestRelease()` and `getLatestReleaseMetadata()` now delegate to a shared private `fetchRelease()` method that checks the cache before making an HTTP request. `/dpm reload` clears the cache so fresh data is fetched after a config change.

## Tests

- Added 2 tests for `clearCache()` contract in `GitHubReleaseServiceTest`
- Note: HTTP-level deduplication (cache preventing a second network call for the same repo) requires a live network and is not unit-tested

## Test plan
- [ ] `mvn test` passes
- [ ] `/dpm update` with several installed plugins shows a line per plugin before the summary
- [ ] `/dpm info <plugin>` followed by `/dpm get <plugin>` makes only one GitHub API call (verify via rate limit counter or server logs)
- [ ] `/dpm reload` clears the cache (subsequent `/dpm info` fetches fresh data)

Closes #39, #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_