### PR TITLE
Fix O(N×M) isInstalled() loops in ListCommand/InfoCommand and DRY violation in onTabComplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Tab-completion for `/dpm list` offers `installed` and `available`
 
 ### Changed
+- `ListCommand` (show-all path) and `InfoCommand` (dependency display) replaced O(N×M) `isInstalled()` calls with a single `filterInstalled()` scan
+- `DansPluginManager.onTabComplete` — extracted `allPluginNames()` helper to remove duplicated plugin-name list building for `get` and `info` tab-completion branches
 - `UpdateCommand` replaced O(N×M) per-record `isInstalled()` loop with a single `filterInstalled()` call
 - `/dpm update` now emits a per-plugin result line for every outcome including already-up-to-date and no-release, consistent with `/dpm get` batch mode
 - `GitHubReleaseService` caches release responses for the session; repeated calls for the same repo make only one HTTP request. `/dpm reload` clears the cache

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -83,18 +83,10 @@ public final class DansPluginManager extends PonderBukkitPlugin {
             return TabCompleter.filterByPrefix(Arrays.asList("help", "list", "get", "clean", "stats", "update", "info", "reload", "remove", "search"), args[0]);
         }
         if (args.length >= 2 && args[0].equalsIgnoreCase("get")) {
-            List<String> names = new ArrayList<>();
-            for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
-                names.add(record.getName());
-            }
-            return TabCompleter.filterByPrefix(names, args[args.length - 1]);
+            return TabCompleter.filterByPrefix(allPluginNames(), args[args.length - 1]);
         }
         if (args.length == 2 && args[0].equalsIgnoreCase("info")) {
-            List<String> names = new ArrayList<>();
-            for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
-                names.add(record.getName());
-            }
-            return TabCompleter.filterByPrefix(names, args[1]);
+            return TabCompleter.filterByPrefix(allPluginNames(), args[1]);
         }
         if (args.length == 2 && args[0].equalsIgnoreCase("list")) {
             return TabCompleter.filterByPrefix(List.of("installed", "available"), args[1]);
@@ -112,6 +104,14 @@ public final class DansPluginManager extends PonderBukkitPlugin {
             return TabCompleter.filterByPrefix(CONFIRM_COMPLETION, args[2]);
         }
         return Collections.emptyList();
+    }
+
+    private List<String> allPluginNames() {
+        List<String> names = new ArrayList<>();
+        for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
+            names.add(record.getName());
+        }
+        return names;
     }
 
     @Override

--- a/src/main/java/dansplugins/dpm/commands/InfoCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/InfoCommand.java
@@ -13,7 +13,9 @@ import org.bukkit.plugin.Plugin;
 import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class InfoCommand extends AbstractPluginCommand {
     private final EphemeralData ephemeralData;
@@ -76,7 +78,8 @@ public class InfoCommand extends AbstractPluginCommand {
             }
         }
 
-        boolean installed = pluginFolderService.isInstalled(record);
+        Set<String> installedNames = installedNamesFor(record);
+        boolean installed = installedNames.contains(record.getName());
         String storedTag = versionStore.getStoredTag(record.getName());
 
         if (installed) {
@@ -93,16 +96,32 @@ public class InfoCommand extends AbstractPluginCommand {
             sender.sendMessage(ChatColor.WHITE + "Installed: " + ChatColor.GRAY + "No");
         }
 
-        showDependencies(sender, record.getHardDependencies(), "Requires");
-        showDependencies(sender, record.getSoftDependencies(), "Integrates with");
+        showDependencies(sender, record.getHardDependencies(), "Requires", installedNames);
+        showDependencies(sender, record.getSoftDependencies(), "Integrates with", installedNames);
     }
 
-    private void showDependencies(CommandSender sender, List<String> deps, String label) {
+    private Set<String> installedNamesFor(ProjectRecord record) {
+        List<ProjectRecord> toScan = new ArrayList<>();
+        toScan.add(record);
+        for (String dep : record.getHardDependencies()) {
+            ProjectRecord r = ephemeralData.getProjectRecord(dep);
+            if (r != null) toScan.add(r);
+        }
+        for (String dep : record.getSoftDependencies()) {
+            ProjectRecord r = ephemeralData.getProjectRecord(dep);
+            if (r != null) toScan.add(r);
+        }
+        Set<String> names = new HashSet<>();
+        for (ProjectRecord r : pluginFolderService.filterInstalled(toScan)) {
+            names.add(r.getName());
+        }
+        return names;
+    }
+
+    private void showDependencies(CommandSender sender, List<String> deps, String label, Set<String> installedNames) {
         if (deps.isEmpty()) return;
         for (String dep : deps) {
-            ProjectRecord depRecord = ephemeralData.getProjectRecord(dep);
-            boolean depInstalled = depRecord != null && pluginFolderService.isInstalled(depRecord);
-            String status = depInstalled
+            String status = installedNames.contains(dep)
                     ? ChatColor.GREEN + dep + " (installed)"
                     : ChatColor.RED + dep + " (not installed)";
             sender.sendMessage(ChatColor.WHITE + label + ": " + status);

--- a/src/main/java/dansplugins/dpm/commands/ListCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/ListCommand.java
@@ -29,10 +29,13 @@ public class ListCommand extends AbstractPluginCommand {
     @Override
     public boolean execute(CommandSender sender) {
         List<ProjectRecord> records = ephemeralData.getAllProjectRecords();
+        Set<String> installedNames = new HashSet<>();
+        for (ProjectRecord r : pluginFolderService.filterInstalled(records)) {
+            installedNames.add(r.getName());
+        }
         sender.sendMessage(ChatColor.AQUA + "=== Plugins (" + records.size() + ") ===");
         for (ProjectRecord record : records) {
-            boolean installed = pluginFolderService.isInstalled(record);
-            if (installed) {
+            if (installedNames.contains(record.getName())) {
                 String tag = versionStore.getStoredTag(record.getName());
                 String version = tag != null ? " " + tag : "";
                 sender.sendMessage(ChatColor.GREEN + record.getName() + version);


### PR DESCRIPTION
## Summary
- **ListCommand** (show-all path): replaced per-record `isInstalled()` call inside a 28-record loop with a single `filterInstalled()` scan up front, then membership checks — consistent with how the `installed` and `available` filter paths already work
- **InfoCommand** (dependency display): extracted `installedNamesFor()` which scans the plugin itself + all its dep records in one `filterInstalled()` call, then passes the resulting name set into `showDependencies()` — eliminating one scan per dep (previously called up to ~5× per `/dpm info`)
- **DansPluginManager.onTabComplete**: extracted private `allPluginNames()` to remove the identical plugin-name list-building block that appeared in both the `get` and `info` tab-completion branches (DRY)

Closes #51
Closes #52

## Test plan
- [x] `mvn test` — 122 tests pass, 0 failures
- [x] No behaviour change: list of visible commands and tab-completion output are identical; only the number of filesystem scans per command invocation is reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_