### PR TITLE
Remove remaining multi-line Javadoc blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Removed
+- Multi-line Javadoc blocks from `HelpCommand`, `DansPluginManager`, `Logger`, and `TabCompleter` (CLAUDE.md violation)
+
 ### Changed
 - `/dpm stats` now shows available plugin count (registered minus installed) as a third stat line
 - `/dpm list available` now appends each plugin's description after its name, separated by an em-dash

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -26,9 +26,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * @author Daniel McCoy Stephenson
- */
 public final class DansPluginManager extends PonderBukkitPlugin {
     private static final List<String> CONFIRM_COMPLETION = List.of("--confirm");
 
@@ -48,9 +45,6 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     private RemoveCommand removeCommand;
     private UpdateCommand updateCommand;
 
-    /**
-     * This runs when the server starts.
-     */
     @Override
     public void onEnable() {
         initializeConfig();
@@ -61,22 +55,11 @@ public final class DansPluginManager extends PonderBukkitPlugin {
         projectRecordInitializer.initializeProjectRecords();
     }
 
-    /**
-     * This runs when the server stops.
-     */
     @Override
     public void onDisable() {
 
     }
 
-    /**
-     * This method handles commands sent to the minecraft server and interprets them if the label matches one of the core commands.
-     * @param sender The sender of the command.
-     * @param cmd The command that was sent. This is unused.
-     * @param label The core command that has been invoked.
-     * @param args Arguments of the core command. Often sub-commands.
-     * @return A boolean indicating whether the execution of the command was successful.
-     */
     @Override
     public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, String[] args) {
         if (args.length == 1) {
@@ -124,18 +107,10 @@ public final class DansPluginManager extends PonderBukkitPlugin {
         return commandService.interpretAndExecuteCommand(sender, label, args);
     }
 
-    /**
-     * This can be used to get the version of the plugin.
-     * @return A string containing the version preceded by 'v'
-     */
     public String getVersion() {
         return pluginVersion;
     }
 
-    /**
-     * Checks if the version is mismatched.
-     * @return A boolean indicating if the version is mismatched.
-     */
     public boolean isVersionMismatched() {
         String configVersion = this.getConfig().getString("version");
         if (configVersion == null) {
@@ -145,10 +120,6 @@ public final class DansPluginManager extends PonderBukkitPlugin {
         }
     }
 
-    /**
-     * Checks if debug is enabled.
-     * @return Whether debug is enabled.
-     */
     public boolean isDebugEnabled() {
         return configService.getBoolean("debugMode");
     }
@@ -179,9 +150,6 @@ public final class DansPluginManager extends PonderBukkitPlugin {
         reloadConfig();
     }
 
-    /**
-     * Initializes Ponder's command service with the plugin's commands.
-     */
     private void initializeCommandService() {
         ArrayList<AbstractPluginCommand> commands = new ArrayList<>(Arrays.asList(
                 new HelpCommand(),

--- a/src/main/java/dansplugins/dpm/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/HelpCommand.java
@@ -7,9 +7,6 @@ import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * @author Daniel McCoy Stephenson
- */
 public class HelpCommand extends AbstractPluginCommand {
 
     public HelpCommand() {

--- a/src/main/java/dansplugins/dpm/utils/Logger.java
+++ b/src/main/java/dansplugins/dpm/utils/Logger.java
@@ -2,9 +2,6 @@ package dansplugins.dpm.utils;
 
 import dansplugins.dpm.DansPluginManager;
 
-/**
- * @author Daniel McCoy Stephenson
- */
 public class Logger {
     private final DansPluginManager dansPluginManager;
 

--- a/src/main/java/dansplugins/dpm/utils/TabCompleter.java
+++ b/src/main/java/dansplugins/dpm/utils/TabCompleter.java
@@ -7,10 +7,6 @@ public class TabCompleter {
 
     private TabCompleter() {}
 
-    /**
-     * Returns every option whose lowercase form starts with the lowercase form
-     * of {@code partial}, preserving original casing in the returned strings.
-     */
     public static List<String> filterByPrefix(List<String> options, String partial) {
         String lower = partial.toLowerCase();
         List<String> result = new ArrayList<>();


### PR DESCRIPTION
## Summary
- Deletes 9 multi-line Javadoc blocks from `HelpCommand`, `DansPluginManager`, `Logger`, and `TabCompleter` that were missed by PR #60
- Blocks removed: `@author` annotations, lifecycle method descriptions (`onEnable`/`onDisable`), self-explanatory method docs (`getVersion`, `isVersionMismatched`, `isDebugEnabled`, `initializeCommandService`), and the `filterByPrefix` description that restates the method name

## Test plan
- [x] `mvn test` passes — no code logic was changed, only comment deletions

Closes #76

---

_drafted by Claude on behalf of Daniel Stephenson_