### PR TITLE
Add /dpm search <keyword>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - `/dpm update [plugin-name ...]` — when plugin names are provided, only those plugins are updated; tab-completion offers installed plugin names at every argument position
+- `/dpm search <keyword>` — searches registered plugin names and descriptions (case-insensitive substring match); results are colour-coded by install status
 - `/dpm stats` now shows installed plugin count alongside the total registered count
 - `/dpm reload` — reloads `config.yml` and re-applies live settings (e.g. `githubToken`) without a server restart
 - `/dpm remove <plugin-name> [--confirm]` — previews the JAR to be deleted; pass `--confirm` to actually remove it and clear the stored version tag

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -13,3 +13,4 @@ All commands use `/dpm` or `/danspluginmanager` as the base.
 | `/dpm info <plugin-name>` | Show description, GitHub owner, repo, latest release tag, publish date, install status, and dependency status for a plugin. | `dpm.info` |
 | `/dpm reload` | Reload `config.yml` and re-apply settings (e.g. `githubToken`). | `dpm.reload` |
 | `/dpm remove <plugin-name> [--confirm]` | Preview removal of an installed plugin, or delete it when `--confirm` is passed. | `dpm.remove` |
+| `/dpm search <keyword>` | Search registered plugins by name or description. Results show install status and version. | `dpm.search` |

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -13,4 +13,4 @@ All commands use `/dpm` or `/danspluginmanager` as the base.
 | `/dpm info <plugin-name>` | Show description, GitHub owner, repo, latest release tag, publish date, install status, and dependency status for a plugin. | `dpm.info` |
 | `/dpm reload` | Reload `config.yml` and re-apply settings (e.g. `githubToken`). | `dpm.reload` |
 | `/dpm remove <plugin-name> [--confirm]` | Preview removal of an installed plugin, or delete it when `--confirm` is passed. | `dpm.remove` |
-| `/dpm search <keyword>` | Search registered plugins by name or description. Results show install status and version. | `dpm.search` |
+| `/dpm search <keyword>` | Search registered plugins by name or description. Results show install status and version. | `dpm.list` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -34,7 +34,6 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 | `dpm.info` | `true` | View description, release info, install status, and dependencies for a plugin. |
 | `dpm.reload` | `op` | Reload the DPM config. |
 | `dpm.remove` | `op` | Preview or remove an installed managed plugin. |
-| `dpm.search` | `true` | Search plugins by name or description. |
 
 ## Configuration
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -17,8 +17,9 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 3. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). Multiple names are accepted: `/dpm get plugin1 plugin2`. If a plugin is already on the latest version, the download is skipped. If required dependencies are not installed, a warning is shown before the download begins.
 4. Run `/dpm update` to check every installed managed plugin against its latest GitHub release and download any that are out of date. Pass one or more plugin names to update only those: `/dpm update medievalfactions`.  
 5. Restart the server to activate downloaded or updated plugins.
-6. Run `/dpm clean` to preview duplicate plugin JARs (e.g. versioned copies left over from manual installs). Add `--confirm` to delete them.
-7. Run `/dpm remove <plugin-name>` to preview which JAR would be deleted. Add `--confirm` to remove it and clear its stored version tag.
+6. Run `/dpm search <keyword>` to find plugins by name or description (e.g. `/dpm search faction`). Green results are installed; grey are not.
+7. Run `/dpm clean` to preview duplicate plugin JARs (e.g. versioned copies left over from manual installs). Add `--confirm` to delete them.
+8. Run `/dpm remove <plugin-name>` to preview which JAR would be deleted. Add `--confirm` to remove it and clear its stored version tag.
 
 ## Permissions
 
@@ -33,6 +34,7 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 | `dpm.info` | `true` | View description, release info, install status, and dependencies for a plugin. |
 | `dpm.reload` | `op` | Reload the DPM config. |
 | `dpm.remove` | `op` | Preview or remove an installed managed plugin. |
