### PR TITLE
Eliminate O(N) directory scans in CleanCommand and batch update/get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Tab-completion for `/dpm list` offers `installed` and `available`
 
 ### Changed
+- `PluginFolderService`: added `findAllConflictingJars(List<ProjectRecord>)` that does a single directory scan for any number of records; `CleanCommand` (preview and `--confirm`) now uses this instead of calling `findConflictingJars()` in a loop, reducing N scans to 1
+- `DownloadService`: added `downloadLatest(ProjectRecord, boolean physicallyInstalled)` overload; `UpdateCommand.runUpdates()` passes `true` since records are pre-confirmed installed via `filterInstalled()`, eliminating one `isInstalled()` scan per plugin per update run
 - `GitHubReleaseService`: extracted `parseStringField` to eliminate duplicated JSON-parsing logic shared by `parseTagName` and `parsePublishedAt`
 - Removed remaining multi-line Javadoc blocks from `GitHubReleaseService`, `DownloadService`, and `StatsCommand`; kept non-obvious algorithm notes as single `//` lines
 - `UpdateCommand` selective path replaced per-plugin `isInstalled()` calls with a single `filterInstalled()` scan

--- a/src/main/java/dansplugins/dpm/commands/CleanCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/CleanCommand.java
@@ -1,7 +1,6 @@
 package dansplugins.dpm.commands;
 
 import dansplugins.dpm.data.EphemeralData;
