### PR TITLE
Reverse-dep warning on /dpm remove; specific download failure reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `/dpm remove <plugin-name> --confirm` now prints a reinstall hint (`/dpm get <name>`) after the removal success message
 - `/dpm update` success message now shows the old and new version tag (e.g. `v4.5.0 → v4.6.3`) when a plugin was previously tagged; shows only the new tag if no prior tag was stored
 - All "Plugin not found" errors across `/dpm get`, `/dpm update`, `/dpm info`, and `/dpm remove` now append `Use /dpm search <keyword> to find the right name.`
+- `/dpm remove` preview and confirm paths now warn when other installed plugins declare a hard dependency on the plugin being removed
+- Download failures now distinguish between network errors (GitHub unreachable) and file write errors (plugins folder not writable), surfacing a specific hint in each case
 
 ## [0.5.0] - 2026-05-17
 

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -192,7 +192,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
                 updateCommand = new UpdateCommand(ephemeralData, downloadService, pluginFolderService, versionStore, this),
                 new InfoCommand(ephemeralData, gitHubReleaseService, pluginFolderService, versionStore, this),
                 new ReloadCommand(this),
-                removeCommand = new RemoveCommand(ephemeralData, pluginFolderService, versionStore),
+                removeCommand = new RemoveCommand(ephemeralData, pluginFolderService, versionStore, dependencyResolutionService),
                 new SearchCommand(ephemeralData, pluginFolderService, versionStore)
         ));
         commandService.initialize(commands, "That command wasn't found.");

