### PR TITLE
Fix O(N×M) in selective update, correct dpm.list doc, remove Javadoc violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Tab-completion for `/dpm list` offers `installed` and `available`
 
 ### Changed
+- `UpdateCommand` selective path replaced per-plugin `isInstalled()` calls with a single `filterInstalled()` scan
+- `USER_GUIDE.md` `dpm.list` permission description now covers `/dpm search` (both commands share this node)
+- Removed multi-line Javadoc blocks from `PluginFolderService`, `VersionStore`, `CleanCommand`, and `DefaultCommand` per CLAUDE.md style rule
 - `ListCommand` (show-all path) and `InfoCommand` (dependency display) replaced O(N×M) `isInstalled()` calls with a single `filterInstalled()` scan
 - `DansPluginManager.onTabComplete` — extracted `allPluginNames()` helper to remove duplicated plugin-name list building for `get` and `info` tab-completion branches
 - `UpdateCommand` replaced O(N×M) per-record `isInstalled()` loop with a single `filterInstalled()` call

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -26,7 +26,7 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 | Permission | Default | Description |
 |------------|---------|-------------|
 | `dpm.help` | `true` | View the help menu. |
-| `dpm.list` | `true` | List DPC plugins, optionally filtered by `installed` or `available`. |
+| `dpm.list` | `true` | Browse DPC plugins: list all/installed/available and search by keyword. |
 | `dpm.stats` | `true` | View plugin statistics. |
 | `dpm.get` | `op` | Download one or more plugins to the server. |
 | `dpm.clean` | `op` | Preview or remove duplicate plugin JARs. |

