### PR TITLE
Add selective /dpm update [plugin-name ...]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- `/dpm update [plugin-name ...]` — when plugin names are provided, only those plugins are updated; tab-completion offers installed plugin names at every argument position
 - `/dpm stats` now shows installed plugin count alongside the total registered count
 - `/dpm reload` — reloads `config.yml` and re-applies live settings (e.g. `githubToken`) without a server restart
 - `/dpm remove <plugin-name> [--confirm]` — previews the JAR to be deleted; pass `--confirm` to actually remove it and clear the stored version tag

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -9,7 +9,7 @@ All commands use `/dpm` or `/danspluginmanager` as the base.
 | `/dpm get <plugin-name> [plugin-name ...]` | Download one or more DPC plugins to the server. | `dpm.get` |
 | `/dpm clean [--confirm]` | Preview duplicate plugin JARs, or delete them when `--confirm` is passed. | `dpm.clean` |
 | `/dpm stats` | View plugin statistics. | `dpm.stats` |
-| `/dpm update` | Update all installed managed plugins to their latest release. | `dpm.update` |
+| `/dpm update [plugin-name ...]` | Update all installed managed plugins to their latest release. Pass one or more names to update only those plugins. | `dpm.update` |
 | `/dpm info <plugin-name>` | Show description, GitHub owner, repo, latest release tag, publish date, install status, and dependency status for a plugin. | `dpm.info` |
 | `/dpm reload` | Reload `config.yml` and re-apply settings (e.g. `githubToken`). | `dpm.reload` |
 | `/dpm remove <plugin-name> [--confirm]` | Preview removal of an installed plugin, or delete it when `--confirm` is passed. | `dpm.remove` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -15,7 +15,7 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 1. Run `/dpm list` to see all DPC plugins. Green entries are installed (with version tag when known); grey entries are not yet installed. Pass `installed` or `available` to filter the list.
 2. Run `/dpm info <plugin-name>` to see a plugin's description, GitHub owner, repository, latest release tag, publish date, install status, and any required or optional dependencies.
 3. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). Multiple names are accepted: `/dpm get plugin1 plugin2`. If a plugin is already on the latest version, the download is skipped. If required dependencies are not installed, a warning is shown before the download begins.
-4. Run `/dpm update` to check every installed managed plugin against its latest GitHub release and download any that are out of date.
+4. Run `/dpm update` to check every installed managed plugin against its latest GitHub release and download any that are out of date. Pass one or more plugin names to update only those: `/dpm update medievalfactions`.  
 5. Restart the server to activate downloaded or updated plugins.
 6. Run `/dpm clean` to preview duplicate plugin JARs (e.g. versioned copies left over from manual installs). Add `--confirm` to delete them.
 7. Run `/dpm remove <plugin-name>` to preview which JAR would be deleted. Add `--confirm` to remove it and clear its stored version tag.
@@ -29,7 +29,7 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 | `dpm.stats` | `true` | View plugin statistics. |
 | `dpm.get` | `op` | Download one or more plugins to the server. |
 | `dpm.clean` | `op` | Preview or remove duplicate plugin JARs. |
-| `dpm.update` | `op` | Update all installed managed plugins. |
+| `dpm.update` | `op` | Update all installed managed plugins, or specific ones by name. |
 | `dpm.info` | `true` | View description, release info, install status, and dependencies for a plugin. |
 | `dpm.reload` | `op` | Reload the DPM config. |
 | `dpm.remove` | `op` | Preview or remove an installed managed plugin. |

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -44,6 +44,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     private VersionStore versionStore;
     private DownloadService downloadService;
     private RemoveCommand removeCommand;
