### PR TITLE
Auto-install missing hard dependencies in /dpm get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- `/dpm get` now auto-downloads missing hard dependencies that are registered DPC plugins before downloading the requested plugin(s); transitive dependencies are resolved recursively and circular chains are handled safely. Dependencies that are not registered DPC plugins still produce a warning.
 - `/dpm update [plugin-name ...]` — when plugin names are provided, only those plugins are updated; tab-completion offers installed plugin names at every argument position
 - `/dpm search <keyword>` — searches registered plugin names and descriptions (case-insensitive substring match); results are colour-coded by install status
 - `/dpm stats` now shows installed plugin count alongside the total registered count

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - One-line descriptions added to all 28 registered plugins; shown by `/dpm info`
 - Dependency declarations on `ProjectRecord` — hard (`depend`) and soft (`softdepend`) DPC-to-DPC relationships sourced from each plugin's `plugin.yml`
 - `/dpm info` shows each dependency and whether it is currently installed
-- `/dpm get` warns when a required hard dependency is not yet installed (download still proceeds)
 - `/dpm get` accepts multiple plugin names: `/dpm get plugin1 plugin2 ...` downloads all named plugins sequentially with per-plugin result lines and a summary
 - `/dpm list installed` shows only plugins whose JAR is present in the plugins folder
 - `/dpm list available` shows only plugins that are not currently installed

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -14,7 +14,7 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 
 1. Run `/dpm list` to see all DPC plugins. Green entries are installed (with version tag when known); grey entries are not yet installed. Pass `installed` or `available` to filter the list.
 2. Run `/dpm info <plugin-name>` to see a plugin's description, GitHub owner, repository, latest release tag, publish date, install status, and any required or optional dependencies.
-3. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). Multiple names are accepted: `/dpm get plugin1 plugin2`. If a plugin is already on the latest version, the download is skipped. If required dependencies are not installed, a warning is shown before the download begins.
+3. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). Multiple names are accepted: `/dpm get plugin1 plugin2`. If a plugin is already on the latest version, the download is skipped. Missing hard dependencies that are registered DPC plugins are automatically included in the download; dependencies that are not registered DPC plugins produce a warning.
 4. Run `/dpm update` to check every installed managed plugin against its latest GitHub release and download any that are out of date. Pass one or more plugin names to update only those: `/dpm update medievalfactions`.  
 5. Restart the server to activate downloaded or updated plugins.
 6. Run `/dpm search <keyword>` to find plugins by name or description (e.g. `/dpm search faction`). Green results are installed; grey are not.

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -5,6 +5,7 @@ import dansplugins.dpm.data.EphemeralData;
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.factories.ProjectRecordFactory;
 import dansplugins.dpm.services.ConfigService;
+import dansplugins.dpm.services.DependencyResolutionService;
 import dansplugins.dpm.services.DownloadService;
 import dansplugins.dpm.services.GitHubReleaseService;
 import dansplugins.dpm.services.PluginFolderService;
@@ -41,6 +42,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     private final Logger logger = new Logger(this);
     private final GitHubReleaseService gitHubReleaseService = new GitHubReleaseService(logger);
     private final PluginFolderService pluginFolderService = new PluginFolderService();
+    private final DependencyResolutionService dependencyResolutionService = new DependencyResolutionService(ephemeralData, pluginFolderService);
     private VersionStore versionStore;
     private DownloadService downloadService;
     private RemoveCommand removeCommand;
