### PR TITLE
Extract parseStringField DRY fix and remove remaining Javadoc blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Tab-completion for `/dpm list` offers `installed` and `available`
 
 ### Changed
+- `GitHubReleaseService`: extracted `parseStringField` to eliminate duplicated JSON-parsing logic shared by `parseTagName` and `parsePublishedAt`
+- Removed remaining multi-line Javadoc blocks from `GitHubReleaseService`, `DownloadService`, and `StatsCommand`; kept non-obvious algorithm notes as single `//` lines
 - `UpdateCommand` selective path replaced per-plugin `isInstalled()` calls with a single `filterInstalled()` scan
 - `USER_GUIDE.md` `dpm.list` permission description now covers `/dpm search` (both commands share this node)
 - Removed multi-line Javadoc blocks from `PluginFolderService`, `VersionStore`, `CleanCommand`, and `DefaultCommand` per CLAUDE.md style rule

--- a/src/main/java/dansplugins/dpm/commands/StatsCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/StatsCommand.java
@@ -9,9 +9,6 @@ import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * @author Daniel McCoy Stephenson
- */
 public class StatsCommand extends AbstractPluginCommand {
     private final EphemeralData ephemeralData;
     private final PluginFolderService pluginFolderService;

--- a/src/main/java/dansplugins/dpm/services/DownloadService.java
+++ b/src/main/java/dansplugins/dpm/services/DownloadService.java
@@ -30,13 +30,6 @@ public class DownloadService {
         this.versionStore = versionStore;
     }
 
-    /**
-     * Resolves the latest release via the GitHub API. Returns {@link #ALREADY_UP_TO_DATE}
-     * if the stored tag matches the latest tag AND the managed JAR is present on disk.
-     * Otherwise removes conflicting JARs and downloads the new version.
-     * Returns bytes downloaded on success, {@link #NO_RELEASE} if no release has been
-     * published yet, or -1 on other errors.
-     */
     public int downloadLatest(ProjectRecord projectRecord) {
         ReleaseInfo release = gitHubReleaseService.getLatestRelease(projectRecord.getOwner(), projectRecord.getRepo());
         if (release == ReleaseInfo.NO_RELEASE) {

--- a/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
+++ b/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
@@ -38,12 +38,6 @@ public class GitHubReleaseService {
         return apiToken;
     }
 
-    /**
-     * Returns a {@link ReleaseInfo} with the tag name and first .jar asset URL for the
-     * latest release. Returns {@link ReleaseInfo#NO_RELEASE} when GitHub reports 404
-     * (no releases published yet). Returns null when no .jar asset exists or on network errors.
-     * Results are cached for the session; call {@link #clearCache()} to force a fresh fetch.
-     */
     public ReleaseInfo getLatestRelease(String owner, String repo) {
         ReleaseInfo release = fetchRelease(owner, repo);
         if (release == null || release == ReleaseInfo.NO_RELEASE) return release;
@@ -78,21 +72,11 @@ public class GitHubReleaseService {
         return sb.toString();
     }
 
-    /**
-     * Returns a {@link ReleaseInfo} with tag name and publish date for the latest release,
-     * without requiring a downloadable .jar asset. Returns {@link ReleaseInfo#NO_RELEASE}
-     * on 404, or null on network/other errors.
-     * Results are cached for the session; call {@link #clearCache()} to force a fresh fetch.
-     */
     public ReleaseInfo getLatestReleaseMetadata(String owner, String repo) {
         return fetchRelease(owner, repo);
     }
 
-    /**
-     * Returns the cached entry or fetches it. Network errors (null) are never cached so
-     * the next call can retry. The generation counter prevents a fetch that started before
-     * a {@link #clearCache()} from repopulating the cache with pre-reload data.
-     */
+    // generation check prevents a pre-clearCache() fetch from re-populating the cache with stale data
     private ReleaseInfo fetchRelease(String owner, String repo) {
         String key = owner + "/" + repo;
         ReleaseInfo cached = releaseCache.get(key);
@@ -106,11 +90,7 @@ public class GitHubReleaseService {
         return fetched;
     }
 
-    /**
-     * Makes the HTTP request and parses the response. Returns {@link ReleaseInfo#NO_RELEASE}
-     * on 404, null on network/other errors, and a fully-populated {@link ReleaseInfo} on success.
-     * Package-private so tests can override it via anonymous subclass.
-     */
+    // package-private so tests can override via anonymous subclass without hitting the network
     ReleaseInfo doFetch(String owner, String repo) {
         String apiUrl = String.format(API_URL, owner, repo);
         HttpURLConnection connection = null;
@@ -137,12 +117,12 @@ public class GitHubReleaseService {
         }
     }
 
-    /**
-     * Extracts the value of the top-level "tag_name" field. Tag names are simple
-     * strings that never contain backslash escapes, so a direct quote scan suffices.
-     */
-    String parseTagName(String json) {
-        String key = "\"tag_name\"";
+    // direct quote-scan is safe for these fields — values are simple strings with no backslash escapes
+    String parseTagName(String json)     { return parseStringField(json, "tag_name"); }
+    String parsePublishedAt(String json) { return parseStringField(json, "published_at"); }
+
+    private String parseStringField(String json, String fieldName) {
+        String key = "\"" + fieldName + "\"";
         int keyIndex = json.indexOf(key);
         if (keyIndex == -1) return null;
         int colonIndex = json.indexOf(':', keyIndex + key.length());
@@ -154,28 +134,7 @@ public class GitHubReleaseService {
         return json.substring(openQuote + 1, closeQuote);
     }
 
-    /**
-     * Extracts the value of the top-level "published_at" field (ISO 8601 date string).
-     * Uses the same quote-scan approach as parseTagName.
-     */
-    String parsePublishedAt(String json) {
-        String key = "\"published_at\"";
-        int keyIndex = json.indexOf(key);
-        if (keyIndex == -1) return null;
-        int colonIndex = json.indexOf(':', keyIndex + key.length());
-        if (colonIndex == -1) return null;
-        int openQuote = json.indexOf('"', colonIndex + 1);
-        if (openQuote == -1) return null;
-        int closeQuote = json.indexOf('"', openQuote + 1);
-        if (closeQuote == -1) return null;
-        return json.substring(openQuote + 1, closeQuote);
-    }
-
-    /**
-     * Extracts the first .jar browser_download_url from within the assets array.
-     * Uses bracket-depth tracking to bound the search strictly to the assets array,
-     * and handles backslash-escaped characters within URL strings.
-     */
+    // bracket-depth tracking bounds the search to the assets array; backslash-escape handling for URL strings
     String parseJarUrlFromAssets(String json) {
         int assetsKeyIndex = json.indexOf("\"assets\":");
         if (assetsKeyIndex == -1) return null;


### PR DESCRIPTION
## Summary
- **`GitHubReleaseService`** — `parseTagName` and `parsePublishedAt` were line-for-line identical; extracted shared logic into private `parseStringField(json, fieldName)`. Both methods are now one-liners. Existing tests call them directly and are unaffected.
- **Javadoc cleanup** — removed multi-line `/** */` blocks from `GitHubReleaseService` (4 blocks), `DownloadService` (1), and `StatsCommand` (1 `@author`). Non-obvious algorithm notes (`fetchRelease` generation-counter race, `doFetch` test-override pattern, `parseStringField` backslash-escape assumption, `parseJarUrlFromAssets` bracket-depth strategy) kept as single `//` lines per CLAUDE.md.

Closes #58
Closes #59

## Test plan
- [x] `mvn test` — all tests pass, 0 failures
- [x] `parseTagName` and `parsePublishedAt` both delegate to the new helper; existing `GitHubReleaseServiceTest` tests covering both methods continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_