### PR TITLE
Add Docker-based integration test CI using OMCSI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -68,6 +68,8 @@ jobs:
             echo "DISCORD_WEBHOOK_URL="
             echo "ALERT_MANAGER_ENABLED=false"
             echo "AGENT_ENABLED=false"
+            echo "LOGS_DIAGNOSTIC_ENABLED=true"
+            echo "LOGS_DIAGNOSTIC_MAX_LINES=200"
           } > omcsi/.env
 
       # Cache the compiled Spigot image layers so the 10–15 min first-run

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
+      - main
       - integration-test-ci
   schedule:
     - cron: '0 2 * * *'  # 02:00 UTC daily
@@ -29,6 +30,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'maven'
 
       - name: Build DPM JAR
         run: mvn package -DskipTests -q
@@ -70,8 +72,8 @@ jobs:
             echo "AGENT_ENABLED=false"
           } > omcsi/.env
 
-      # Cache the compiled Spigot image layers so the 10–15 min first-run
-      # compilation is skipped on subsequent runs with the same Dockerfiles.
+      # On cache hit: load images and skip the 10–15 min Spigot compilation entirely.
+      # On cache miss: build from scratch and save the result for next time.
       - name: Cache OMCSI Docker images
         id: docker-cache
         uses: actions/cache@v4
@@ -85,6 +87,7 @@ jobs:
         run: docker load < /tmp/omcsi-images.tar
 
       - name: Build OMCSI Docker stack
+        if: steps.docker-cache.outputs.cache-hit != 'true'
         working-directory: omcsi
         env:
           DOCKER_BUILDKIT: '1'
@@ -101,7 +104,7 @@ jobs:
 
       - name: Start OMCSI stack
         working-directory: omcsi
-        run: docker compose up -d
+        run: docker compose up -d ${{ steps.docker-cache.outputs.cache-hit == 'true' && '--no-build' || '' }}
 
       - name: Run integration tests
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,99 @@
+name: Integration Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'  # 02:00 UTC daily
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout DPM
+        uses: actions/checkout@v4
+
+      - name: Checkout OMCSI
+        uses: actions/checkout@v4
+        with:
+          repository: dmccoystephenson/omcsi
+          token: ${{ secrets.OMCSI_GITHUB_TOKEN }}
+          path: omcsi
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build DPM JAR
+        run: mvn package -DskipTests -q
+
+      - name: Locate built JAR
+        id: jar
+        run: |
+          path=$(ls target/DansPluginManager-*.jar | grep -v original | head -1)
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies
+        run: pip install requests
+
+      - name: Configure OMCSI environment
+        run: |
+          {
+            echo "DEPLOY_AUTH_TOKEN=${{ secrets.OMCSI_DEPLOY_TOKEN }}"
+            echo "RCON_PASSWORD=${{ secrets.OMCSI_RCON_PASSWORD }}"
+            echo "ONLINE_MODE=false"
+            echo "DISCORD_WEBHOOK_URL="
+            echo "ALERT_EMAIL="
+          } > omcsi/.env
+
+      # Cache the compiled Spigot image layers so the 10–15 min first-run
+      # compilation is skipped on subsequent runs with the same Dockerfiles.
+      - name: Cache OMCSI Docker images
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/omcsi-images.tar
+          key: omcsi-docker-${{ hashFiles('omcsi/**/Dockerfile', 'omcsi/docker-compose.yml') }}
+          restore-keys: omcsi-docker-
+
+      - name: Load cached Docker images
+        if: steps.docker-cache.outputs.cache-hit == 'true'
+        run: docker load < /tmp/omcsi-images.tar
+
+      - name: Build OMCSI Docker stack
+        working-directory: omcsi
+        env:
+          DOCKER_BUILDKIT: '1'
+          BUILDKIT_PROGRESS: plain
+        run: docker compose build
+
+      - name: Save Docker images to cache
+        if: steps.docker-cache.outputs.cache-hit != 'true'
+        run: |
+          docker compose -f omcsi/docker-compose.yml images -q \
+            | sort -u \
+            | xargs docker save > /tmp/omcsi-images.tar
+
+      - name: Start OMCSI stack
+        working-directory: omcsi
+        run: docker compose up -d
+
+      - name: Run integration tests
+        env:
+          OMCSI_API_BASE: http://localhost:8092
+          OMCSI_DEPLOY_TOKEN: ${{ secrets.OMCSI_DEPLOY_TOKEN }}
+          DPM_JAR_PATH: ${{ steps.jar.outputs.path }}
+        run: python integration-test/test_dpm.py
+
+      - name: Tear down OMCSI stack
+        if: always()
+        working-directory: omcsi
+        run: docker compose down

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -95,7 +95,7 @@ jobs:
         if: steps.docker-cache.outputs.cache-hit != 'true'
         working-directory: omcsi
         run: |
-          docker compose images -q \
+          docker compose config --images \
             | sort -u \
             | xargs docker save > /tmp/omcsi-images.tar
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,7 +61,7 @@ jobs:
             echo "DIFFICULTY=peaceful"
             echo "GAMEMODE=creative"
             echo "PVP_ENABLED=false"
-            echo "JAVA_OPTS=-Xmx2G -Xms1G -Dlogs.diagnostic.enabled=true -Dlogs.diagnostic.max-lines=200"
+            echo "JAVA_OPTS=-Xmx2G -Xms1G"
             echo "DEPLOY_AUTH_TOKEN=${{ secrets.OMCSI_DEPLOY_TOKEN }}"
             echo "RCON_PASSWORD=${{ secrets.OMCSI_RCON_PASSWORD }}"
             echo "DISCORD_ENABLED=false"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,15 +61,13 @@ jobs:
             echo "DIFFICULTY=peaceful"
             echo "GAMEMODE=creative"
             echo "PVP_ENABLED=false"
-            echo "JAVA_OPTS=-Xmx2G -Xms1G"
+            echo "JAVA_OPTS=-Xmx2G -Xms1G -Dlogs.diagnostic.enabled=true -Dlogs.diagnostic.max-lines=200"
             echo "DEPLOY_AUTH_TOKEN=${{ secrets.OMCSI_DEPLOY_TOKEN }}"
             echo "RCON_PASSWORD=${{ secrets.OMCSI_RCON_PASSWORD }}"
             echo "DISCORD_ENABLED=false"
             echo "DISCORD_WEBHOOK_URL="
             echo "ALERT_MANAGER_ENABLED=false"
             echo "AGENT_ENABLED=false"
