### PR TITLE
Error visibility: Logger.warn(), 401/rate-limit distinction (#79, #80, #88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- `Logger.warn()` — always prints to the console regardless of `debugMode`, used for operator-visible error messages (#80)
+
 ### Fixed
+- GitHub rate-limit responses (HTTP 429 and HTTP 403 with `X-RateLimit-Remaining: 0`) now produce a specific warning advising to configure a `githubToken`; previously they were logged as generic API errors (#79)
+- GitHub API authentication failures (HTTP 401) now produce a specific warning identifying the token as the cause; previously folded into the generic non-200 path (#88)
+- Network errors, JAR download failures, and missing `.jar` releases now use `Logger.warn()` so they always appear in the server console, even when `debugMode` is off (#80)
 - JAR download stream now sets a 10 s connect timeout and 30 s read timeout; previously `URL.openStream()` had no timeout, so a hung CDN would stall the async task indefinitely
 - Conflicting JARs (e.g. `Plugin-1.0.0.jar`) are now removed only after a successful download; previously they were deleted before the network call, silently uninstalling the plugin on any download failure
 - JAR write buffer increased from 1 KiB to 8 KiB, reducing I/O cycles for large plugin files

--- a/src/main/java/dansplugins/dpm/services/DownloadService.java
+++ b/src/main/java/dansplugins/dpm/services/DownloadService.java
@@ -47,7 +47,7 @@ public class DownloadService {
             return NO_RELEASE;
         }
         if (release == null) {
-            logger.log("Could not resolve release info for " + projectRecord.getName() + ".");
+            logger.warn("Could not resolve release info for " + projectRecord.getName() + ".");
             return NETWORK_ERROR;
         }
 
@@ -85,7 +85,7 @@ public class DownloadService {
         try {
             stream = openNetworkStream(url);
         } catch (IOException e) {
-            logger.log("Network error reaching " + url + ": " + e.getMessage());
+            logger.warn("Network error reaching " + url + ": " + e.getMessage());
             return NETWORK_ERROR;
         }
         File dest = new File(path);
@@ -93,7 +93,7 @@ public class DownloadService {
             return writeStreamToFile(stream, dest);
         } catch (IOException e) {
             dest.delete();
-            logger.log("File write error to " + path + ": " + e.getMessage());
+            logger.warn("File write error to " + path + ": " + e.getMessage());
             return FILE_ERROR;
         }
     }

--- a/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
+++ b/src/main/java/dansplugins/dpm/services/GitHubReleaseService.java
@@ -42,13 +42,13 @@ public class GitHubReleaseService {
         ReleaseInfo release = fetchRelease(owner, repo);
         if (release == null || release == ReleaseInfo.NO_RELEASE) return release;
         if (release.getJarUrl() == null) {
-            logger.log("Release " + release.getTagName() + " for " + owner + "/" + repo + " has no .jar asset.");
+            logger.warn("Release " + release.getTagName() + " for " + owner + "/" + repo + " has no .jar asset.");
             return null;
         }
         return release;
     }
 
-    private HttpURLConnection openConnection(String apiUrl) throws IOException {
+    HttpURLConnection openConnection(String apiUrl) throws IOException {
         HttpURLConnection connection = (HttpURLConnection) new URL(apiUrl).openConnection();
         connection.setRequestProperty("Accept", "application/vnd.github+json");
         connection.setRequestProperty("User-Agent", "Dans-Plugin-Manager");
@@ -100,15 +100,26 @@ public class GitHubReleaseService {
             if (responseCode == 404) {
                 return ReleaseInfo.NO_RELEASE;
             }
+            if (responseCode == 401) {
+                logger.warn("GitHub API rejected the configured token for " + owner + "/" + repo
+                        + " — verify or clear githubToken in config.yml.");
+                return null;
+            }
+            if (responseCode == 429
+                    || (responseCode == 403 && "0".equals(connection.getHeaderField("X-RateLimit-Remaining")))) {
+                logger.warn("GitHub rate limit reached for " + owner + "/" + repo
+                        + " — configure a githubToken in config.yml to raise the limit.");
+                return null;
+            }
             if (responseCode != 200) {
                 String errorBody = readStream(connection.getErrorStream());
-                logger.log("GitHub API returned HTTP " + responseCode + " for " + owner + "/" + repo + ": " + errorBody);
+                logger.warn("GitHub API returned HTTP " + responseCode + " for " + owner + "/" + repo + ": " + errorBody);
                 return null;
             }
             String json = readStream(connection.getInputStream());
             return new ReleaseInfo(parseTagName(json), parseJarUrlFromAssets(json), parsePublishedAt(json));
         } catch (IOException e) {
-            logger.log("Failed to reach GitHub API for " + owner + "/" + repo + ": " + e.getMessage());
+            logger.warn("Failed to reach GitHub API for " + owner + "/" + repo + ": " + e.getMessage());
             return null;
         } finally {
             if (connection != null) {

--- a/src/main/java/dansplugins/dpm/utils/Logger.java
+++ b/src/main/java/dansplugins/dpm/utils/Logger.java
@@ -15,4 +15,8 @@ public class Logger {
         }
     }
 
+    public void warn(String message) {
+        System.out.println("[DPM] " + message);
+    }
+
 }

--- a/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
@@ -199,6 +199,7 @@ class DownloadServiceTest {
 
         Logger noOpLogger = new Logger(null) {
             @Override public void log(String message) {}
+            @Override public void warn(String message) {}
         };
         PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
         DownloadService svc = new DownloadService(noOpLogger,
@@ -220,6 +221,7 @@ class DownloadServiceTest {
 
         Logger noOpLogger = new Logger(null) {
             @Override public void log(String message) {}
+            @Override public void warn(String message) {}
         };
         PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
         DownloadService svc = new DownloadService(noOpLogger,
@@ -239,6 +241,7 @@ class DownloadServiceTest {
     void downloadLatest_returnsNetworkError_whenUrlUnreachable(@TempDir Path tempDir) {
         Logger noOpLogger = new Logger(null) {
             @Override public void log(String message) {}
+            @Override public void warn(String message) {}
         };
         PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
         DownloadService svc = new DownloadService(noOpLogger,
@@ -261,6 +264,7 @@ class DownloadServiceTest {
 
         Logger noOpLogger = new Logger(null) {
             @Override public void log(String message) {}
+            @Override public void warn(String message) {}
         };
         PluginFolderService pluginFolderService = new PluginFolderService(readOnlyDir.getAbsolutePath() + "/");
         DownloadService svc = new DownloadService(noOpLogger,

--- a/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/GitHubReleaseServiceTest.java
@@ -1,8 +1,16 @@
 package dansplugins.dpm.services;
 
 import dansplugins.dpm.objects.ReleaseInfo;
+import dansplugins.dpm.utils.Logger;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -249,6 +257,66 @@ class GitHubReleaseServiceTest {
     }
 
     // -------------------------------------------------------------------------
+    // doFetch() — HTTP error code distinction (#79, #88)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void doFetch_returnsNull_andWarns_onHttp401() throws IOException {
+        List<String> warnings = new ArrayList<>();
+        GitHubReleaseService svc = new GitHubReleaseService(capturingLogger(warnings)) {
+            @Override
+            HttpURLConnection openConnection(String url) throws IOException {
+                return fakeConnection(401, null);
+            }
+        };
+        assertNull(svc.doFetch("org", "repo"));
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("token") && m.contains("org/repo")),
+                "401 must produce a token-specific warning");
+    }
+
+    @Test
+    void doFetch_returnsNull_andWarns_onHttp429RateLimit() throws IOException {
+        List<String> warnings = new ArrayList<>();
+        GitHubReleaseService svc = new GitHubReleaseService(capturingLogger(warnings)) {
+            @Override
+            HttpURLConnection openConnection(String url) throws IOException {
+                return fakeConnection(429, null);
+            }
+        };
+        assertNull(svc.doFetch("org", "repo"));
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("rate limit") && m.contains("org/repo")),
+                "429 must produce a rate-limit warning");
+    }
+
+    @Test
+    void doFetch_returnsNull_andWarns_onHttp403WithZeroRateLimitRemaining() throws IOException {
+        List<String> warnings = new ArrayList<>();
+        GitHubReleaseService svc = new GitHubReleaseService(capturingLogger(warnings)) {
+            @Override
+            HttpURLConnection openConnection(String url) throws IOException {
+                return fakeConnection(403, "0");
+            }
+        };
+        assertNull(svc.doFetch("org", "repo"));
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("rate limit") && m.contains("org/repo")),
+                "403 + X-RateLimit-Remaining: 0 must produce a rate-limit warning");
+    }
+
+    @Test
+    void doFetch_returnsNull_andWarns_onGenericNon200() throws IOException {
+        List<String> warnings = new ArrayList<>();
+        GitHubReleaseService svc = new GitHubReleaseService(capturingLogger(warnings)) {
+            @Override
+            HttpURLConnection openConnection(String url) throws IOException {
+                return fakeConnection(500, null);
+            }
+        };
+        assertNull(svc.doFetch("org", "repo"));
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("500")),
+                "Generic non-200 must warn with the HTTP status code");
+    }
+
+    // -------------------------------------------------------------------------
     // parseJarUrlFromAssets() — edge cases
     // -------------------------------------------------------------------------
 
@@ -262,5 +330,35 @@ class GitHubReleaseServiceTest {
         // No closing bracket — bracket-depth tracking should handle gracefully
         String json = "{\"assets\":[{\"name\":\"Plugin-1.0.jar\",\"browser_download_url\":\"https://example.com/Plugin-1.0.jar\"";
         assertNull(service.parseJarUrlFromAssets(json));
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private Logger capturingLogger(List<String> warnings) {
+        return new Logger(null) {
+            @Override public void log(String m) {}
+            @Override public void warn(String m) { warnings.add(m); }
+        };
+    }
+
+    @SuppressWarnings("resource")
+    private HttpURLConnection fakeConnection(int statusCode, String rateLimitRemaining) throws IOException {
+        return new HttpURLConnection(new URL("http://fake.invalid")) {
+            @Override public void connect() {}
+            @Override public void disconnect() {}
+            @Override public boolean usingProxy() { return false; }
+            @Override public int getResponseCode() { return statusCode; }
+            @Override
+            public String getHeaderField(String name) {
+                if ("X-RateLimit-Remaining".equals(name)) return rateLimitRemaining;
+                return null;
+            }
+            @Override public InputStream getErrorStream() { return new ByteArrayInputStream(new byte[0]); }
+            @Override public InputStream getInputStream() throws IOException {
+                throw new IOException("not used in error-path tests");
+            }
+        };
     }
 }

--- a/src/test/java/dansplugins/dpm/utils/LoggerTest.java
+++ b/src/test/java/dansplugins/dpm/utils/LoggerTest.java
@@ -1,0 +1,31 @@
+package dansplugins.dpm.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LoggerTest {
+
+    // -------------------------------------------------------------------------
+    // warn()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void warn_alwaysOutputsRegardlessOfDebugMode() {
+        Logger logger = new Logger(null);
+
+        PrintStream original = System.out;
+        ByteArrayOutputStream capture = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(capture));
+        try {
+            logger.warn("something went wrong");
+        } finally {
+            System.setOut(original);
+        }
+        assertTrue(capture.toString().contains("[DPM] something went wrong"),
+                "warn() must always print regardless of debugMode");
+    }
+}


### PR DESCRIPTION
## Summary

- Add Logger.warn() that always prints regardless of debugMode so operators see errors in production
- Distinguish HTTP 401 (bad token) from generic GitHub API errors with an actionable message
- Distinguish HTTP 429 / 403+X-RateLimit-Remaining:0 from generic errors with a rate-limit message
- Switch all error log calls in DownloadService and GitHubReleaseService to warn()
- Make openConnection() and doFetch() package-private for testability via anonymous subclass

## Test plan

- [x] mvn test passes (144 tests, 0 failures)
- [x] LoggerTest.warn_alwaysOutputsRegardlessOfDebugMode
- [x] doFetch_returnsNull_andWarns_onHttp401
- [x] doFetch_returnsNull_andWarns_onHttp429RateLimit
- [x] doFetch_returnsNull_andWarns_onHttp403WithZeroRateLimitRemaining
- [x] doFetch_returnsNull_andWarns_onGenericNon200

Closes #79
Closes #80
Closes #88

Generated with Claude Code

---

_drafted by Claude on behalf of Daniel Stephenson_