### PR TITLE
UX polish: stats available count, list descriptions, remove reinstall hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+- `/dpm stats` now shows available plugin count (registered minus installed) as a third stat line
+- `/dpm list available` now appends each plugin's description after its name, separated by an em-dash
+- `/dpm remove <plugin-name> --confirm` now prints a reinstall hint (`/dpm get <name>`) after the removal success message
+
 ## [0.5.0] - 2026-05-17
 
 ### Added

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -25,6 +25,7 @@ These tests exercise the full stack: Maven build → JAR deploy → Spigot reloa
 | 9 | `dpm get medievalfactions` | `Downloaded` or `already up to date` — confirms real GitHub API call and file write |
 | 10 | `dpm search faction` | `=== Search Results` — confirms registry search |
 | 11 | `dpm get nonexistentplugin` | `Plugin not found: nonexistentplugin` — confirms error path doesn't crash the server |
+| 12 | `dpm stats` | `Available plugins:` — confirms available count line renders after 0.6.0 stat addition |
 
 ## What is not yet covered
 
@@ -33,7 +34,6 @@ These tests exercise the full stack: Maven build → JAR deploy → Spigot reloa
 | `dpm update` / `dpm update <name>` | Exercises the same download path as `dpm get` but with version comparison; low incremental value |
 | `dpm clean [--confirm]` | Requires duplicate JARs to be present; hard to set up reliably in CI |
 | `dpm info <name>` | Mainly a display command; low regression risk |
-| `dpm stats` | Low regression risk |
 | `dpm reload` | Would confirm `githubToken` config reloads without server restart |
 | `dpm get <multiple names>` | Batch mode not tested; same download code path as single |
 | Permission enforcement | Console has all permissions; player-level permission checks cannot be exercised without a player login |

--- a/integration-test/test_dpm.py
+++ b/integration-test/test_dpm.py
@@ -167,6 +167,10 @@ def main():
     cursor = send_command("dpm get nonexistentplugin")
     assert_log_contains("Plugin not found: nonexistentplugin", cursor=cursor)
 
+    print("\n[12] /dpm stats — confirm stats output includes available plugin count...")
+    cursor = send_command("dpm stats")
+    assert_log_contains("Available plugins:", cursor=cursor)
+
     print("\n=== All integration tests passed ===")
 
 

--- a/src/main/java/dansplugins/dpm/commands/ListCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/ListCommand.java
@@ -82,7 +82,9 @@ public class ListCommand extends AbstractPluginCommand {
         }
         sender.sendMessage(ChatColor.AQUA + "=== Available Plugins (" + available.size() + ") ===");
         for (ProjectRecord record : available) {
-            sender.sendMessage(ChatColor.GRAY + record.getName());
+            String desc = record.getDescription();
+            String suffix = desc != null ? ChatColor.DARK_GRAY + " — " + desc : "";
+            sender.sendMessage(ChatColor.GRAY + record.getName() + suffix);
         }
         return true;
     }

--- a/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
@@ -54,6 +54,7 @@ public class RemoveCommand extends AbstractPluginCommand {
             versionStore.removeTag(record.getName());
             sender.sendMessage(ChatColor.GREEN + "Removed " + record.getName() + ".");
             sender.sendMessage(ChatColor.YELLOW + "Restart the server for the removal to take effect.");
+            sender.sendMessage(ChatColor.YELLOW + "To reinstall, run " + ChatColor.WHITE + "/dpm get " + record.getName() + ChatColor.YELLOW + ".");
         } else {
             sender.sendMessage(ChatColor.RED + "Failed to delete " + jar.getName() + ". Check server file permissions.");
         }

--- a/src/main/java/dansplugins/dpm/commands/StatsCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/StatsCommand.java
@@ -21,10 +21,13 @@ public class StatsCommand extends AbstractPluginCommand {
 
     @Override
     public boolean execute(CommandSender commandSender) {
+        int total = ephemeralData.getNumProjectRecords();
         int installed = pluginFolderService.filterInstalled(ephemeralData.getAllProjectRecords()).size();
+        int available = total - installed;
         commandSender.sendMessage(ChatColor.AQUA + "=== DPM Stats ===");
-        commandSender.sendMessage(ChatColor.AQUA + "Registered plugins: " + ephemeralData.getNumProjectRecords());
+        commandSender.sendMessage(ChatColor.AQUA + "Registered plugins: " + total);
         commandSender.sendMessage(ChatColor.AQUA + "Installed plugins: " + installed);
+        commandSender.sendMessage(ChatColor.AQUA + "Available plugins: " + available);
         return true;
     }
 


### PR DESCRIPTION
## Summary

- `/dpm stats` now shows a third stat line: **Available plugins** (registered minus installed), resolving #72
- `/dpm list available` appends each plugin's description after its name (e.g. `activitytracker — Logs player activity...`), resolving #68
- `/dpm remove <name> --confirm` now prints a reinstall hint (`/dpm get <name>`) after the removal success message, resolving #69
- Integration test step [12] asserts the new `Available plugins:` line in stats output; README coverage table updated

## Test plan

- [x] `mvn test` — 131 tests, all pass
- [x] `StatsCommand` output verified: three lines (Registered, Installed, Available)
- [x] `ListCommand.executeAvailable()` verified: description appended when present, null-safe
- [x] `RemoveCommand` verified: reinstall hint only appears after `--confirm` path succeeds
- [x] Integration test step [12] added for stats `Available plugins:` assertion

Closes #68
Closes #69
Closes #72

---

_drafted by Claude on behalf of Daniel Stephenson_