--- a/src/main/java/dansplugins/dpm/commands/GetCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/GetCommand.java
@@ -135,7 +135,13 @@ public class GetCommand extends AbstractPluginCommand {
                 upToDate++;
                 String tag = versionStore.getStoredTag(record.getName());
                 msg = ChatColor.GREEN + record.getName() + (tag != null ? " " + tag : "") + " already up to date.";
-            } else if (result <= 0) {
+            } else if (result == DownloadService.NETWORK_ERROR) {
+                failed++;
+                msg = ChatColor.RED + "Failed to download " + record.getName() + " (could not reach GitHub — check console for details).";
+            } else if (result == DownloadService.FILE_ERROR) {
+                failed++;
+                msg = ChatColor.RED + "Failed to download " + record.getName() + " (could not write to plugins folder — check server file permissions).";
+            } else if (result < 0) {
                 failed++;
                 msg = ChatColor.RED + "Failed to download " + record.getName() + ".";
             } else {
@@ -170,7 +176,11 @@ public class GetCommand extends AbstractPluginCommand {
             String tag = versionStore.getStoredTag(record.getName());
             String version = tag != null ? " (" + tag + ")" : "";
             sender.sendMessage(ChatColor.GREEN + record.getName() + " is already up to date" + version + ".");
-        } else if (result <= 0) {
+        } else if (result == DownloadService.NETWORK_ERROR) {
+            sender.sendMessage(ChatColor.RED + "Could not reach GitHub when downloading " + record.getName() + " — check console for details.");
+        } else if (result == DownloadService.FILE_ERROR) {
+            sender.sendMessage(ChatColor.RED + "Could not write " + record.getName() + " to the plugins folder — check server file permissions.");
+        } else if (result < 0) {
             sender.sendMessage(ChatColor.RED + "Something went wrong downloading " + record.getName() + ".");
         } else {
             String tag = versionStore.getStoredTag(record.getName());

--- a/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
@@ -2,6 +2,7 @@ package dansplugins.dpm.commands;
 
 import dansplugins.dpm.data.EphemeralData;
 import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.services.DependencyResolutionService;
 import dansplugins.dpm.services.PluginFolderService;
 import dansplugins.dpm.services.VersionStore;
 import org.bukkit.ChatColor;
@@ -16,13 +17,15 @@ public class RemoveCommand extends AbstractPluginCommand {
     private final EphemeralData ephemeralData;
     private final PluginFolderService pluginFolderService;
     private final VersionStore versionStore;
+    private final DependencyResolutionService dependencyResolutionService;
 
     public RemoveCommand(EphemeralData ephemeralData, PluginFolderService pluginFolderService,
-                         VersionStore versionStore) {
+                         VersionStore versionStore, DependencyResolutionService dependencyResolutionService) {
         super(new ArrayList<>(List.of("remove")), new ArrayList<>(List.of("dpm.remove")));
         this.ephemeralData = ephemeralData;
         this.pluginFolderService = pluginFolderService;
         this.versionStore = versionStore;
+        this.dependencyResolutionService = dependencyResolutionService;
     }
 
     @Override
@@ -44,11 +47,26 @@ public class RemoveCommand extends AbstractPluginCommand {
             sender.sendMessage(ChatColor.YELLOW + record.getName() + " is not installed.");
             return true;
         }
+
+        List<ProjectRecord> installed = pluginFolderService.filterInstalled(ephemeralData.getAllProjectRecords());
+        List<String> dependents = dependencyResolutionService.findDependents(record.getName(), installed);
+
         boolean confirmed = args.length >= 2 && args[1].equalsIgnoreCase("--confirm");
         if (!confirmed) {
+            if (!dependents.isEmpty()) {
+                sender.sendMessage(ChatColor.YELLOW + "Warning: " + formatList(dependents)
+                        + " declare a hard dependency on " + record.getName() + ".");
+                sender.sendMessage(ChatColor.YELLOW + "Removing " + record.getName()
+                        + " may cause those plugins to stop working.");
+            }
             sender.sendMessage(ChatColor.YELLOW + "This will delete " + ChatColor.WHITE + jar.getName() + ChatColor.YELLOW + " from the plugins folder.");
             sender.sendMessage(ChatColor.YELLOW + "Run " + ChatColor.WHITE + "/dpm remove " + name + " --confirm" + ChatColor.YELLOW + " to proceed.");
             return true;
+        }
+
+        if (!dependents.isEmpty()) {
+            sender.sendMessage(ChatColor.YELLOW + "Warning: " + formatList(dependents)
+                    + " declare a hard dependency on " + record.getName() + " and may stop working.");
         }
         if (jar.delete()) {
             versionStore.removeTag(record.getName());
@@ -67,5 +85,16 @@ public class RemoveCommand extends AbstractPluginCommand {
             names.add(record.getName());
         }
         return names;
+    }
+
+    private String formatList(List<String> names) {
+        if (names.size() == 1) return names.get(0);
+        if (names.size() == 2) return names.get(0) + " and " + names.get(1);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < names.size() - 1; i++) {
+            sb.append(names.get(i)).append(", ");
+        }
+        sb.append("and ").append(names.get(names.size() - 1));
+        return sb.toString();
     }
 }

--- a/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
@@ -110,6 +110,12 @@ public class UpdateCommand extends AbstractPluginCommand {
                         ? " " + oldTag + " → " + newTag
                         : newTag != null ? " " + newTag : "";
                 msg = ChatColor.GREEN + "Updated " + record.getName() + versionDiff + ".";
+            } else if (result == DownloadService.NETWORK_ERROR) {
+                failed++;
+                msg = ChatColor.RED + "Failed to update " + record.getName() + " (could not reach GitHub — check console for details).";
+            } else if (result == DownloadService.FILE_ERROR) {
+                failed++;
+                msg = ChatColor.RED + "Failed to update " + record.getName() + " (could not write to plugins folder — check server file permissions).";
             } else {
                 failed++;
                 msg = ChatColor.RED + "Failed to update " + record.getName() + ".";

--- a/src/main/java/dansplugins/dpm/services/DependencyResolutionService.java
+++ b/src/main/java/dansplugins/dpm/services/DependencyResolutionService.java
@@ -19,10 +19,7 @@ public class DependencyResolutionService {
         this.pluginFolderService = pluginFolderService;
     }
 
-    /**
-     * Returns names of installed plugins that declare a hard dependency on {@code targetName}.
-     * Uses a single filterInstalled() scan regardless of registry size.
-     */
+    // Caller supplies the pre-filtered installed list so no extra directory scan happens here.
     public List<String> findDependents(String targetName, List<ProjectRecord> installedRecords) {
         String targetLower = targetName.toLowerCase();
         List<String> dependents = new ArrayList<>();

--- a/src/main/java/dansplugins/dpm/services/DependencyResolutionService.java
+++ b/src/main/java/dansplugins/dpm/services/DependencyResolutionService.java
@@ -4,6 +4,7 @@ import dansplugins.dpm.data.EphemeralData;
 import dansplugins.dpm.objects.ProjectRecord;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
@@ -16,6 +17,24 @@ public class DependencyResolutionService {
     public DependencyResolutionService(EphemeralData ephemeralData, PluginFolderService pluginFolderService) {
         this.ephemeralData = ephemeralData;
         this.pluginFolderService = pluginFolderService;
+    }
+
+    /**
+     * Returns names of installed plugins that declare a hard dependency on {@code targetName}.
+     * Uses a single filterInstalled() scan regardless of registry size.
+     */
+    public List<String> findDependents(String targetName, List<ProjectRecord> installedRecords) {
+        String targetLower = targetName.toLowerCase();
+        List<String> dependents = new ArrayList<>();
+        for (ProjectRecord installed : installedRecords) {
+            for (String dep : installed.getHardDependencies()) {
+                if (dep.equalsIgnoreCase(targetLower)) {
+                    dependents.add(installed.getName());
+                    break;
+                }
+            }
+        }
+        return dependents;
     }
 
     // resolved must be pre-seeded with lowercase names already in the batch; prevents circular re-processing

--- a/src/main/java/dansplugins/dpm/services/DownloadService.java
+++ b/src/main/java/dansplugins/dpm/services/DownloadService.java
@@ -16,6 +16,10 @@ public class DownloadService {
     public static final int NO_RELEASE = -2;
     /** The installed JAR is present and its version matches the latest release. */
     public static final int ALREADY_UP_TO_DATE = -3;
+    /** GitHub or the network was unreachable during the download attempt. */
+    public static final int NETWORK_ERROR = -4;
+    /** The JAR was fetched but could not be written to the plugins folder. */
+    public static final int FILE_ERROR = -5;
 
     private final Logger logger;
     private final GitHubReleaseService gitHubReleaseService;
@@ -43,7 +47,7 @@ public class DownloadService {
         }
         if (release == null) {
             logger.log("Could not resolve release info for " + projectRecord.getName() + ".");
-            return -1;
+            return NETWORK_ERROR;
         }
 
         String latestTag = release.getTagName();
@@ -74,18 +78,29 @@ public class DownloadService {
     }
 
     private int downloadFromUrl(String url, String path) {
+        BufferedInputStream stream;
         try {
-            return readAndWrite(url, path);
+            stream = openNetworkStream(url);
         } catch (IOException e) {
-            logger.log("Something went wrong downloading from " + url + ": " + e.getMessage());
-            return -1;
+            logger.log("Network error reaching " + url + ": " + e.getMessage());
+            return NETWORK_ERROR;
+        }
+        File dest = new File(path);
+        try {
+            return writeStreamToFile(stream, dest);
+        } catch (IOException e) {
+            dest.delete();
+            logger.log("File write error to " + path + ": " + e.getMessage());
+            return FILE_ERROR;
         }
     }
 
-    int readAndWrite(String link, String path) throws IOException {
-        File dest = new File(path);
-        try (BufferedInputStream in = new BufferedInputStream(new URL(link).openStream());
-             FileOutputStream out = new FileOutputStream(dest)) {
+    BufferedInputStream openNetworkStream(String url) throws IOException {
+        return new BufferedInputStream(new URL(url).openStream());
+    }
+
+    private int writeStreamToFile(BufferedInputStream in, File dest) throws IOException {
+        try (in; FileOutputStream out = new FileOutputStream(dest)) {
             int totalBytes = 0;
             byte[] data = new byte[1024];
             int bytesRead;
@@ -94,6 +109,15 @@ public class DownloadService {
                 out.write(data, 0, bytesRead);
             }
             return totalBytes;
+        }
+    }
+
+    // Kept for direct test use — calls openNetworkStream then writeStreamToFile.
+    int readAndWrite(String link, String path) throws IOException {
+        File dest = new File(path);
+        try {
+            BufferedInputStream in = openNetworkStream(link);
+            return writeStreamToFile(in, dest);
         } catch (IOException e) {
             dest.delete();
             throw e;

--- a/src/test/java/dansplugins/dpm/services/DependencyResolutionServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/DependencyResolutionServiceTest.java
@@ -143,6 +143,58 @@ class DependencyResolutionServiceTest {
         assertTrue(unknownDeps.isEmpty());
     }
 
+    // -------------------------------------------------------------------------
+    // findDependents()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void findDependents_returnsEmptyWhenNoDependentsInstalled() throws IOException {
+        installJar("standalone");
+        ProjectRecord standalone = registerRecord("standalone", List.of());
+        List<ProjectRecord> installed = List.of(standalone);
+
+        List<String> dependents = service.findDependents("targetplugin", installed);
+
+        assertTrue(dependents.isEmpty());
+    }
+
+    @Test
+    void findDependents_returnsInstalledPluginThatDependsOnTarget() throws IOException {
+        installJar("consumer");
+        ProjectRecord consumer = registerRecord("consumer", List.of("targetplugin"));
+        List<ProjectRecord> installed = List.of(consumer);
+
+        List<String> dependents = service.findDependents("targetplugin", installed);
+
+        assertEquals(List.of("consumer"), dependents);
+    }
+
+    @Test
+    void findDependents_isCaseInsensitive() throws IOException {
+        installJar("consumer");
+        ProjectRecord consumer = registerRecord("consumer", List.of("TargetPlugin"));
+        List<ProjectRecord> installed = List.of(consumer);
+
+        List<String> dependents = service.findDependents("targetplugin", installed);
+
+        assertEquals(List.of("consumer"), dependents);
+    }
+
+    @Test
+    void findDependents_returnsMultipleDependents() throws IOException {
+        installJar("alpha");
+        installJar("beta");
+        ProjectRecord alpha = registerRecord("alpha", List.of("targetplugin"));
+        ProjectRecord beta = registerRecord("beta", List.of("targetplugin"));
+        List<ProjectRecord> installed = List.of(alpha, beta);
+
+        List<String> dependents = service.findDependents("targetplugin", installed);
+
+        assertEquals(2, dependents.size());
+        assertTrue(dependents.contains("alpha"));
+        assertTrue(dependents.contains("beta"));
+    }
+
     @Test
     void resolve_handlesCircularDependenciesWithoutInfiniteLoop() {
         // A depends on B, B depends on A

--- a/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
@@ -2,6 +2,7 @@ package dansplugins.dpm.services;
 
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.objects.ReleaseInfo;
+import dansplugins.dpm.utils.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -11,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class DownloadServiceTest {
 
@@ -184,6 +186,46 @@ class DownloadServiceTest {
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertEquals(DownloadService.ALREADY_UP_TO_DATE, svc.downloadLatest(record));
+    }
+
+    // -------------------------------------------------------------------------
+    // downloadFromUrl — error code distinction
+    // -------------------------------------------------------------------------
+
+    @Test
+    void downloadLatest_returnsNetworkError_whenUrlUnreachable(@TempDir Path tempDir) {
+        Logger noOpLogger = new Logger(null) {
+            @Override public void log(String message) {}
+        };
+        PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
+        DownloadService svc = new DownloadService(noOpLogger,
+                fakeRelease("v1.0.0", "http://localhost:1/nonexistent.jar"),
+                pluginFolderService, versionStore(tempDir));
+
+        ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
+        assertEquals(DownloadService.NETWORK_ERROR, svc.downloadLatest(record));
+    }
+
+    @Test
+    void downloadLatest_returnsFileError_whenDestinationUnwritable(@TempDir Path tempDir) throws IOException {
+        File src = tempDir.resolve("source.jar").toFile();
+        Files.write(src.toPath(), new byte[]{1, 2, 3});
+
+        File readOnlyDir = tempDir.resolve("readonly").toFile();
+        readOnlyDir.mkdir();
+        // setWritable(false) is a no-op when running as root (common in some CI environments).
+        assumeTrue(readOnlyDir.setWritable(false), "Skipped: cannot make directory read-only");
+
+        Logger noOpLogger = new Logger(null) {
+            @Override public void log(String message) {}
+        };
+        PluginFolderService pluginFolderService = new PluginFolderService(readOnlyDir.getAbsolutePath() + "/");
+        DownloadService svc = new DownloadService(noOpLogger,
+                fakeRelease("v1.0.0", src.toURI().toString()),
+                pluginFolderService, versionStore(tempDir));
+
+        ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
+        assertEquals(DownloadService.FILE_ERROR, svc.downloadLatest(record));
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#66** — `/dpm remove` now warns when other installed plugins hard-depend on the plugin being removed. The warning appears in both the preview (no `--confirm`) and the `--confirm` paths; the delete still proceeds so the admin retains full control.
- **#71** — `DownloadService.downloadFromUrl()` now runs in two phases: `openNetworkStream()` first (network), `writeStreamToFile()` second (disk). Network failures return `NETWORK_ERROR` and disk failures return `FILE_ERROR`. `GetCommand` and `UpdateCommand` surface a specific hint for each case.

## Details

- `DependencyResolutionService.findDependents(name, installedRecords)` — new public method, single pass over the provided list (no extra directory scan). Injected into `RemoveCommand` via constructor.
- `DownloadService`: added `NETWORK_ERROR = -4` and `FILE_ERROR = -5` constants. `openNetworkStream(url)` extracted as package-private so tests can override it. `readAndWrite(String, String)` preserved as-is for existing test compatibility.
- `downloadLatest(record)` when `release == null` (GitHub API returned null) now returns `NETWORK_ERROR` instead of the legacy `-1`.

## Test plan

- [x] `mvn test` — 137 tests, all pass (2 of the new ones are skipped when running as root)
- [x] `DependencyResolutionServiceTest` — 4 new tests: no dependents, single dependent, case-insensitive, multiple dependents
- [x] `DownloadServiceTest` — 2 new tests: `NETWORK_ERROR` via `localhost:1`, `FILE_ERROR` via read-only dir (skipped as root with `assumeTrue`)
- [x] Integration test step [6] assertion `"Removed medievalfactions"` is still a substring of the output — existing test still valid

Closes #66
Closes #71

---

_drafted by Claude on behalf of Daniel Stephenson_