-import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.services.PluginFolderService;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -12,6 +11,7 @@ import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class CleanCommand extends AbstractPluginCommand {
     private final EphemeralData ephemeralData;
@@ -29,12 +29,8 @@ public class CleanCommand extends AbstractPluginCommand {
     public boolean execute(CommandSender sender) {
         sender.sendMessage(ChatColor.AQUA + "Scanning for duplicate plugin JARs...");
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            List<String> conflicts = new ArrayList<>();
-            for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
-                for (File conflict : pluginFolderService.findConflictingJars(record)) {
-                    conflicts.add(conflict.getName() + " (" + record.getName() + ")");
-                }
-            }
+            List<String> conflicts = buildConflictLabels(
+                    pluginFolderService.findAllConflictingJars(ephemeralData.getAllProjectRecords()));
             Bukkit.getScheduler().runTask(plugin, () -> {
                 if (conflicts.isEmpty()) {
                     sender.sendMessage(ChatColor.GREEN + "No duplicate JARs found.");
@@ -55,11 +51,14 @@ public class CleanCommand extends AbstractPluginCommand {
         if (args.length > 0 && args[0].equalsIgnoreCase("--confirm")) {
             sender.sendMessage(ChatColor.AQUA + "Removing duplicate plugin JARs...");
             Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+                Map<String, List<File>> conflictMap =
+                        pluginFolderService.findAllConflictingJars(ephemeralData.getAllProjectRecords());
                 List<String> removed = new ArrayList<>();
                 List<String> failed = new ArrayList<>();
-                for (ProjectRecord record : ephemeralData.getAllProjectRecords()) {
-                    for (File conflict : pluginFolderService.findConflictingJars(record)) {
-                        String label = conflict.getName() + " (" + record.getName() + ")";
+                for (Map.Entry<String, List<File>> entry : conflictMap.entrySet()) {
+                    String pluginName = entry.getKey();
+                    for (File conflict : entry.getValue()) {
+                        String label = conflict.getName() + " (" + pluginName + ")";
                         if (conflict.delete()) {
                             removed.add(label);
                         } else {
@@ -90,5 +89,15 @@ public class CleanCommand extends AbstractPluginCommand {
             return true;
         }
         return execute(sender);
+    }
+
+    private List<String> buildConflictLabels(Map<String, List<File>> conflictMap) {
+        List<String> labels = new ArrayList<>();
+        for (Map.Entry<String, List<File>> entry : conflictMap.entrySet()) {
+            for (File f : entry.getValue()) {
+                labels.add(f.getName() + " (" + entry.getKey() + ")");
+            }
+        }
+        return labels;
     }
 }

--- a/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
@@ -94,7 +94,7 @@ public class UpdateCommand extends AbstractPluginCommand {
         int failed = 0;
 
         for (ProjectRecord record : records) {
-            int result = downloadService.downloadLatest(record);
+            int result = downloadService.downloadLatest(record, true);
             final String msg;
             if (result == DownloadService.ALREADY_UP_TO_DATE) {
                 upToDate++;

--- a/src/main/java/dansplugins/dpm/services/DownloadService.java
+++ b/src/main/java/dansplugins/dpm/services/DownloadService.java
@@ -31,6 +31,12 @@ public class DownloadService {
     }
 
     public int downloadLatest(ProjectRecord projectRecord) {
+        return downloadLatest(projectRecord, pluginFolderService.isInstalled(projectRecord));
+    }
+
+    // physicallyInstalled lets callers that have already confirmed the JAR is present (e.g. via
+    // filterInstalled()) skip the per-call isInstalled() directory scan.
+    public int downloadLatest(ProjectRecord projectRecord, boolean physicallyInstalled) {
         ReleaseInfo release = gitHubReleaseService.getLatestRelease(projectRecord.getOwner(), projectRecord.getRepo());
         if (release == ReleaseInfo.NO_RELEASE) {
             return NO_RELEASE;
@@ -43,7 +49,7 @@ public class DownloadService {
         String latestTag = release.getTagName();
         if (latestTag != null
                 && latestTag.equals(versionStore.getStoredTag(projectRecord.getName()))
-                && pluginFolderService.isInstalled(projectRecord)) {
+                && physicallyInstalled) {
             return ALREADY_UP_TO_DATE;
         }
 

--- a/src/main/java/dansplugins/dpm/services/PluginFolderService.java
+++ b/src/main/java/dansplugins/dpm/services/PluginFolderService.java
@@ -5,7 +5,9 @@ import dansplugins.dpm.objects.ProjectRecord;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class PluginFolderService {
@@ -68,6 +70,27 @@ public class PluginFolderService {
             }
         }
         return conflicts;
+    }
+
+    public Map<String, List<File>> findAllConflictingJars(List<ProjectRecord> records) {
+        Map<String, List<File>> result = new LinkedHashMap<>();
+        File pluginsDir = new File(pluginsFolder);
+        File[] jars = pluginsDir.listFiles((dir, name) -> name.toLowerCase().endsWith(".jar"));
+        if (jars == null) return result;
+        for (ProjectRecord record : records) {
+            String managedFilename = record.getName() + ".jar";
+            List<File> conflicts = new ArrayList<>();
+            for (File jar : jars) {
+                if (jar.getName().equalsIgnoreCase(managedFilename)) continue;
+                if (normalize(jar.getName()).equals(record.getName())) {
+                    conflicts.add(jar);
+                }
+            }
+            if (!conflicts.isEmpty()) {
+                result.put(record.getName(), conflicts);
+            }
+        }
+        return result;
     }
 
     // strips .jar, trailing version suffix (-4.6.3, -v1.0), hyphens/underscores, lowercases

--- a/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
@@ -137,6 +137,56 @@ class DownloadServiceTest {
     }
 
     // -------------------------------------------------------------------------
+    // downloadLatest(record, physicallyInstalled)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void downloadLatest_withTrueHint_returnsAlreadyUpToDate_withoutDirectoryScan(@TempDir Path tempDir) {
+        VersionStore versionStore = versionStore(tempDir);
+        versionStore.setTag("testplugin", "v1.0.0");
+
+        // PluginFolderService with a non-existent folder — isInstalled() would return false
+        // if called, but the hint bypasses the scan entirely.
+        PluginFolderService noScanService = new PluginFolderService("/this/path/does/not/exist");
+        DownloadService svc = new DownloadService(null, fakeRelease("v1.0.0", "http://unused"),
+                noScanService, versionStore);
+
+        ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
+        assertEquals(DownloadService.ALREADY_UP_TO_DATE, svc.downloadLatest(record, true));
+    }
+
+    @Test
+    void downloadLatest_withFalseHint_downloadsEvenWhenTagMatches(@TempDir Path tempDir) throws IOException {
+        VersionStore versionStore = versionStore(tempDir);
+        versionStore.setTag("testplugin", "v1.0.0");
+
+        File src = tempDir.resolve("source.jar").toFile();
+        Files.write(src.toPath(), new byte[]{1, 2, 3});
+
+        PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
+        DownloadService svc = new DownloadService(null, fakeRelease("v1.0.0", src.toURI().toString()),
+                pluginFolderService, versionStore);
+
+        ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
+        assertTrue(svc.downloadLatest(record, false) > 0,
+                "physicallyInstalled=false must trigger download even when tag matches");
+    }
+
+    @Test
+    void downloadLatest_noArgOverload_callsIsInstalledViaScan(@TempDir Path tempDir) throws IOException {
+        VersionStore versionStore = versionStore(tempDir);
+        versionStore.setTag("testplugin", "v1.0.0");
+        Files.write(tempDir.resolve("testplugin.jar"), new byte[]{1});
+
+        PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
+        DownloadService svc = new DownloadService(null, fakeRelease("v1.0.0", "http://unused"),
+                pluginFolderService, versionStore);
+
+        ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
+        assertEquals(DownloadService.ALREADY_UP_TO_DATE, svc.downloadLatest(record));
+    }
+
+    // -------------------------------------------------------------------------
     // helpers
     // -------------------------------------------------------------------------
 

--- a/src/test/java/dansplugins/dpm/services/PluginFolderServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/PluginFolderServiceTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -301,6 +302,84 @@ class PluginFolderServiceTest {
         PluginFolderService svc = new PluginFolderService(tempDir.toString() + "/");
         ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
         assertNotNull(svc.getInstalledFile(record));
+    }
+
+    // -------------------------------------------------------------------------
+    // findAllConflictingJars()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void findAllConflictingJars_returnsConflictsForAffectedPlugin(@TempDir Path tempDir) throws IOException {
+        createFile(tempDir, "Medieval-Factions-4.6.3.jar");
+        createFile(tempDir, "medievalfactions.jar");
+
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        List<ProjectRecord> records = List.of(
+                ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions"),
+                ProjectRecord.forGitHub("currencies", "Dans-Plugins", "Currencies")
+        );
+
+        Map<String, List<File>> result = svc.findAllConflictingJars(records);
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey("medievalfactions"));
+        assertEquals(1, result.get("medievalfactions").size());
+        assertEquals("Medieval-Factions-4.6.3.jar", result.get("medievalfactions").get(0).getName());
+    }
+
+    @Test
+    void findAllConflictingJars_emptyWhenNoConflicts(@TempDir Path tempDir) throws IOException {
+        createFile(tempDir, "medievalfactions.jar");
+
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        List<ProjectRecord> records = List.of(
+                ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions")
+        );
+
+        assertTrue(svc.findAllConflictingJars(records).isEmpty());
+    }
+
+    @Test
+    void findAllConflictingJars_handlesMultiplePluginsWithConflicts(@TempDir Path tempDir) throws IOException {
+        createFile(tempDir, "Medieval-Factions-4.6.3.jar");
+        createFile(tempDir, "medievalfactions.jar");
+        createFile(tempDir, "Currencies-2.1.jar");
+        createFile(tempDir, "currencies.jar");
+
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        List<ProjectRecord> records = List.of(
+                ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions"),
+                ProjectRecord.forGitHub("currencies", "Dans-Plugins", "Currencies")
+        );
+
+        Map<String, List<File>> result = svc.findAllConflictingJars(records);
+        assertEquals(2, result.size());
+        assertEquals(1, result.get("medievalfactions").size());
+        assertEquals(1, result.get("currencies").size());
+    }
+
+    @Test
+    void findAllConflictingJars_emptyFolder(@TempDir Path tempDir) {
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        List<ProjectRecord> records = List.of(
+                ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions")
+        );
+        assertTrue(svc.findAllConflictingJars(records).isEmpty());
+    }
+
+    @Test
+    void findAllConflictingJars_nonExistentFolderReturnsEmpty() {
+        PluginFolderService svc = new PluginFolderService("/this/path/does/not/exist");
+        List<ProjectRecord> records = List.of(
+                ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions")
+        );
+        assertTrue(svc.findAllConflictingJars(records).isEmpty());
+    }
+
+    @Test
+    void findAllConflictingJars_emptyInputReturnsEmpty(@TempDir Path tempDir) throws IOException {
+        createFile(tempDir, "Medieval-Factions-4.6.3.jar");
+        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        assertTrue(svc.findAllConflictingJars(List.of()).isEmpty());
     }
 
     private void createFile(Path dir, String name) throws IOException {


### PR DESCRIPTION
## Summary

- **`CleanCommand` O(N) scan fix (#62)**: Added `PluginFolderService.findAllConflictingJars(List<ProjectRecord>)` which does a single `listFiles()` scan for any number of records. `CleanCommand` (both the preview path and the `--confirm` path) now calls this instead of calling `findConflictingJars()` in a loop, reducing 28 directory scans to 1 for a typical DPC server.

- **`DownloadService` per-call scan fix (#63)**: Added `downloadLatest(ProjectRecord, boolean physicallyInstalled)` overload. When callers have already confirmed a plugin is installed via `filterInstalled()`, they pass `true` to skip the per-call `isInstalled()` directory scan. `UpdateCommand.runUpdates()` uses this overload since its records are pre-confirmed installed. The existing no-arg `downloadLatest(ProjectRecord)` delegates to this overload (calls `isInstalled()` as before), so `GetCommand` and other callers are unchanged.

Both fixes follow the same pattern as the existing `isInstalled()` → `filterInstalled()` refactors already applied to `UpdateCommand.executeSelective()` and `ListCommand`.

## Test plan

- [x] `mvn test` — all 131 tests pass
- [x] `findAllConflictingJars()` covered: multi-plugin conflicts, no conflicts, empty folder, non-existent folder, empty input
- [x] `downloadLatest(record, true)` covered: short-circuits to ALREADY_UP_TO_DATE without scanning; `false` hint downloads even when tag matches; no-arg overload behavior preserved

Closes #62
Closes #63

---

_drafted by Claude on behalf of Daniel Stephenson_