-            echo "LOGS_DIAGNOSTIC_ENABLED=true"
-            echo "LOGS_DIAGNOSTIC_MAX_LINES=200"
           } > omcsi/.env
 
       # Cache the compiled Spigot image layers so the 10–15 min first-run

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout OMCSI
         uses: actions/checkout@v4
         with:
-          repository: dmccoystephenson/omcsi
+          repository: dmccoystephenson/open-mc-server-infrastructure
           token: ${{ secrets.OMCSI_GITHUB_TOKEN }}
           path: omcsi
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,6 +2,9 @@ name: Integration Tests
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - integration-test-ci
   schedule:
     - cron: '0 2 * * *'  # 02:00 UTC daily
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - integration-test-ci
   schedule:
     - cron: '0 2 * * *'  # 02:00 UTC daily
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -86,25 +86,24 @@ jobs:
         if: steps.docker-cache.outputs.cache-hit == 'true'
         run: docker load < /tmp/omcsi-images.tar
 
-      - name: Build OMCSI Docker stack
+      # Only build/start minecraft-wrapper (Spigot + REST API) and its declared
+      # dependency alert-manager. The webapp, nginx, backup-manager, and agent-manager
+      # services are not needed for CI and add unnecessary build and startup time.
+      - name: Build OMCSI services
         if: steps.docker-cache.outputs.cache-hit != 'true'
         working-directory: omcsi
         env:
           DOCKER_BUILDKIT: '1'
           BUILDKIT_PROGRESS: plain
-        run: docker compose build
+        run: docker compose build minecraft-wrapper alert-manager
 
       - name: Save Docker images to cache
         if: steps.docker-cache.outputs.cache-hit != 'true'
-        working-directory: omcsi
-        run: |
-          docker compose config --images \
-            | sort -u \
-            | xargs docker save > /tmp/omcsi-images.tar
+        run: docker save open-mc-server open-mc-server-alert-manager > /tmp/omcsi-images.tar
 
-      - name: Start OMCSI stack
+      - name: Start minecraft-wrapper
         working-directory: omcsi
-        run: docker compose up -d ${{ steps.docker-cache.outputs.cache-hit == 'true' && '--no-build' || '' }}
+        run: docker compose up -d ${{ steps.docker-cache.outputs.cache-hit == 'true' && '--no-build' || '' }} minecraft-wrapper
 
       - name: Run integration tests
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   integration:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     steps:
       - name: Checkout DPM
@@ -50,11 +50,24 @@ jobs:
       - name: Configure OMCSI environment
         run: |
           {
+            echo "MINECRAFT_VERSION=26.1"
+            echo "OPERATOR_UUID=00000000-0000-0000-0000-000000000001"
+            echo "OPERATOR_NAME=CIRunner"
+            echo "OPERATOR_LEVEL=4"
+            echo "ONLINE_MODE=false"
+            echo "OVERWRITE_EXISTING_SERVER=true"
+            echo "SERVER_MOTD=DPM Integration Test"
+            echo "MAX_PLAYERS=5"
+            echo "DIFFICULTY=peaceful"
+            echo "GAMEMODE=creative"
+            echo "PVP_ENABLED=false"
+            echo "JAVA_OPTS=-Xmx2G -Xms1G"
             echo "DEPLOY_AUTH_TOKEN=${{ secrets.OMCSI_DEPLOY_TOKEN }}"
             echo "RCON_PASSWORD=${{ secrets.OMCSI_RCON_PASSWORD }}"
-            echo "ONLINE_MODE=false"
+            echo "DISCORD_ENABLED=false"
             echo "DISCORD_WEBHOOK_URL="
-            echo "ALERT_EMAIL="
+            echo "ALERT_MANAGER_ENABLED=false"
+            echo "AGENT_ENABLED=false"
           } > omcsi/.env
 
       # Cache the compiled Spigot image layers so the 10–15 min first-run
@@ -64,7 +77,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/omcsi-images.tar
-          key: omcsi-docker-${{ hashFiles('omcsi/**/Dockerfile', 'omcsi/docker-compose.yml') }}
+          key: omcsi-docker-${{ hashFiles('omcsi/**/Dockerfile', 'omcsi/compose.yml') }}
           restore-keys: omcsi-docker-
 
       - name: Load cached Docker images
@@ -80,8 +93,9 @@ jobs:
 
       - name: Save Docker images to cache
         if: steps.docker-cache.outputs.cache-hit != 'true'
+        working-directory: omcsi
         run: |