@@ -183,7 +185,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     private void initializeCommandService() {
         ArrayList<AbstractPluginCommand> commands = new ArrayList<>(Arrays.asList(
                 new HelpCommand(),
-                new GetCommand(ephemeralData, downloadService, pluginFolderService, versionStore, this),
+                new GetCommand(ephemeralData, downloadService, dependencyResolutionService, versionStore, this),
                 new ListCommand(ephemeralData, pluginFolderService, versionStore),
                 new StatsCommand(ephemeralData, pluginFolderService),
                 new CleanCommand(ephemeralData, pluginFolderService, this),

--- a/src/main/java/dansplugins/dpm/commands/GetCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/GetCommand.java
@@ -2,8 +2,8 @@ package dansplugins.dpm.commands;
 
 import dansplugins.dpm.data.EphemeralData;
 import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.services.DependencyResolutionService;
 import dansplugins.dpm.services.DownloadService;
-import dansplugins.dpm.services.PluginFolderService;
 import dansplugins.dpm.services.VersionStore;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -12,24 +12,25 @@ import org.bukkit.plugin.Plugin;
 import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class GetCommand extends AbstractPluginCommand {
     private final EphemeralData ephemeralData;
     private final DownloadService downloadService;
-    private final PluginFolderService pluginFolderService;
+    private final DependencyResolutionService dependencyResolutionService;
     private final VersionStore versionStore;
     private final Plugin plugin;
 
     public GetCommand(EphemeralData ephemeralData, DownloadService downloadService,
-                      PluginFolderService pluginFolderService, VersionStore versionStore, Plugin plugin) {
+                      DependencyResolutionService dependencyResolutionService,
+                      VersionStore versionStore, Plugin plugin) {
         super(new ArrayList<>(List.of("get")), new ArrayList<>(List.of("dpm.get")));
         this.ephemeralData = ephemeralData;
         this.downloadService = downloadService;
-        this.pluginFolderService = pluginFolderService;
+        this.dependencyResolutionService = dependencyResolutionService;
         this.versionStore = versionStore;
         this.plugin = plugin;
     }
@@ -54,17 +55,37 @@ public class GetCommand extends AbstractPluginCommand {
             sender.sendMessage(ChatColor.RED + "Plugin not found: " + name);
             return false;
         }
-        warnMissingDependencies(sender, record, Collections.emptySet());
-        sender.sendMessage(ChatColor.AQUA + "Fetching " + record.getName() + "...");
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            int result = downloadService.downloadLatest(record);
-            Bukkit.getScheduler().runTask(plugin, () -> reportSingleResult(sender, record, result));
-        });
+
+        List<ProjectRecord> depsToFetch = new ArrayList<>();
+        List<String> unknownDeps = new ArrayList<>();
+        Set<String> resolved = new HashSet<>();
+        resolved.add(record.getName().toLowerCase());
+        dependencyResolutionService.resolve(List.of(record), resolved, depsToFetch, unknownDeps);
+
+        for (String dep : unknownDeps) {
+            sender.sendMessage(ChatColor.YELLOW + "Warning: " + record.getName()
+                    + " requires " + dep + ", which is not installed and is not a managed DPC plugin.");
+        }
+
+        if (depsToFetch.isEmpty()) {
+            sender.sendMessage(ChatColor.AQUA + "Fetching " + record.getName() + "...");
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+                int result = downloadService.downloadLatest(record);
+                Bukkit.getScheduler().runTask(plugin, () -> reportSingleResult(sender, record, result));
+            });
+        } else {
+            for (ProjectRecord dep : depsToFetch) {
+                sender.sendMessage(ChatColor.AQUA + "Info: Also downloading required dependency " + dep.getName() + ".");
+            }
+            List<ProjectRecord> allToFetch = new ArrayList<>(depsToFetch);
+            allToFetch.add(record);
+            sender.sendMessage(ChatColor.AQUA + "Fetching " + allToFetch.size() + " plugin(s)...");
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> runBatch(sender, allToFetch, 0));
+        }
         return true;
     }
 
     private boolean executeBatch(CommandSender sender, String[] args) {
-        // First pass: resolve all names so the full batch set is known before warnings fire.
         List<ProjectRecord> records = new ArrayList<>();
         int notFound = 0;
         for (String name : args) {
@@ -77,17 +98,28 @@ public class GetCommand extends AbstractPluginCommand {
             }
         }
 
-        // Warn about missing deps, suppressing warnings for deps already in this batch.
-        Set<String> batchNames = new HashSet<>();
-        for (ProjectRecord r : records) batchNames.add(r.getName());
-        for (ProjectRecord record : records) {
-            warnMissingDependencies(sender, record, batchNames);
+        Set<String> resolved = records.stream()
+                .map(r -> r.getName().toLowerCase())
+                .collect(Collectors.toCollection(HashSet::new));
+        List<ProjectRecord> depsToFetch = new ArrayList<>();
+        List<String> unknownDeps = new ArrayList<>();
+        dependencyResolutionService.resolve(records, resolved, depsToFetch, unknownDeps);
+
+        for (String dep : unknownDeps) {
+            sender.sendMessage(ChatColor.YELLOW + "Warning: required dependency '" + dep
+                    + "' is not installed and is not a managed DPC plugin.");
         }
 
-        if (records.isEmpty()) return false;
-        sender.sendMessage(ChatColor.AQUA + "Fetching " + records.size() + " plugin(s)...");
+        List<ProjectRecord> allToFetch = new ArrayList<>(depsToFetch);
+        for (ProjectRecord dep : depsToFetch) {
+            sender.sendMessage(ChatColor.AQUA + "Info: Also downloading required dependency " + dep.getName() + ".");
+        }
+        allToFetch.addAll(records);
+
+        if (allToFetch.isEmpty()) return false;
+        sender.sendMessage(ChatColor.AQUA + "Fetching " + allToFetch.size() + " plugin(s)...");
         final int fn = notFound;
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> runBatch(sender, records, fn));
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> runBatch(sender, allToFetch, fn));
         return true;
     }
 