+| `dpm.search` | `true` | Search plugins by name or description. |
 
 ## Configuration
 

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -78,7 +78,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     @Override
     public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, String[] args) {
         if (args.length == 1) {
-            return TabCompleter.filterByPrefix(Arrays.asList("help", "list", "get", "clean", "stats", "update", "info", "reload", "remove"), args[0]);
+            return TabCompleter.filterByPrefix(Arrays.asList("help", "list", "get", "clean", "stats", "update", "info", "reload", "remove", "search"), args[0]);
         }
         if (args.length >= 2 && args[0].equalsIgnoreCase("get")) {
             List<String> names = new ArrayList<>();
@@ -190,7 +190,8 @@ public final class DansPluginManager extends PonderBukkitPlugin {
                 updateCommand = new UpdateCommand(ephemeralData, downloadService, pluginFolderService, versionStore, this),
                 new InfoCommand(ephemeralData, gitHubReleaseService, pluginFolderService, versionStore, this),
                 new ReloadCommand(this),
-                removeCommand = new RemoveCommand(ephemeralData, pluginFolderService, versionStore)
+                removeCommand = new RemoveCommand(ephemeralData, pluginFolderService, versionStore),
+                new SearchCommand(ephemeralData, pluginFolderService, versionStore)
         ));
         commandService.initialize(commands, "That command wasn't found.");
     }

--- a/src/main/java/dansplugins/dpm/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/HelpCommand.java
@@ -28,6 +28,7 @@ public class HelpCommand extends AbstractPluginCommand {
         commandSender.sendMessage(ChatColor.AQUA + "/dpm info <plugin-name> - Show description, release info, install status, and dependencies for a plugin.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm reload - Reload the DPM config.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm remove <plugin-name> [--confirm] - Preview or remove an installed plugin.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm search <keyword> - Search plugins by name or description.");
         return true;
     }
 