-          docker compose -f omcsi/docker-compose.yml images -q \
+          docker compose images -q \
             | sort -u \
             | xargs docker save > /tmp/omcsi-images.tar
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- Docker-based integration test CI (`integration-test/test_dpm.py` + `.github/workflows/integration.yml`) that spins up an OMCSI Spigot stack, deploys DPM, and asserts `dpm list`, `dpm get`, and `dpm search` produce the expected output; runs on workflow dispatch and nightly schedule
 - `/dpm get` now auto-downloads missing hard dependencies that are registered DPC plugins before downloading the requested plugin(s); transitive dependencies are resolved recursively and circular chains are handled safely. Dependencies that are not registered DPC plugins still produce a warning.
 - `/dpm update [plugin-name ...]` — when plugin names are provided, only those plugins are updated; tab-completion offers installed plugin names at every argument position
 - `/dpm search <keyword>` — searches registered plugin names and descriptions (case-insensitive substring match); results are colour-coded by install status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,26 @@ Filesystem tests use `@TempDir Path tempDir` and construct a `PluginFolderServic
 - Command classes depend on Bukkit and cannot be unit tested here. Cover the underlying services instead.
 - When a bug is fixed, add a regression test that would have caught it.
 
+## Integration test suite
+
+`integration-test/test_dpm.py` runs DPM commands against a live Spigot server and asserts on console output. See `integration-test/README.md` for the full coverage picture.
+
+**Before closing any PR**, ask: does this change affect a command's output, a new command, a new code path, or a bug fix that was caught by the integration tests? If yes, update the harness.
+
+Specifically, add or extend a test step when:
+- A **new command** is added — add a step that sends it and asserts its expected output string
+- An **existing command's output changes** — update the assertion string to match
+- A **new flag or subcommand** is added (e.g. `dpm list installed`) — add a step exercising it
+- A **bug is fixed** that unit tests couldn't have caught (real filesystem, real GitHub API, real Bukkit routing) — add a regression step
+- A **new error path** is reachable from the console — assert the error message so it can't silently break
+
+Do **not** add an integration test step for:
+- Pure display/formatting tweaks with no logic change
+- Changes fully covered by the existing unit test suite
+- Paths that require a player login or real server state that can't be reproduced in CI
+
+After editing the harness, update the coverage table in `integration-test/README.md` to keep "What the tests cover" and "What is not yet covered" accurate.
+
 ## Code patterns
 
 **Avoid O(N×M) directory scans** — `PluginFolderService.isInstalled()` scans the directory on every call. Never call it inside a loop over plugin records; use `filterInstalled(records)` instead, which does one scan for any number of records. `RemoveCommand` was fixed this way; `UpdateCommand` still uses the loop pattern and is tracked in issue #37.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,10 @@ mvn clean package
 
 The built JAR is in `target/`.
 
+## Integration tests
+
+End-to-end tests deploy DPM against a live Spigot server (via [OMCSI](https://github.com/dmccoystephenson/omcsi)) and assert real command output. See [`integration-test/README.md`](integration-test/README.md) for setup instructions and the list of required secrets for the CI workflow.
+
 ## Questions
 
 Ask in the [Discord server](https://discord.gg/xXtuAQ2).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ The built JAR is in `target/`.
 
 ## Integration tests
 
-End-to-end tests deploy DPM against a live Spigot server (via [OMCSI](https://github.com/dmccoystephenson/omcsi)) and assert real command output. See [`integration-test/README.md`](integration-test/README.md) for setup instructions and the list of required secrets for the CI workflow.
+End-to-end tests deploy DPM against a live Spigot server (via [OMCSI](https://github.com/dmccoystephenson/open-mc-server-infrastructure)) and assert real command output. See [`integration-test/README.md`](integration-test/README.md) for setup instructions and the list of required secrets for the CI workflow.
 
 ## Questions
 

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -17,27 +17,29 @@ These tests exercise the full stack: Maven build → JAR deploy → Spigot reloa
 
 | Step | Command | Assertion |
 |------|---------|-----------|
-| 4 | `dpm list` | `=== Plugins` in logs — confirms plugin loaded and command routes correctly |
-| 5 | `dpm get medievalfactions` | `Downloaded` or `already up to date` in logs — confirms real GitHub API call and file write |
-| 6 | `dpm search faction` | `=== Search Results` in logs — confirms search over the registered plugin registry |
+| 4 | `dpm list` | `=== Plugins` — confirms plugin loaded and command routes correctly |
+| 5 | `dpm get currencies` | `Also downloading required dependency` + `Downloaded` — confirms hard-dependency auto-install triggers when dep is missing |
+| 6 | `dpm remove medievalfactions --confirm` | `Removed MedievalFactions` — confirms JAR is deleted from plugins folder |
+| 7 | `dpm list installed` | `=== Installed Plugins` — confirms installed-only filter |
+| 8 | `dpm list available` | `=== Available Plugins` — confirms available-only filter |
+| 9 | `dpm get medievalfactions` | `Downloaded` or `already up to date` — confirms real GitHub API call and file write |
+| 10 | `dpm search faction` | `=== Search Results` — confirms registry search |
+| 11 | `dpm get nonexistentplugin` | `Plugin not found: nonexistentplugin` — confirms error path doesn't crash the server |
 
 ## What is not yet covered
 
 | Area | Notes |
 |------|-------|
-| `dpm update` / `dpm update <name>` | Not tested; exercises the same download path as `dpm get` but with version comparison |
-| `dpm remove <name> [--confirm]` | Not tested; requires a plugin to be installed first |
-| `dpm clean [--confirm]` | Not tested; requires duplicate JARs to be present |
-| `dpm info <name>` | Not tested; mainly a display command, low regression risk |
-| `dpm stats` | Not tested; low regression risk |
-| `dpm reload` | Not tested; would confirm `githubToken` config reloads correctly |
-| `dpm list installed` / `dpm list available` | Filter flags not exercised |
-| `dpm get` with hard dependencies | Auto-install of declared `hardDependencies` not verified end-to-end |
-| `dpm get <multiple names>` | Batch mode not tested |
-| Permission enforcement | Console has all permissions; player-level permission checks are not exercised |
-| Error paths | Plugin-not-found, network failure, and invalid-arg responses are not asserted |
+| `dpm update` / `dpm update <name>` | Exercises the same download path as `dpm get` but with version comparison; low incremental value |
+| `dpm clean [--confirm]` | Requires duplicate JARs to be present; hard to set up reliably in CI |
+| `dpm info <name>` | Mainly a display command; low regression risk |
+| `dpm stats` | Low regression risk |
+| `dpm reload` | Would confirm `githubToken` config reloads without server restart |
+| `dpm get <multiple names>` | Batch mode not tested; same download code path as single |
+| Permission enforcement | Console has all permissions; player-level permission checks cannot be exercised without a player login |
+| Network failure / download error paths | Hard to simulate reliably in CI |
 | Tab-completion | Cannot be tested via console API |
-| Config `githubToken` | Authenticated GitHub API not tested (unauthenticated rate limit applies) |
+| Config `githubToken` | Authenticated GitHub API not tested; unauthenticated rate limit applies in CI |
 
 ## Prerequisites
 

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -2,13 +2,42 @@
 
 End-to-end tests that deploy DPM to a live Spigot server (via [OMCSI](https://github.com/dmccoystephenson/open-mc-server-infrastructure)) and assert that key commands produce the expected output.
 
+## Why this exists
+
+Unit tests can verify parsing logic and service behaviour in isolation, but they cannot catch:
+
+- **Real GitHub API failures** — rate limits, renamed repos, changed release JSON shape
+- **Real file-system behaviour** — JAR placement, duplicate detection, version-tag storage
+- **Real Bukkit command routing** — whether the command is registered, dispatched, and reaches the right handler on a live server
+- **Plugin load failures** — a JAR that passes unit tests can still fail to enable on a real Spigot version due to API incompatibilities
+
+These tests exercise the full stack: Maven build → JAR deploy → Spigot reload → console command → log assertion.
+
 ## What the tests cover
 
 | Step | Command | Assertion |
 |------|---------|-----------|
-| 4 | `dpm list` | `=== Plugins` in logs |
-| 5 | `dpm get medievalfactions` | `Downloaded` or `already up to date` in logs |
-| 6 | `dpm search faction` | `=== Search Results` in logs |
+| 4 | `dpm list` | `=== Plugins` in logs — confirms plugin loaded and command routes correctly |
+| 5 | `dpm get medievalfactions` | `Downloaded` or `already up to date` in logs — confirms real GitHub API call and file write |
+| 6 | `dpm search faction` | `=== Search Results` in logs — confirms search over the registered plugin registry |
+
+## What is not yet covered
+
+| Area | Notes |
+|------|-------|
+| `dpm update` / `dpm update <name>` | Not tested; exercises the same download path as `dpm get` but with version comparison |
+| `dpm remove <name> [--confirm]` | Not tested; requires a plugin to be installed first |
+| `dpm clean [--confirm]` | Not tested; requires duplicate JARs to be present |
+| `dpm info <name>` | Not tested; mainly a display command, low regression risk |
+| `dpm stats` | Not tested; low regression risk |
+| `dpm reload` | Not tested; would confirm `githubToken` config reloads correctly |
+| `dpm list installed` / `dpm list available` | Filter flags not exercised |
+| `dpm get` with hard dependencies | Auto-install of declared `hardDependencies` not verified end-to-end |
+| `dpm get <multiple names>` | Batch mode not tested |
+| Permission enforcement | Console has all permissions; player-level permission checks are not exercised |
+| Error paths | Plugin-not-found, network failure, and invalid-arg responses are not asserted |
+| Tab-completion | Cannot be tested via console API |
+| Config `githubToken` | Authenticated GitHub API not tested (unauthenticated rate limit applies) |
 
 ## Prerequisites
 
@@ -28,11 +57,18 @@ git clone https://github.com/dmccoystephenson/open-mc-server-infrastructure ../o
 **2. Create `../omcsi/.env`** with the following values:
 
 ```
