### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-17
+
 ### Added
 - Docker-based integration test CI (`integration-test/test_dpm.py` + `.github/workflows/integration.yml`) that spins up an OMCSI Spigot stack, deploys DPM, and asserts `dpm list`, `dpm get`, and `dpm search` produce the expected output; runs on workflow dispatch and nightly schedule
 - `/dpm get` now auto-downloads missing hard dependencies that are registered DPC plugins before downloading the requested plugin(s); transitive dependencies are resolved recursively and circular chains are handled safely. Dependencies that are not registered DPC plugins still produce a warning.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dansplugins</groupId>
     <artifactId>DansPluginManager</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
     <packaging>jar</packaging>
 
     <name>Dan's Plugin Manager</name>


### PR DESCRIPTION
## Summary
- Bumps version to `0.5.0` in `pom.xml`
- Promotes the `[Unreleased]` changelog block to `[0.5.0] - 2026-05-17`

## Test plan
- [ ] Verify `mvn clean package` succeeds
- [ ] Confirm `pom.xml` version reads `0.5.0`
- [ ] Confirm `CHANGELOG.md` has a `[0.5.0]` entry dated 2026-05-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_