--- a/src/main/java/dansplugins/dpm/commands/SearchCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/SearchCommand.java
@@ -20,7 +20,7 @@ public class SearchCommand extends AbstractPluginCommand {
 
     public SearchCommand(EphemeralData ephemeralData, PluginFolderService pluginFolderService,
                          VersionStore versionStore) {
-        super(new ArrayList<>(List.of("search")), new ArrayList<>(List.of("dpm.search")));
+        super(new ArrayList<>(List.of("search")), new ArrayList<>(List.of("dpm.list")));
         this.ephemeralData = ephemeralData;
         this.pluginFolderService = pluginFolderService;
         this.versionStore = versionStore;

--- a/src/main/java/dansplugins/dpm/commands/SearchCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/SearchCommand.java
@@ -1,0 +1,70 @@
+package dansplugins.dpm.commands;
+
+import dansplugins.dpm.data.EphemeralData;
+import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.services.PluginFolderService;
+import dansplugins.dpm.services.VersionStore;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class SearchCommand extends AbstractPluginCommand {
+    private final EphemeralData ephemeralData;
+    private final PluginFolderService pluginFolderService;
+    private final VersionStore versionStore;
+
+    public SearchCommand(EphemeralData ephemeralData, PluginFolderService pluginFolderService,
+                         VersionStore versionStore) {
+        super(new ArrayList<>(List.of("search")), new ArrayList<>(List.of("dpm.search")));
+        this.ephemeralData = ephemeralData;
+        this.pluginFolderService = pluginFolderService;
+        this.versionStore = versionStore;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender) {
+        sender.sendMessage(ChatColor.RED + "Usage: /dpm search <keyword>");
+        return false;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        String keyword = String.join(" ", args);
+        List<ProjectRecord> matches = new ArrayList<>();
+        for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
+            if (matchesKeyword(record, keyword)) matches.add(record);
+        }
+        if (matches.isEmpty()) {
+            sender.sendMessage(ChatColor.YELLOW + "No plugins found matching \"" + keyword + "\".");
+            return true;
+        }
+        Set<String> installedNames = new HashSet<>();
+        for (ProjectRecord r : pluginFolderService.filterInstalled(matches)) {
+            installedNames.add(r.getName());
+        }
+        sender.sendMessage(ChatColor.AQUA + "=== Search Results (" + matches.size() + ") ===");
+        for (ProjectRecord record : matches) {
+            String desc = record.getDescription() != null ? ChatColor.GRAY + " — " + record.getDescription() : "";
+            if (installedNames.contains(record.getName())) {
+                String tag = versionStore.getStoredTag(record.getName());
+                String version = tag != null ? " " + tag : "";
+                sender.sendMessage(ChatColor.GREEN + record.getName() + version + desc);
+            } else {
+                sender.sendMessage(ChatColor.GRAY + record.getName() + desc);
+            }
+        }
+        return true;
+    }
+
+    static boolean matchesKeyword(ProjectRecord record, String keyword) {
+        String kw = keyword.toLowerCase();
+        if (record.getName().toLowerCase().contains(kw)) return true;
+        return record.getDescription() != null
+                && record.getDescription().toLowerCase().contains(kw);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -26,5 +26,3 @@ permissions:
     default: op
   dpm.remove:
     default: op
-  dpm.search:
-    default: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -26,3 +26,5 @@ permissions:
     default: op
   dpm.remove:
     default: op
+  dpm.search:
+    default: true

--- a/src/test/java/dansplugins/dpm/commands/SearchCommandTest.java
+++ b/src/test/java/dansplugins/dpm/commands/SearchCommandTest.java
@@ -1,0 +1,75 @@
+package dansplugins.dpm.commands;
+
+import dansplugins.dpm.objects.ProjectRecord;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SearchCommandTest {
+
+    // -------------------------------------------------------------------------
+    // matchesKeyword()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void matchesKeyword_matchesNameSubstring() {
+        ProjectRecord record = ProjectRecord.forGitHub("MedievalFactions", "Dans-Plugins", "MedievalFactions");
+        assertTrue(SearchCommand.matchesKeyword(record, "medieval"));
+    }
+
+    @Test
+    void matchesKeyword_matchesNameCaseInsensitive() {
+        ProjectRecord record = ProjectRecord.forGitHub("MedievalFactions", "Dans-Plugins", "MedievalFactions");
+        assertTrue(SearchCommand.matchesKeyword(record, "MEDIEVAL"));
+    }
+
+    @Test
+    void matchesKeyword_matchesDescriptionSubstring() {
+        ProjectRecord record = ProjectRecord.builder("MyPlugin", "org", "MyPlugin")
+                .description("A land claiming and faction system")
+                .build();
+        assertTrue(SearchCommand.matchesKeyword(record, "faction"));
+    }
+
+    @Test
+    void matchesKeyword_matchesDescriptionCaseInsensitive() {
+        ProjectRecord record = ProjectRecord.builder("MyPlugin", "org", "MyPlugin")
+                .description("A Land Claiming System")
+                .build();
+        assertTrue(SearchCommand.matchesKeyword(record, "land claiming"));
+    }
+
+    @Test
+    void matchesKeyword_returnsFalseWhenNoMatch() {
+        ProjectRecord record = ProjectRecord.builder("MyPlugin", "org", "MyPlugin")
+                .description("A land claiming system")
+                .build();
+        assertFalse(SearchCommand.matchesKeyword(record, "economy"));
+    }
+
+    @Test
+    void matchesKeyword_returnsFalseWhenDescriptionNullAndNameNoMatch() {
+        ProjectRecord record = ProjectRecord.forGitHub("MyPlugin", "org", "MyPlugin");
+        assertFalse(SearchCommand.matchesKeyword(record, "economy"));
+    }
+
+    @Test
+    void matchesKeyword_nullDescriptionDoesNotThrow() {
+        ProjectRecord record = ProjectRecord.forGitHub("MyPlugin", "org", "MyPlugin");
+        assertDoesNotThrow(() -> SearchCommand.matchesKeyword(record, "anything"));
+    }
+
+    @Test
+    void matchesKeyword_emptyKeywordMatchesAll() {
+        ProjectRecord record = ProjectRecord.forGitHub("AnyPlugin", "org", "AnyPlugin");
+        assertTrue(SearchCommand.matchesKeyword(record, ""));
+    }
+
+    @Test
+    void matchesKeyword_multiWordKeywordMatchesDescription() {
+        ProjectRecord record = ProjectRecord.builder("MyPlugin", "org", "MyPlugin")
+                .description("Custom spawn point management")
+                .build();
+        assertTrue(SearchCommand.matchesKeyword(record, "spawn point"));
+    }
+}


### PR DESCRIPTION
## Summary
- New `/dpm search <keyword>` command — case-insensitive substring match against plugin name and description
- Multi-word keywords work (`/dpm search land claiming`)
- Results colour-coded by install status (green = installed with version, grey = not installed)
- `dpm.search` permission added to `plugin.yml` with default `true` (read-only, safe for all players)
- `SearchCommand.matchesKeyword()` extracted as package-private static for unit testing
- 9 unit tests covering name match, description match, case-insensitivity, null description, empty keyword, multi-word keyword, no-match

Closes #43

## Test plan
- [ ] `/dpm search faction` returns Medieval Factions and any other faction-related plugins
- [ ] `/dpm search FACTION` returns same results (case-insensitive)
- [ ] `/dpm search land claiming` matches on multi-word description substring
- [ ] `/dpm search zzznomatch` prints "No plugins found matching..." message
- [ ] `/dpm search` (no keyword) prints usage error
- [ ] Installed plugins shown in green with version tag; uninstalled in grey
- [ ] `mvn test` passes (115 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_