-DEPLOY_AUTH_TOKEN=<your-token>
-RCON_PASSWORD=<any-password>
+MINECRAFT_VERSION=26.1
+OPERATOR_UUID=00000000-0000-0000-0000-000000000001
+OPERATOR_NAME=LocalDev
+OPERATOR_LEVEL=4
 ONLINE_MODE=false
-DISCORD_WEBHOOK_URL=
-ALERT_EMAIL=
+OVERWRITE_EXISTING_SERVER=true
+SERVER_MOTD=DPM Integration Test
+JAVA_OPTS=-Xmx2G -Xms1G
+DEPLOY_AUTH_TOKEN=<any-token>
+RCON_PASSWORD=<any-password>
+DISCORD_ENABLED=false
+AGENT_ENABLED=false
 ```
 
 **3. Start the stack** (first run compiles Spigot from source — allow 10–15 min):
@@ -60,7 +96,7 @@ python integration-test/test_dpm.py
 **6. Tear down** when done:
 
 ```bash
-docker compose -f ../omcsi/docker-compose.yml down
+docker compose -f ../omcsi/compose.yml down
 ```
 
 ## Required GitHub Actions secrets
@@ -73,9 +109,9 @@ docker compose -f ../omcsi/docker-compose.yml down
 
 ## OMCSI REST API reference
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/server/status` | Returns `{"running": true/false}` |
-| `POST` | `/api/plugins/deploy` | Multipart upload of JAR; Bearer auth required |
-| `POST` | `/api/server/command` | JSON `{"command": "..."}` sent to console; Bearer auth required |
-| `GET` | `/api/server/logs?lines=N` | Returns last N lines of `logs/latest.log` |
+| Method | Path | Auth | Body | Description |
+|--------|------|------|------|-------------|
+| `GET` | `/api/server/status` | none | — | Returns `{"running": true/false}` |
+| `POST` | `/api/plugins/deploy` | Bearer | multipart: `pluginName` (filename) + `file` (JAR) | Writes JAR to plugins directory |
+| `POST` | `/api/server/command` | none | `text/plain` command string | Sends raw console command via FIFO |
+| `GET` | `/api/server/logs?lines=N` | none | — | Returns last N lines as JSON; requires `LOGS_DIAGNOSTIC_ENABLED=true` in container env |

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -1,6 +1,6 @@
 # Integration Tests
 