@@ -144,17 +176,6 @@ public class GetCommand extends AbstractPluginCommand {
             String tag = versionStore.getStoredTag(record.getName());
             String version = tag != null ? " " + tag : "";
             sender.sendMessage(ChatColor.GREEN + "Downloaded" + version + " (" + (result / 1024) + " KB). Restart the server to enable " + record.getName() + ".");
-        }
-    }
-
-    private void warnMissingDependencies(CommandSender sender, ProjectRecord record, Set<String> batchNames) {
-        for (String dep : record.getHardDependencies()) {
-            if (batchNames.contains(dep)) continue;
-            ProjectRecord depRecord = ephemeralData.getProjectRecord(dep);
-            if (depRecord == null || !pluginFolderService.isInstalled(depRecord)) {
-                sender.sendMessage(ChatColor.YELLOW + "Warning: " + record.getName()
-                        + " requires " + dep + ", which is not installed. Run /dpm get " + dep + " first.");
-            }
         }
     }
 }

--- a/src/main/java/dansplugins/dpm/services/DependencyResolutionService.java
+++ b/src/main/java/dansplugins/dpm/services/DependencyResolutionService.java
@@ -4,7 +4,6 @@ import dansplugins.dpm.data.EphemeralData;
 import dansplugins.dpm.objects.ProjectRecord;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
@@ -19,17 +18,7 @@ public class DependencyResolutionService {
         this.pluginFolderService = pluginFolderService;
     }
 