--- a/src/main/java/dansplugins/dpm/commands/CleanCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/CleanCommand.java
@@ -13,9 +13,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * @author Daniel McCoy Stephenson
- */
 public class CleanCommand extends AbstractPluginCommand {
     private final EphemeralData ephemeralData;
     private final PluginFolderService pluginFolderService;

--- a/src/main/java/dansplugins/dpm/commands/DefaultCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/DefaultCommand.java
@@ -8,9 +8,6 @@ import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-/**
- * @author Daniel McCoy Stephenson
- */
 public class DefaultCommand extends AbstractPluginCommand {
     private final DansPluginManager dansPluginManager;
 

--- a/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
@@ -13,6 +13,7 @@ import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class UpdateCommand extends AbstractPluginCommand {
@@ -52,18 +53,24 @@ public class UpdateCommand extends AbstractPluginCommand {
     }
 
     private boolean executeSelective(CommandSender sender, String[] names) {
-        List<ProjectRecord> toUpdate = new ArrayList<>();
+        List<ProjectRecord> candidates = new ArrayList<>();
         for (String name : names) {
             ProjectRecord record = ephemeralData.getProjectRecord(name);
             if (record == null) {
                 sender.sendMessage(ChatColor.RED + "Plugin not found: " + name);
-                continue;
+            } else {
+                candidates.add(record);
             }
-            if (!pluginFolderService.isInstalled(record)) {
-                sender.sendMessage(ChatColor.YELLOW + record.getName() + " is not installed — use /dpm get " + record.getName() + " first.");
-                continue;
+        }
+        Set<String> installedNames = pluginFolderService.filterInstalled(candidates)
+                .stream().map(ProjectRecord::getName).collect(Collectors.toSet());
+        List<ProjectRecord> toUpdate = new ArrayList<>();
+        for (ProjectRecord r : candidates) {
+            if (installedNames.contains(r.getName())) {
+                toUpdate.add(r);
+            } else {
+                sender.sendMessage(ChatColor.YELLOW + r.getName() + " is not installed — use /dpm get " + r.getName() + " first.");
             }
-            toUpdate.add(record);
         }
         if (toUpdate.isEmpty()) return false;
         sender.sendMessage(ChatColor.AQUA + "Checking " + toUpdate.size() + " plugin(s) for updates...");

--- a/src/main/java/dansplugins/dpm/services/PluginFolderService.java
+++ b/src/main/java/dansplugins/dpm/services/PluginFolderService.java
@@ -27,10 +27,6 @@ public class PluginFolderService {
         return getInstalledFile(record) != null;
     }
 
-    /**
-     * Returns the installed JAR file for the record, or null if not found.
-     * Case-insensitive — all isInstalled() calls delegate here.
-     */
     public File getInstalledFile(ProjectRecord record) {
         String managedFilename = record.getName() + ".jar";
         File pluginsDir = new File(pluginsFolder);
@@ -42,10 +38,6 @@ public class PluginFolderService {
         return null;
     }
 
-    /**
-     * Returns the subset of records whose managed JAR is present in the plugins folder.
-     * Scans the directory once regardless of how many records are provided.
-     */
     public List<ProjectRecord> filterInstalled(List<ProjectRecord> records) {
         File pluginsDir = new File(pluginsFolder);
         File[] files = pluginsDir.listFiles();
@@ -63,10 +55,6 @@ public class PluginFolderService {
         return installed;
     }
 
-    /**
-     * Returns all JARs in the plugins folder whose normalized name matches the record
-     * but are not the managed file ({recordName}.jar).
-     */
     public List<File> findConflictingJars(ProjectRecord record) {
         List<File> conflicts = new ArrayList<>();
         File pluginsDir = new File(pluginsFolder);
@@ -82,16 +70,7 @@ public class PluginFolderService {
         return conflicts;
     }
 
-    /**
-     * Normalizes a JAR filename for comparison against a record name:
-     * strips the .jar extension, removes any trailing version suffix
-     * (e.g. -4.6.3, -v1.0), strips hyphens and underscores, lowercases.
-     *
-     * Examples:
-     *   Medieval-Factions-4.6.3.jar  -> medievalfactions
-     *   ActivityTracker-v1.0.jar     -> activitytracker
-     *   Bluemap_MedievalFactions.jar -> bluemapmedievalfactions
-     */
+    // strips .jar, trailing version suffix (-4.6.3, -v1.0), hyphens/underscores, lowercases
     String normalize(String filename) {
         String name = filename.replaceAll("(?i)\\.jar$", "");
         name = name.replaceAll("[-_]v?\\d.*$", "");

--- a/src/main/java/dansplugins/dpm/services/VersionStore.java
+++ b/src/main/java/dansplugins/dpm/services/VersionStore.java
@@ -7,13 +7,6 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-/**
- * Persists the last-downloaded release tag for each managed plugin so that
- * re-downloads can be skipped when the plugin is already on the latest version.
- *
- * Tags are keyed by lower-cased plugin name and stored in a .properties file
- * inside the plugin's data folder.
- */
 public class VersionStore {
     private static final Logger LOGGER = Logger.getLogger(VersionStore.class.getName());
 


### PR DESCRIPTION
## Summary
- **UpdateCommand selective path** (`/dpm update plugin1 plugin2 ...`): replaced per-plugin `isInstalled()` call inside a loop with a single `filterInstalled()` scan — consistent with the bulk update path and all other commands fixed in #51, #53
- **USER_GUIDE.md** `dpm.list` permission row: description now mentions `/dpm search` since `SearchCommand` shares the `dpm.list` node (per CLAUDE.md: permissions table must reflect the `super()` call in each command's constructor)
- **Javadoc cleanup**: removed multi-line `/** */` blocks from `PluginFolderService` (4 blocks), `VersionStore` (1), `CleanCommand` (1 `@author`), and `DefaultCommand` (1 `@author`) per CLAUDE.md style rule; `normalize`'s non-obvious regex logic kept as a single `//` line

Closes #54
Closes #55
Closes #56

## Test plan
- [x] `mvn test` — 122 tests pass, 0 failures
- [x] No behaviour change: selective update output and logic are identical; only number of filesystem scans reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_