-End-to-end tests that deploy DPM to a live Spigot server (via [OMCSI](https://github.com/dmccoystephenson/omcsi)) and assert that key commands produce the expected output.
+End-to-end tests that deploy DPM to a live Spigot server (via [OMCSI](https://github.com/dmccoystephenson/open-mc-server-infrastructure)) and assert that key commands produce the expected output.
 
 ## What the tests cover
 
@@ -13,7 +13,7 @@ End-to-end tests that deploy DPM to a live Spigot server (via [OMCSI](https://gi
 ## Prerequisites
 
 - Docker with Compose v2 (`docker compose`)
-- Access to the [OMCSI](https://github.com/dmccoystephenson/omcsi) repository
+- Access to the [OMCSI](https://github.com/dmccoystephenson/open-mc-server-infrastructure) repository
 - Python 3.9+ and `pip install requests`
 - A built DPM JAR (`mvn package -DskipTests`)
 
@@ -22,7 +22,7 @@ End-to-end tests that deploy DPM to a live Spigot server (via [OMCSI](https://gi
 **1. Clone OMCSI** next to this repo (or anywhere):
 
 ```bash
-git clone https://github.com/dmccoystephenson/omcsi ../omcsi
+git clone https://github.com/dmccoystephenson/open-mc-server-infrastructure ../omcsi
 ```
 
 **2. Create `../omcsi/.env`** with the following values:

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -1,0 +1,81 @@
+# Integration Tests
+
+End-to-end tests that deploy DPM to a live Spigot server (via [OMCSI](https://github.com/dmccoystephenson/omcsi)) and assert that key commands produce the expected output.
+
+## What the tests cover
+
+| Step | Command | Assertion |
+|------|---------|-----------|
+| 4 | `dpm list` | `=== Plugins` in logs |
+| 5 | `dpm get medievalfactions` | `Downloaded` or `already up to date` in logs |
+| 6 | `dpm search faction` | `=== Search Results` in logs |
+
+## Prerequisites
+
+- Docker with Compose v2 (`docker compose`)
+- Access to the [OMCSI](https://github.com/dmccoystephenson/omcsi) repository
+- Python 3.9+ and `pip install requests`
+- A built DPM JAR (`mvn package -DskipTests`)
+
+## Running locally
+
+**1. Clone OMCSI** next to this repo (or anywhere):
+
+```bash
+git clone https://github.com/dmccoystephenson/omcsi ../omcsi
+```
+
+**2. Create `../omcsi/.env`** with the following values:
+
+```
+DEPLOY_AUTH_TOKEN=<your-token>
+RCON_PASSWORD=<any-password>
+ONLINE_MODE=false
+DISCORD_WEBHOOK_URL=
+ALERT_EMAIL=
+```
+
+**3. Start the stack** (first run compiles Spigot from source — allow 10–15 min):
+
+```bash
+cd ../omcsi
+docker compose up -d --build
+```
+
+**4. Build DPM** from the repo root:
+
+```bash
+mvn package -DskipTests
+```
+
+**5. Run the test harness**:
+
+```bash
+export OMCSI_API_BASE=http://localhost:8092
+export OMCSI_DEPLOY_TOKEN=<your-token>
+export DPM_JAR_PATH=$(ls target/DansPluginManager-*.jar | grep -v original | head -1)
+python integration-test/test_dpm.py
+```
+
+**6. Tear down** when done:
+
+```bash
+docker compose -f ../omcsi/docker-compose.yml down
+```
+
+## Required GitHub Actions secrets
+
+| Secret | Purpose |
+|--------|---------|
+| `OMCSI_GITHUB_TOKEN` | PAT with read access to the OMCSI repository |
+| `OMCSI_DEPLOY_TOKEN` | Bearer token for the OMCSI REST API (`DEPLOY_AUTH_TOKEN` in `.env`) |
+| `OMCSI_RCON_PASSWORD` | RCON password (`RCON_PASSWORD` in `.env`) |
+
+## OMCSI REST API reference
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/server/status` | Returns `{"running": true/false}` |
+| `POST` | `/api/plugins/deploy` | Multipart upload of JAR; Bearer auth required |
+| `POST` | `/api/server/command` | JSON `{"command": "..."}` sent to console; Bearer auth required |
+| `GET` | `/api/server/logs?lines=N` | Returns last N lines of `logs/latest.log` |

--- a/integration-test/test_dpm.py
+++ b/integration-test/test_dpm.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Integration test harness for Dans Plugin Manager.
+
+Deploys the DPM JAR to a live OMCSI Spigot server via REST API and
+asserts that key commands produce the expected console output.
+
+Required environment variables:
+  OMCSI_DEPLOY_TOKEN  Bearer token accepted by the OMCSI REST API
+  DPM_JAR_PATH        Path to the built DansPluginManager-*.jar
+
+Optional:
+  OMCSI_API_BASE      Base URL of the OMCSI REST API (default: http://localhost:8092)
+"""
+
+import os
+import sys
+import time
+
+import requests
+
+API_BASE = os.getenv("OMCSI_API_BASE", "http://localhost:8092")
+TOKEN = os.environ["OMCSI_DEPLOY_TOKEN"]
+JAR_PATH = os.environ["DPM_JAR_PATH"]
+
+_HEADERS = {"Authorization": f"Bearer {TOKEN}"}
+
+
+def _api(method, path, **kwargs):
+    resp = requests.request(
+        method, f"{API_BASE}{path}", headers=_HEADERS, timeout=30, **kwargs
+    )
+    resp.raise_for_status()
+    return resp
+
+
+def wait_until_running(timeout=300, poll_interval=10, label="server"):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            if _api("GET", "/api/server/status").json().get("running"):
+                print(f"  {label} ready.")
+                return
+        except Exception as exc:
+            print(f"  status check error: {exc}")
+        remaining = int(deadline - time.time())
+        print(f"  waiting for {label} ({remaining}s remaining)...")
+        time.sleep(poll_interval)
+    sys.exit(f"Timed out waiting for {label}")
+
+
+def send_command(cmd):
+    _api("POST", "/api/server/command", json={"command": cmd})
+    print(f"  > {cmd}")
+
+
+def _log_tail(lines=100):
+    return _api("GET", f"/api/server/logs?lines={lines}").text
+
+
+def assert_log_contains(expected, lines=100, retries=6, delay=5):
+    for attempt in range(1, retries + 1):
+        if expected in _log_tail(lines):
+            print(f"  PASS: found {expected!r}")
+            return
+        if attempt < retries:
+            print(f"  attempt {attempt}: {expected!r} not in logs yet, retrying in {delay}s...")
+            time.sleep(delay)
+    print("--- log tail ---")
+    print(_log_tail(lines))
+    sys.exit(f"FAIL: {expected!r} not found after {retries} attempts")
+
+
+def assert_log_contains_any(candidates, lines=100, retries=6, delay=5):
+    for attempt in range(1, retries + 1):
+        log = _log_tail(lines)
+        for expected in candidates:
+            if expected in log:
+                print(f"  PASS: found {expected!r}")
+                return
+        if attempt < retries:
+            print(f"  attempt {attempt}: none of {candidates!r} in logs yet, retrying in {delay}s...")
+            time.sleep(delay)
+    print("--- log tail ---")
+    print(_log_tail(lines))
+    sys.exit(f"FAIL: none of {candidates!r} found after {retries} attempts")
+
+
+def deploy_jar(path):
+    with open(path, "rb") as jar:
+        _api(
+            "POST",
+            "/api/plugins/deploy",
+            files={"file": ("plugin.jar", jar, "application/java-archive")},
+        )
+    print(f"  deployed {path}")
+
+
+def main():
+    print("=== DPM Integration Tests ===\n")
+
+    print("[1] Waiting for Spigot server to start...")
+    wait_until_running(timeout=300)
+
+    print("\n[2] Deploying DPM JAR...")
+    deploy_jar(JAR_PATH)
+
+    print("\n[3] Reloading server to activate plugin...")
+    send_command("reload confirm")
+    time.sleep(15)
+    wait_until_running(timeout=120, label="server after reload")
+
+    print("\n[4] /dpm list — expect '=== Plugins'...")
+    send_command("dpm list")
+    assert_log_contains("=== Plugins")
+
+    print("\n[5] /dpm get medievalfactions — expect download confirmation...")
+    send_command("dpm get medievalfactions")
+    # "Downloaded" on first run; "already up to date" on subsequent runs
+    assert_log_contains_any(["Downloaded", "already up to date"], retries=8, delay=5)
+
+    print("\n[6] /dpm search faction — expect '=== Search Results'...")
+    send_command("dpm search faction")
+    assert_log_contains("=== Search Results")
+
+    print("\n=== All integration tests passed ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/integration-test/test_dpm.py
+++ b/integration-test/test_dpm.py
@@ -52,7 +52,12 @@ def wait_until_running(timeout=300, poll_interval=10, label="server"):
 
 
 def send_command(cmd):
-    _api("POST", "/api/server/command", json={"command": cmd})
+    requests.post(
+        f"{API_BASE}/api/server/command",
+        headers={**_HEADERS, "Content-Type": "text/plain; charset=utf-8"},
+        data=cmd.encode("utf-8"),
+        timeout=30,
+    ).raise_for_status()
     print(f"  > {cmd}")
 
 
@@ -66,7 +71,7 @@ def _docker_logs(tail=200):
     return result.stdout + result.stderr
 
 
-def assert_log_contains(expected, tail=200, retries=6, delay=5):
+def assert_log_contains(expected, tail=500, retries=6, delay=5):
     for attempt in range(1, retries + 1):
         if expected in _docker_logs(tail):
             print(f"  PASS: found {expected!r}")
@@ -79,7 +84,7 @@ def assert_log_contains(expected, tail=200, retries=6, delay=5):
     sys.exit(f"FAIL: {expected!r} not found after {retries} attempts")
 
 
-def assert_log_contains_any(candidates, tail=200, retries=6, delay=5):
+def assert_log_contains_any(candidates, tail=500, retries=6, delay=5):
     for attempt in range(1, retries + 1):
         log = _docker_logs(tail)
         for expected in candidates:

--- a/integration-test/test_dpm.py
+++ b/integration-test/test_dpm.py
@@ -54,7 +54,8 @@ def send_command(cmd):
 
 
 def _log_tail(lines=100):
-    return _api("GET", f"/api/server/logs?lines={lines}").text
+    data = _api("GET", f"/api/server/logs?lines={lines}").json()
+    return "\n".join(data.get("lines", []))
 
 
 def assert_log_contains(expected, lines=100, retries=6, delay=5):

--- a/integration-test/test_dpm.py
+++ b/integration-test/test_dpm.py
@@ -13,6 +13,7 @@ Optional:
   OMCSI_CONTAINER_NAME  Docker container name for log reading (default: open-mc-server)
 """
 
+import datetime
 import os
 import subprocess
 import sys
@@ -52,6 +53,9 @@ def wait_until_running(timeout=300, poll_interval=10, label="server"):
 
 
 def send_command(cmd):
+    """Send a console command and return a timestamp cursor for scoped log assertions."""
+    # Subtract 1 s so logs emitted in the same second as the command are included.
+    cursor = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=1)
     requests.post(
         f"{API_BASE}/api/server/command",
         headers={**_HEADERS, "Content-Type": "text/plain; charset=utf-8"},
@@ -59,34 +63,38 @@ def send_command(cmd):
         timeout=30,
     ).raise_for_status()
     print(f"  > {cmd}")
+    return cursor
 
 
-def _docker_logs(tail=500):
-    """Read recent container log lines via docker logs."""
-    result = subprocess.run(
-        ["docker", "logs", "--tail", str(tail), CONTAINER],
-        capture_output=True, text=True, timeout=15,
-    )
+def _docker_logs(cursor=None, tail=500):
+    """Return container log output, scoped to lines after *cursor* when provided."""
+    cmd = ["docker", "logs"]
+    if cursor is not None:
+        cmd += ["--since", cursor.isoformat()]
+    else:
+        cmd += ["--tail", str(tail)]
+    cmd.append(CONTAINER)
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
     # Minecraft server output may appear on either stream depending on the wrapper
     return result.stdout + result.stderr
 
 
-def assert_log_contains(expected, tail=500, retries=6, delay=5):
+def assert_log_contains(expected, cursor=None, tail=500, retries=6, delay=5):
     for attempt in range(1, retries + 1):
-        if expected in _docker_logs(tail):
+        if expected in _docker_logs(cursor=cursor, tail=tail):
             print(f"  PASS: found {expected!r}")
             return
         if attempt < retries:
             print(f"  attempt {attempt}: {expected!r} not in logs yet, retrying in {delay}s...")
             time.sleep(delay)
     print("--- last container logs ---")
-    print(_docker_logs(tail))
+    print(_docker_logs(cursor=cursor, tail=tail))
     sys.exit(f"FAIL: {expected!r} not found after {retries} attempts")
 
 
-def assert_log_contains_any(candidates, tail=500, retries=6, delay=5):
+def assert_log_contains_any(candidates, cursor=None, tail=500, retries=6, delay=5):
     for attempt in range(1, retries + 1):
-        log = _docker_logs(tail)
+        log = _docker_logs(cursor=cursor, tail=tail)
         for expected in candidates:
             if expected in log:
                 print(f"  PASS: found {expected!r}")
@@ -95,7 +103,7 @@ def assert_log_contains_any(candidates, tail=500, retries=6, delay=5):
             print(f"  attempt {attempt}: none of {candidates!r} in logs yet, retrying in {delay}s...")
             time.sleep(delay)
     print("--- last container logs ---")
-    print(_docker_logs(tail))
+    print(_docker_logs(cursor=cursor, tail=tail))
     sys.exit(f"FAIL: none of {candidates!r} found after {retries} attempts")
 
 
@@ -125,39 +133,39 @@ def main():
     wait_until_running(timeout=120, label="server after reload")
 
     print("\n[4] /dpm list — confirm plugin loaded and command routes correctly...")
-    send_command("dpm list")
-    assert_log_contains("=== Plugins")
+    cursor = send_command("dpm list")
+    assert_log_contains("=== Plugins", cursor=cursor)
 
     # Test dependency auto-install: currencies hard-depends on medievalfactions, which is
     # not yet installed. DPM should detect this and download medievalfactions automatically.
     print("\n[5] /dpm get currencies — confirm hard-dependency auto-install...")
-    send_command("dpm get currencies")
-    assert_log_contains("Also downloading required dependency", retries=3, delay=3)
-    assert_log_contains_any(["Downloaded", "already up to date"], retries=8, delay=5)
+    cursor = send_command("dpm get currencies")
+    assert_log_contains("Also downloading required dependency", cursor=cursor, retries=3, delay=3)
+    assert_log_contains_any(["Downloaded", "already up to date"], cursor=cursor, retries=8, delay=5)
 
     print("\n[6] /dpm remove medievalfactions --confirm — confirm file deletion...")
-    send_command("dpm remove medievalfactions --confirm")
-    assert_log_contains("Removed MedievalFactions")
+    cursor = send_command("dpm remove medievalfactions --confirm")
+    assert_log_contains("Removed MedievalFactions", cursor=cursor)
 
     print("\n[7] /dpm list installed — confirm filter shows only installed plugins...")
-    send_command("dpm list installed")
-    assert_log_contains("=== Installed Plugins")
+    cursor = send_command("dpm list installed")
+    assert_log_contains("=== Installed Plugins", cursor=cursor)
 
     print("\n[8] /dpm list available — confirm filter shows only uninstalled plugins...")
-    send_command("dpm list available")
-    assert_log_contains("=== Available Plugins")
+    cursor = send_command("dpm list available")
+    assert_log_contains("=== Available Plugins", cursor=cursor)
 
     print("\n[9] /dpm get medievalfactions — confirm standard download...")
-    send_command("dpm get medievalfactions")
-    assert_log_contains_any(["Downloaded", "already up to date"], retries=8, delay=5)
+    cursor = send_command("dpm get medievalfactions")
+    assert_log_contains_any(["Downloaded", "already up to date"], cursor=cursor, retries=8, delay=5)
 
     print("\n[10] /dpm search faction — confirm registry search...")
-    send_command("dpm search faction")
-    assert_log_contains("=== Search Results")
+    cursor = send_command("dpm search faction")
+    assert_log_contains("=== Search Results", cursor=cursor)
 
     print("\n[11] /dpm get nonexistentplugin — confirm error path...")
-    send_command("dpm get nonexistentplugin")
-    assert_log_contains("Plugin not found: nonexistentplugin")
+    cursor = send_command("dpm get nonexistentplugin")
+    assert_log_contains("Plugin not found: nonexistentplugin", cursor=cursor)
 
     print("\n=== All integration tests passed ===")
 

--- a/integration-test/test_dpm.py
+++ b/integration-test/test_dpm.py
@@ -90,7 +90,8 @@ def deploy_jar(path):
         _api(
             "POST",
             "/api/plugins/deploy",
-            files={"file": ("plugin.jar", jar, "application/java-archive")},
+            data={"pluginName": "DansPluginManager.jar"},
+            files={"file": ("DansPluginManager.jar", jar, "application/java-archive")},
         )
     print(f"  deployed {path}")
 

--- a/integration-test/test_dpm.py
+++ b/integration-test/test_dpm.py
@@ -61,7 +61,7 @@ def send_command(cmd):
     print(f"  > {cmd}")
 
 
-def _docker_logs(tail=200):
+def _docker_logs(tail=500):
     """Read recent container log lines via docker logs."""
     result = subprocess.run(
         ["docker", "logs", "--tail", str(tail), CONTAINER],
@@ -124,18 +124,40 @@ def main():
     time.sleep(15)
     wait_until_running(timeout=120, label="server after reload")
 
-    print("\n[4] /dpm list — expect '=== Plugins'...")
+    print("\n[4] /dpm list — confirm plugin loaded and command routes correctly...")
     send_command("dpm list")
     assert_log_contains("=== Plugins")
 
-    print("\n[5] /dpm get medievalfactions — expect download confirmation...")
-    send_command("dpm get medievalfactions")
-    # "Downloaded" on first run; "already up to date" on subsequent runs
+    # Test dependency auto-install: currencies hard-depends on medievalfactions, which is
+    # not yet installed. DPM should detect this and download medievalfactions automatically.
+    print("\n[5] /dpm get currencies — confirm hard-dependency auto-install...")
+    send_command("dpm get currencies")
+    assert_log_contains("Also downloading required dependency", retries=3, delay=3)
     assert_log_contains_any(["Downloaded", "already up to date"], retries=8, delay=5)
 
-    print("\n[6] /dpm search faction — expect '=== Search Results'...")
+    print("\n[6] /dpm remove medievalfactions --confirm — confirm file deletion...")
+    send_command("dpm remove medievalfactions --confirm")
+    assert_log_contains("Removed MedievalFactions")
+
+    print("\n[7] /dpm list installed — confirm filter shows only installed plugins...")
+    send_command("dpm list installed")
+    assert_log_contains("=== Installed Plugins")
+
+    print("\n[8] /dpm list available — confirm filter shows only uninstalled plugins...")
+    send_command("dpm list available")
+    assert_log_contains("=== Available Plugins")
+
+    print("\n[9] /dpm get medievalfactions — confirm standard download...")
+    send_command("dpm get medievalfactions")
+    assert_log_contains_any(["Downloaded", "already up to date"], retries=8, delay=5)
+
+    print("\n[10] /dpm search faction — confirm registry search...")
     send_command("dpm search faction")
     assert_log_contains("=== Search Results")
+
+    print("\n[11] /dpm get nonexistentplugin — confirm error path...")
+    send_command("dpm get nonexistentplugin")
+    assert_log_contains("Plugin not found: nonexistentplugin")
 
     print("\n=== All integration tests passed ===")
 

--- a/integration-test/test_dpm.py
+++ b/integration-test/test_dpm.py
@@ -5,14 +5,16 @@ Deploys the DPM JAR to a live OMCSI Spigot server via REST API and
 asserts that key commands produce the expected console output.
 
 Required environment variables:
-  OMCSI_DEPLOY_TOKEN  Bearer token accepted by the OMCSI REST API
-  DPM_JAR_PATH        Path to the built DansPluginManager-*.jar
+  OMCSI_DEPLOY_TOKEN    Bearer token accepted by the OMCSI REST API
+  DPM_JAR_PATH          Path to the built DansPluginManager-*.jar
 
 Optional:
-  OMCSI_API_BASE      Base URL of the OMCSI REST API (default: http://localhost:8092)
+  OMCSI_API_BASE        Base URL of the OMCSI REST API (default: http://localhost:8092)
+  OMCSI_CONTAINER_NAME  Docker container name for log reading (default: open-mc-server)
 """
 
 import os
+import subprocess
 import sys
 import time
 
@@ -21,6 +23,7 @@ import requests
 API_BASE = os.getenv("OMCSI_API_BASE", "http://localhost:8092")
 TOKEN = os.environ["OMCSI_DEPLOY_TOKEN"]
 JAR_PATH = os.environ["DPM_JAR_PATH"]
+CONTAINER = os.getenv("OMCSI_CONTAINER_NAME", "open-mc-server")
 
 _HEADERS = {"Authorization": f"Bearer {TOKEN}"}
 
@@ -53,27 +56,32 @@ def send_command(cmd):
     print(f"  > {cmd}")
 
 
-def _log_tail(lines=100):
-    data = _api("GET", f"/api/server/logs?lines={lines}").json()
-    return "\n".join(data.get("lines", []))
+def _docker_logs(tail=200):
+    """Read recent container log lines via docker logs."""
+    result = subprocess.run(
+        ["docker", "logs", "--tail", str(tail), CONTAINER],
+        capture_output=True, text=True, timeout=15,
+    )
+    # Minecraft server output may appear on either stream depending on the wrapper
+    return result.stdout + result.stderr
 
 
-def assert_log_contains(expected, lines=100, retries=6, delay=5):
+def assert_log_contains(expected, tail=200, retries=6, delay=5):
     for attempt in range(1, retries + 1):
-        if expected in _log_tail(lines):
+        if expected in _docker_logs(tail):
             print(f"  PASS: found {expected!r}")
             return
         if attempt < retries:
             print(f"  attempt {attempt}: {expected!r} not in logs yet, retrying in {delay}s...")
             time.sleep(delay)
-    print("--- log tail ---")
-    print(_log_tail(lines))
+    print("--- last container logs ---")
+    print(_docker_logs(tail))
     sys.exit(f"FAIL: {expected!r} not found after {retries} attempts")
 
 
-def assert_log_contains_any(candidates, lines=100, retries=6, delay=5):
+def assert_log_contains_any(candidates, tail=200, retries=6, delay=5):
     for attempt in range(1, retries + 1):
-        log = _log_tail(lines)
+        log = _docker_logs(tail)
         for expected in candidates:
             if expected in log:
                 print(f"  PASS: found {expected!r}")
@@ -81,8 +89,8 @@ def assert_log_contains_any(candidates, lines=100, retries=6, delay=5):
         if attempt < retries:
             print(f"  attempt {attempt}: none of {candidates!r} in logs yet, retrying in {delay}s...")
             time.sleep(delay)
-    print("--- log tail ---")
-    print(_log_tail(lines))
+    print("--- last container logs ---")
+    print(_docker_logs(tail))
     sys.exit(f"FAIL: none of {candidates!r} found after {retries} attempts")
 
 

--- a/integration-test/test_dpm.py
+++ b/integration-test/test_dpm.py
@@ -145,7 +145,7 @@ def main():
 
     print("\n[6] /dpm remove medievalfactions --confirm — confirm file deletion...")
     cursor = send_command("dpm remove medievalfactions --confirm")
-    assert_log_contains("Removed MedievalFactions", cursor=cursor)
+    assert_log_contains("Removed medievalfactions", cursor=cursor)
 
     print("\n[7] /dpm list installed — confirm filter shows only installed plugins...")
     cursor = send_command("dpm list installed")


### PR DESCRIPTION
Closes #49

## Summary

- Adds `integration-test/test_dpm.py` — Python harness that deploys the DPM JAR to a live OMCSI Spigot server, reloads the server, then asserts that `dpm list`, `dpm get medievalfactions`, and `dpm search faction` produce the expected console output
- Adds `.github/workflows/integration.yml` — triggers on `workflow_dispatch` and nightly (`cron: 0 2 * * *`); checks out both repos, builds the JAR, configures OMCSI `.env` from secrets, caches Docker images, runs the harness, always tears down
- Adds `integration-test/README.md` — local run instructions and required CI secrets table
- Updates `CONTRIBUTING.md` with an Integration Tests section
- Updates `CHANGELOG.md` with an Unreleased entry

## Required secrets (add in repo settings before first run)

| Secret | Purpose |
|--------|---------|
| `OMCSI_GITHUB_TOKEN` | PAT with read access to `dmccoystephenson/omcsi` |
| `OMCSI_DEPLOY_TOKEN` | Bearer token for the OMCSI REST API |
| `OMCSI_RCON_PASSWORD` | RCON password |

## Test plan

- [ ] Add the three secrets above to repository settings
- [ ] Trigger the workflow manually via Actions → Integration Tests → Run workflow
- [ ] Confirm all six test steps pass in the workflow log
- [ ] Verify `docker compose down` runs even on failure (always block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_