-    /**
-     * Resolves all missing hard dependencies for the given records, recursively.
-     *
-     * Populates depsToFetch with DPC plugins that need to be downloaded, and unknownDeps
-     * with dependency names that are not registered DPC plugins (cannot be auto-downloaded).
-     *
-     * The resolved set must be pre-populated with the lowercase names of records already
-     * in the download batch — this prevents re-processing and handles circular chains.
-     *
-     * The directory is scanned once regardless of how many records are processed.
-     */
+    // resolved must be pre-seeded with lowercase names already in the batch; prevents circular re-processing
     public void resolve(List<ProjectRecord> toProcess, Set<String> resolved,
                         List<ProjectRecord> depsToFetch, List<String> unknownDeps) {
         Set<String> installedLower = pluginFolderService.filterInstalled(ephemeralData.getAllProjectRecords())

--- a/src/main/java/dansplugins/dpm/services/DependencyResolutionService.java
+++ b/src/main/java/dansplugins/dpm/services/DependencyResolutionService.java
@@ -1,0 +1,56 @@
+package dansplugins.dpm.services;
+
+import dansplugins.dpm.data.EphemeralData;
+import dansplugins.dpm.objects.ProjectRecord;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DependencyResolutionService {
+    private final EphemeralData ephemeralData;
+    private final PluginFolderService pluginFolderService;
+
+    public DependencyResolutionService(EphemeralData ephemeralData, PluginFolderService pluginFolderService) {
+        this.ephemeralData = ephemeralData;
+        this.pluginFolderService = pluginFolderService;
+    }
+
+    /**
+     * Resolves all missing hard dependencies for the given records, recursively.
+     *
+     * Populates depsToFetch with DPC plugins that need to be downloaded, and unknownDeps
+     * with dependency names that are not registered DPC plugins (cannot be auto-downloaded).
+     *
+     * The resolved set must be pre-populated with the lowercase names of records already
+     * in the download batch — this prevents re-processing and handles circular chains.
+     *
+     * The directory is scanned once regardless of how many records are processed.
+     */
+    public void resolve(List<ProjectRecord> toProcess, Set<String> resolved,
+                        List<ProjectRecord> depsToFetch, List<String> unknownDeps) {
+        Set<String> installedLower = pluginFolderService.filterInstalled(ephemeralData.getAllProjectRecords())
+                .stream().map(r -> r.getName().toLowerCase()).collect(Collectors.toSet());
+
+        Queue<ProjectRecord> queue = new ArrayDeque<>(toProcess);
+        while (!queue.isEmpty()) {
+            ProjectRecord record = queue.poll();
+            for (String dep : record.getHardDependencies()) {
+                String depLower = dep.toLowerCase();
+                if (resolved.contains(depLower)) continue;
+                resolved.add(depLower);
+                if (installedLower.contains(depLower)) continue;
+                ProjectRecord depRecord = ephemeralData.getProjectRecord(dep);
+                if (depRecord == null) {
+                    unknownDeps.add(dep);
+                } else {
+                    depsToFetch.add(depRecord);
+                    queue.add(depRecord);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/dansplugins/dpm/services/DependencyResolutionServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/DependencyResolutionServiceTest.java
@@ -1,0 +1,163 @@
+package dansplugins.dpm.services;
+
+import dansplugins.dpm.data.EphemeralData;
+import dansplugins.dpm.objects.ProjectRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DependencyResolutionServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    private EphemeralData ephemeralData;
+    private PluginFolderService pluginFolderService;
+    private DependencyResolutionService service;
+
+    @BeforeEach
+    void setUp() {
+        ephemeralData = new EphemeralData();
+        pluginFolderService = new PluginFolderService(tempDir.toString());
+        service = new DependencyResolutionService(ephemeralData, pluginFolderService);
+    }
+
+    private ProjectRecord registerRecord(String name, List<String> hardDeps) {
+        ProjectRecord record = ProjectRecord.builder(name, "owner", "repo")
+                .hardDependencies(hardDeps)
+                .build();
+        ephemeralData.addProjectRecord(record);
+        return record;
+    }
+
+    private void installJar(String name) throws IOException {
+        Files.createFile(tempDir.resolve(name + ".jar"));
+    }
+
+    // -------------------------------------------------------------------------
+    // resolve()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void resolve_returnsEmptyWhenNoDependencies() {
+        ProjectRecord a = registerRecord("pluginA", List.of());
+        List<ProjectRecord> depsToFetch = new ArrayList<>();
+        List<String> unknownDeps = new ArrayList<>();
+        Set<String> resolved = new HashSet<>();
+        resolved.add("plugina");
+
+        service.resolve(List.of(a), resolved, depsToFetch, unknownDeps);
+
+        assertTrue(depsToFetch.isEmpty());
+        assertTrue(unknownDeps.isEmpty());
+    }
+
+    @Test
+    void resolve_fetchesMissingKnownDependency() {
+        ProjectRecord dep = registerRecord("depPlugin", List.of());
+        ProjectRecord main = registerRecord("mainPlugin", List.of("depPlugin"));
+        List<ProjectRecord> depsToFetch = new ArrayList<>();
+        List<String> unknownDeps = new ArrayList<>();
+        Set<String> resolved = new HashSet<>();
+        resolved.add("mainplugin");
+
+        service.resolve(List.of(main), resolved, depsToFetch, unknownDeps);
+
+        assertEquals(1, depsToFetch.size());
+        assertEquals("depPlugin", depsToFetch.get(0).getName());
+        assertTrue(unknownDeps.isEmpty());
+    }
+
+    @Test
+    void resolve_addsToUnknownWhenDepNotInEphemeralData() {
+        ProjectRecord main = registerRecord("mainPlugin", List.of("externalPlugin"));
+        List<ProjectRecord> depsToFetch = new ArrayList<>();
+        List<String> unknownDeps = new ArrayList<>();
+        Set<String> resolved = new HashSet<>();
+        resolved.add("mainplugin");
+
+        service.resolve(List.of(main), resolved, depsToFetch, unknownDeps);
+
+        assertTrue(depsToFetch.isEmpty());
+        assertEquals(List.of("externalPlugin"), unknownDeps);
+    }
+
+    @Test
+    void resolve_skipsAlreadyInstalledDependency() throws IOException {
+        installJar("depPlugin");
+        ProjectRecord dep = registerRecord("depPlugin", List.of());
+        ProjectRecord main = registerRecord("mainPlugin", List.of("depPlugin"));
+        List<ProjectRecord> depsToFetch = new ArrayList<>();
+        List<String> unknownDeps = new ArrayList<>();
+        Set<String> resolved = new HashSet<>();
+        resolved.add("mainplugin");
+
+        service.resolve(List.of(main), resolved, depsToFetch, unknownDeps);
+
+        assertTrue(depsToFetch.isEmpty());
+        assertTrue(unknownDeps.isEmpty());
+    }
+
+    @Test
+    void resolve_skipsDepAlreadyInResolvedSet() {
+        ProjectRecord dep = registerRecord("depPlugin", List.of());
+        ProjectRecord main = registerRecord("mainPlugin", List.of("depPlugin"));
+        List<ProjectRecord> depsToFetch = new ArrayList<>();
+        List<String> unknownDeps = new ArrayList<>();
+        Set<String> resolved = new HashSet<>();
+        resolved.add("mainplugin");
+        resolved.add("depplugin"); // already in batch
+
+        service.resolve(List.of(main), resolved, depsToFetch, unknownDeps);
+
+        assertTrue(depsToFetch.isEmpty());
+        assertTrue(unknownDeps.isEmpty());
+    }
+
+    @Test
+    void resolve_resolvesTransitiveDependencies() {
+        ProjectRecord c = registerRecord("pluginC", List.of());
+        ProjectRecord b = registerRecord("pluginB", List.of("pluginC"));
+        ProjectRecord a = registerRecord("pluginA", List.of("pluginB"));
+        List<ProjectRecord> depsToFetch = new ArrayList<>();
+        List<String> unknownDeps = new ArrayList<>();
+        Set<String> resolved = new HashSet<>();
+        resolved.add("plugina");
+
+        service.resolve(List.of(a), resolved, depsToFetch, unknownDeps);
+
+        assertEquals(2, depsToFetch.size());
+        assertTrue(depsToFetch.stream().anyMatch(r -> r.getName().equals("pluginB")));
+        assertTrue(depsToFetch.stream().anyMatch(r -> r.getName().equals("pluginC")));
+        assertTrue(unknownDeps.isEmpty());
+    }
+
+    @Test
+    void resolve_handlesCircularDependenciesWithoutInfiniteLoop() {
+        // A depends on B, B depends on A
+        ProjectRecord a = registerRecord("pluginA", List.of("pluginB"));
+        ProjectRecord b = registerRecord("pluginB", List.of("pluginA"));
+        List<ProjectRecord> depsToFetch = new ArrayList<>();
+        List<String> unknownDeps = new ArrayList<>();
+        Set<String> resolved = new HashSet<>();
+        resolved.add("plugina");
+
+        // Should terminate and add pluginB exactly once (pluginA is already in resolved)
+        service.resolve(List.of(a), resolved, depsToFetch, unknownDeps);
+
+        assertEquals(1, depsToFetch.size());
+        assertEquals("pluginB", depsToFetch.get(0).getName());
+        assertTrue(unknownDeps.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts recursive dependency resolution into a new `DependencyResolutionService` that resolves transitive hard deps with a single directory scan and handles circular chains safely via a visited set
- `GetCommand` now uses the service: missing hard deps that are registered DPC plugins are automatically added to the download batch before the requested plugin(s); unknown (non-DPC) deps still produce a warning
- 7 new unit tests cover: no-deps, known missing dep, unknown dep, already-installed dep, dep already in batch, transitive deps, and circular deps

## Test plan
- [x] `mvn test` — 122 tests pass, 0 failures
- [x] `resolve_fetchesMissingKnownDependency` — dep is auto-fetched when missing
- [x] `resolve_addsToUnknownWhenDepNotInEphemeralData` — non-DPC dep goes to unknownDeps
- [x] `resolve_skipsAlreadyInstalledDependency` — installed dep is not re-downloaded
- [x] `resolve_resolvesTransitiveDependencies` — A→B→C all resolved
- [x] `resolve_handlesCircularDependenciesWithoutInfiniteLoop` — A→B→A terminates safely

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_