### PR TITLE
Download reliability: timeout, safe conflict removal, 8 KiB buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- JAR download stream now sets a 10 s connect timeout and 30 s read timeout; previously `URL.openStream()` had no timeout, so a hung CDN would stall the async task indefinitely
+- Conflicting JARs (e.g. `Plugin-1.0.0.jar`) are now removed only after a successful download; previously they were deleted before the network call, silently uninstalling the plugin on any download failure
+- JAR write buffer increased from 1 KiB to 8 KiB, reducing I/O cycles for large plugin files
+
 ### Removed
 - Multi-line Javadoc blocks from `HelpCommand`, `DansPluginManager`, `Logger`, and `TabCompleter` (CLAUDE.md violation)
 

--- a/src/main/java/dansplugins/dpm/services/DownloadService.java
+++ b/src/main/java/dansplugins/dpm/services/DownloadService.java
@@ -8,6 +8,7 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
 
@@ -57,11 +58,13 @@ public class DownloadService {
             return ALREADY_UP_TO_DATE;
         }
 
-        removeConflictingJars(projectRecord);
         String dest = pluginFolderService.getPluginsFolder() + projectRecord.getName() + ".jar";
         int bytes = downloadFromUrl(release.getJarUrl(), dest);
-        if (bytes > 0 && latestTag != null) {
-            versionStore.setTag(projectRecord.getName(), latestTag);
+        if (bytes > 0) {
+            removeConflictingJars(projectRecord);
+            if (latestTag != null) {
+                versionStore.setTag(projectRecord.getName(), latestTag);
+            }
         }
         return bytes;
     }
@@ -70,9 +73,9 @@ public class DownloadService {
         List<File> conflicts = pluginFolderService.findConflictingJars(projectRecord);
         for (File conflict : conflicts) {
             if (conflict.delete()) {
-                logger.log("Removed conflicting JAR before download: " + conflict.getName());
+                logger.log("Removed older JAR after download: " + conflict.getName());
             } else {
-                logger.log("Failed to remove conflicting JAR: " + conflict.getName());
+                logger.log("Failed to remove older JAR: " + conflict.getName());
             }
         }
     }
@@ -96,15 +99,23 @@ public class DownloadService {
     }
 
     BufferedInputStream openNetworkStream(String url) throws IOException {
-        return new BufferedInputStream(new URL(url).openStream());
+        URL u = new URL(url);
+        String protocol = u.getProtocol();
+        if ("http".equalsIgnoreCase(protocol) || "https".equalsIgnoreCase(protocol)) {
+            HttpURLConnection connection = (HttpURLConnection) u.openConnection();
+            connection.setConnectTimeout(10000);
+            connection.setReadTimeout(30000);
+            return new BufferedInputStream(connection.getInputStream());
+        }
+        return new BufferedInputStream(u.openStream());
     }
 
     private int writeStreamToFile(BufferedInputStream in, File dest) throws IOException {
         try (in; FileOutputStream out = new FileOutputStream(dest)) {
             int totalBytes = 0;
-            byte[] data = new byte[1024];
+            byte[] data = new byte[8192];
             int bytesRead;
-            while ((bytesRead = in.read(data, 0, 1024)) != -1) {
+            while ((bytesRead = in.read(data)) != -1) {
                 totalBytes += bytesRead;
                 out.write(data, 0, bytesRead);
             }

--- a/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
@@ -189,6 +189,49 @@ class DownloadServiceTest {
     }
 
     // -------------------------------------------------------------------------
+    // removeConflictingJars — ordering relative to download
+    // -------------------------------------------------------------------------
+
+    @Test
+    void downloadLatest_doesNotRemoveConflictingJars_whenDownloadFails(@TempDir Path tempDir) throws IOException {
+        File conflicting = tempDir.resolve("testplugin-1.0.0.jar").toFile();
+        Files.write(conflicting.toPath(), new byte[]{1, 2, 3});
+
+        Logger noOpLogger = new Logger(null) {
+            @Override public void log(String message) {}
+        };
+        PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
+        DownloadService svc = new DownloadService(noOpLogger,
+                fakeRelease("v2.0.0", "http://localhost:1/nonexistent.jar"),
+                pluginFolderService, versionStore(tempDir));
+
+        ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
+        assertEquals(DownloadService.NETWORK_ERROR, svc.downloadLatest(record));
+        assertTrue(conflicting.exists(), "Conflicting JAR must survive a failed download");
+    }
+
+    @Test
+    void downloadLatest_removesConflictingJars_afterSuccessfulDownload(@TempDir Path tempDir) throws IOException {
+        File conflicting = tempDir.resolve("testplugin-1.0.0.jar").toFile();
+        Files.write(conflicting.toPath(), new byte[]{1, 2, 3});
+
+        File src = tempDir.resolve("source.jar").toFile();
+        Files.write(src.toPath(), new byte[]{4, 5, 6});
+
+        Logger noOpLogger = new Logger(null) {
+            @Override public void log(String message) {}
+        };
+        PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
+        DownloadService svc = new DownloadService(noOpLogger,
+                fakeRelease("v2.0.0", src.toURI().toString()),
+                pluginFolderService, versionStore(tempDir));
+
+        ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
+        assertTrue(svc.downloadLatest(record) > 0);
+        assertFalse(conflicting.exists(), "Conflicting JAR must be removed after a successful download");
+    }
+
+    // -------------------------------------------------------------------------
     // downloadFromUrl — error code distinction
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **#78** — JAR download stream now sets a 10 s connect / 30 s read timeout via `HttpURLConnection`. `URL.openStream()` used no timeout, so a hung GitHub CDN would block the async task indefinitely. Falls back to `URL.openStream()` for non-http/https schemes so file-based unit tests are unaffected.
- **#84** — `removeConflictingJars()` now runs only after a successful download (`bytes > 0`). Previously it ran before the network call, so a failed download silently uninstalled the existing plugin JAR.
- **#86** — Write buffer increased from 1 024 to 8 192 bytes, matching the Java-recommended default for file I/O.

## Test plan

- [x] `mvn test` passes (139 tests, 0 failures)
- [x] New regression test: conflicting JAR survives a failed download
- [x] New regression test: conflicting JAR is removed after a successful download
- [x] Existing `downloadLatest_*` tests unchanged

Closes #78
Closes #84
Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_