+    private UpdateCommand updateCommand;
 
     /**
      * This runs when the server starts.
@@ -98,6 +99,9 @@ public final class DansPluginManager extends PonderBukkitPlugin {
         }
         if (args.length == 2 && args[0].equalsIgnoreCase("remove")) {
             return TabCompleter.filterByPrefix(removeCommand.getInstalledPluginNames(), args[1]);
+        }
+        if (args.length >= 2 && args[0].equalsIgnoreCase("update")) {
+            return TabCompleter.filterByPrefix(updateCommand.getInstalledPluginNames(), args[args.length - 1]);
         }
         if (args.length == 2 && args[0].equalsIgnoreCase("clean")) {
             return TabCompleter.filterByPrefix(CONFIRM_COMPLETION, args[1]);
@@ -183,7 +187,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
                 new ListCommand(ephemeralData, pluginFolderService, versionStore),
                 new StatsCommand(ephemeralData, pluginFolderService),
                 new CleanCommand(ephemeralData, pluginFolderService, this),
-                new UpdateCommand(ephemeralData, downloadService, pluginFolderService, versionStore, this),
+                updateCommand = new UpdateCommand(ephemeralData, downloadService, pluginFolderService, versionStore, this),
                 new InfoCommand(ephemeralData, gitHubReleaseService, pluginFolderService, versionStore, this),
                 new ReloadCommand(this),
                 removeCommand = new RemoveCommand(ephemeralData, pluginFolderService, versionStore)

--- a/src/main/java/dansplugins/dpm/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/HelpCommand.java
@@ -24,7 +24,7 @@ public class HelpCommand extends AbstractPluginCommand {
         commandSender.sendMessage(ChatColor.AQUA + "/dpm get <plugin-name> [plugin-name ...] - Download one or more plugins.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm clean [--confirm] - Preview or remove duplicate plugin JARs.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm stats - View plugin statistics.");
-        commandSender.sendMessage(ChatColor.AQUA + "/dpm update - Update all installed plugins.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm update [plugin-name ...] - Update all installed plugins, or specific ones.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm info <plugin-name> - Show description, release info, install status, and dependencies for a plugin.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm reload - Reload the DPM config.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm remove <plugin-name> [--confirm] - Preview or remove an installed plugin.");

--- a/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
@@ -13,6 +13,7 @@ import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class UpdateCommand extends AbstractPluginCommand {
     private final EphemeralData ephemeralData;
@@ -46,7 +47,33 @@ public class UpdateCommand extends AbstractPluginCommand {
 
     @Override
     public boolean execute(CommandSender sender, String[] args) {
-        return execute(sender);
+        if (args.length == 0) return execute(sender);
+        return executeSelective(sender, args);
+    }
+
+    private boolean executeSelective(CommandSender sender, String[] names) {
+        List<ProjectRecord> toUpdate = new ArrayList<>();
+        for (String name : names) {
+            ProjectRecord record = ephemeralData.getProjectRecord(name);
+            if (record == null) {
+                sender.sendMessage(ChatColor.RED + "Plugin not found: " + name);
+                continue;
+            }
+            if (!pluginFolderService.isInstalled(record)) {
+                sender.sendMessage(ChatColor.YELLOW + record.getName() + " is not installed — use /dpm get " + record.getName() + " first.");
+                continue;
+            }
+            toUpdate.add(record);
+        }
+        if (toUpdate.isEmpty()) return false;
+        sender.sendMessage(ChatColor.AQUA + "Checking " + toUpdate.size() + " plugin(s) for updates...");
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> runUpdates(sender, toUpdate));
+        return true;
+    }
+
+    public List<String> getInstalledPluginNames() {
+        return pluginFolderService.filterInstalled(ephemeralData.getAllProjectRecords())
+                .stream().map(ProjectRecord::getName).collect(Collectors.toList());
     }
 
     private List<ProjectRecord> getInstalledPlugins() {


### PR DESCRIPTION
## Summary
- `/dpm update plugin1 plugin2` now updates only the named plugins instead of all installed plugins
- Warns and skips plugins that are not registered or not installed
- Tab-completion offers installed plugin names at every argument position (matches `/dpm get` behaviour)
- No-arg form (`/dpm update`) is unchanged

Closes #41

## Test plan
- [ ] `/dpm update` (no args) still updates all installed plugins
- [ ] `/dpm update <installed-plugin>` updates only that plugin
- [ ] `/dpm update <plugin1> <plugin2>` updates both
- [ ] Unregistered name prints "Plugin not found" and skips
- [ ] Registered but not-installed name prints "not installed" message and skips
- [ ] Tab-complete after `/dpm update ` offers installed plugin names
- [ ] Tab-complete at second and third positions still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_