### PR TITLE
Console audit trail for installs/updates/removals; VersionStore visibility (#81, #82, #87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - `Logger.warn()` — always prints to the console regardless of `debugMode`, used for operator-visible error messages (#80)
+- Server-console audit trail: `plugin.getLogger().info()` is emitted on success and `.warning()` on failure for `/dpm get`, `/dpm update`, `/dpm remove`, and `/dpm clean --confirm` (#81, #87)
 
 ### Fixed
+- `VersionStore` now uses the injected `dansplugins.dpm.utils.Logger` instead of a static JUL logger; load and save failures emit a clearly prefixed warning that always appears in the server console (#82)
 - GitHub rate-limit responses (HTTP 429 and HTTP 403 with `X-RateLimit-Remaining: 0`) now produce a specific warning advising to configure a `githubToken`; previously they were logged as generic API errors (#79)
 - GitHub API authentication failures (HTTP 401) now produce a specific warning identifying the token as the cause; previously folded into the generic non-200 path (#88)
 - Network errors, JAR download failures, and missing `.jar` releases now use `Logger.warn()` so they always appear in the server console, even when `debugMode` is off (#80)

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -49,7 +49,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     public void onEnable() {
         initializeConfig();
         gitHubReleaseService.setApiToken(configService.getStringOrDefault("githubToken", ""));
-        versionStore = new VersionStore(new File(getDataFolder(), "dpm-versions.properties"));
+        versionStore = new VersionStore(new File(getDataFolder(), "dpm-versions.properties"), logger);
         downloadService = new DownloadService(logger, gitHubReleaseService, pluginFolderService, versionStore);
         initializeCommandService();
         projectRecordInitializer.initializeProjectRecords();
@@ -160,7 +160,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
                 updateCommand = new UpdateCommand(ephemeralData, downloadService, pluginFolderService, versionStore, this),
                 new InfoCommand(ephemeralData, gitHubReleaseService, pluginFolderService, versionStore, this),
                 new ReloadCommand(this),
-                removeCommand = new RemoveCommand(ephemeralData, pluginFolderService, versionStore, dependencyResolutionService),
+                removeCommand = new RemoveCommand(ephemeralData, pluginFolderService, versionStore, dependencyResolutionService, this),
                 new SearchCommand(ephemeralData, pluginFolderService, versionStore)
         ));
         commandService.initialize(commands, "That command wasn't found.");

--- a/src/main/java/dansplugins/dpm/commands/CleanCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/CleanCommand.java
@@ -60,8 +60,10 @@ public class CleanCommand extends AbstractPluginCommand {
                     for (File conflict : entry.getValue()) {
                         String label = conflict.getName() + " (" + pluginName + ")";
                         if (conflict.delete()) {
+                            plugin.getLogger().info("[DPM] Cleaned duplicate JAR: " + label);
                             removed.add(label);
                         } else {
+                            plugin.getLogger().warning("[DPM] Failed to delete duplicate JAR: " + label + " — check file permissions.");
                             failed.add(label);
                         }
                     }

--- a/src/main/java/dansplugins/dpm/commands/GetCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/GetCommand.java
@@ -137,17 +137,21 @@ public class GetCommand extends AbstractPluginCommand {
                 msg = ChatColor.GREEN + record.getName() + (tag != null ? " " + tag : "") + " already up to date.";
             } else if (result == DownloadService.NETWORK_ERROR) {
                 failed++;
+                plugin.getLogger().warning("[DPM] Failed to install " + record.getName() + " — could not reach GitHub.");
                 msg = ChatColor.RED + "Failed to download " + record.getName() + " (could not reach GitHub — check console for details).";
             } else if (result == DownloadService.FILE_ERROR) {
                 failed++;
+                plugin.getLogger().warning("[DPM] Failed to install " + record.getName() + " — could not write to plugins folder.");
                 msg = ChatColor.RED + "Failed to download " + record.getName() + " (could not write to plugins folder — check server file permissions).";
             } else if (result < 0) {
                 failed++;
+                plugin.getLogger().warning("[DPM] Failed to install " + record.getName() + ".");
                 msg = ChatColor.RED + "Failed to download " + record.getName() + ".";
             } else {
                 downloaded++;
                 String tag = versionStore.getStoredTag(record.getName());
                 String version = tag != null ? " " + tag : "";
+                plugin.getLogger().info("[DPM] Installed " + record.getName() + version + ".");
                 msg = ChatColor.GREEN + "Downloaded " + record.getName() + version + " (" + (result / 1024) + " KB).";
             }
             Bukkit.getScheduler().runTask(plugin, () -> sender.sendMessage(msg));
@@ -177,14 +181,18 @@ public class GetCommand extends AbstractPluginCommand {
             String version = tag != null ? " (" + tag + ")" : "";
             sender.sendMessage(ChatColor.GREEN + record.getName() + " is already up to date" + version + ".");
         } else if (result == DownloadService.NETWORK_ERROR) {
+            plugin.getLogger().warning("[DPM] Failed to install " + record.getName() + " — could not reach GitHub.");
             sender.sendMessage(ChatColor.RED + "Could not reach GitHub when downloading " + record.getName() + " — check console for details.");
         } else if (result == DownloadService.FILE_ERROR) {
+            plugin.getLogger().warning("[DPM] Failed to install " + record.getName() + " — could not write to plugins folder.");
             sender.sendMessage(ChatColor.RED + "Could not write " + record.getName() + " to the plugins folder — check server file permissions.");
         } else if (result < 0) {
+            plugin.getLogger().warning("[DPM] Failed to install " + record.getName() + ".");
             sender.sendMessage(ChatColor.RED + "Something went wrong downloading " + record.getName() + ".");
         } else {
             String tag = versionStore.getStoredTag(record.getName());
             String version = tag != null ? " " + tag : "";
+            plugin.getLogger().info("[DPM] Installed " + record.getName() + version + ".");
             sender.sendMessage(ChatColor.GREEN + "Downloaded" + version + " (" + (result / 1024) + " KB). Restart the server to enable " + record.getName() + ".");
         }
     }

--- a/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
@@ -7,6 +7,7 @@ import dansplugins.dpm.services.PluginFolderService;
 import dansplugins.dpm.services.VersionStore;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
 import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
 
 import java.io.File;
@@ -18,14 +19,17 @@ public class RemoveCommand extends AbstractPluginCommand {
     private final PluginFolderService pluginFolderService;
     private final VersionStore versionStore;
     private final DependencyResolutionService dependencyResolutionService;
+    private final Plugin plugin;
 
     public RemoveCommand(EphemeralData ephemeralData, PluginFolderService pluginFolderService,
-                         VersionStore versionStore, DependencyResolutionService dependencyResolutionService) {
+                         VersionStore versionStore, DependencyResolutionService dependencyResolutionService,
+                         Plugin plugin) {
         super(new ArrayList<>(List.of("remove")), new ArrayList<>(List.of("dpm.remove")));
         this.ephemeralData = ephemeralData;
         this.pluginFolderService = pluginFolderService;
         this.versionStore = versionStore;
         this.dependencyResolutionService = dependencyResolutionService;
+        this.plugin = plugin;
     }
 
     @Override
@@ -70,10 +74,12 @@ public class RemoveCommand extends AbstractPluginCommand {
         }
         if (jar.delete()) {
             versionStore.removeTag(record.getName());
+            plugin.getLogger().info("[DPM] Removed " + record.getName() + ".");
             sender.sendMessage(ChatColor.GREEN + "Removed " + record.getName() + ".");
             sender.sendMessage(ChatColor.YELLOW + "Restart the server for the removal to take effect.");
             sender.sendMessage(ChatColor.YELLOW + "To reinstall, run " + ChatColor.WHITE + "/dpm get " + record.getName() + ChatColor.YELLOW + ".");
         } else {
+            plugin.getLogger().warning("[DPM] Failed to delete " + jar.getName() + " — check server file permissions.");
             sender.sendMessage(ChatColor.RED + "Failed to delete " + jar.getName() + ". Check server file permissions.");
         }
         return true;

--- a/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
@@ -109,15 +109,19 @@ public class UpdateCommand extends AbstractPluginCommand {
                 String versionDiff = oldTag != null && newTag != null
                         ? " " + oldTag + " → " + newTag
                         : newTag != null ? " " + newTag : "";
+                plugin.getLogger().info("[DPM] Updated " + record.getName() + versionDiff + ".");
                 msg = ChatColor.GREEN + "Updated " + record.getName() + versionDiff + ".";
             } else if (result == DownloadService.NETWORK_ERROR) {
                 failed++;
+                plugin.getLogger().warning("[DPM] Failed to update " + record.getName() + " — could not reach GitHub.");
                 msg = ChatColor.RED + "Failed to update " + record.getName() + " (could not reach GitHub — check console for details).";
             } else if (result == DownloadService.FILE_ERROR) {
                 failed++;
+                plugin.getLogger().warning("[DPM] Failed to update " + record.getName() + " — could not write to plugins folder.");
                 msg = ChatColor.RED + "Failed to update " + record.getName() + " (could not write to plugins folder — check server file permissions).";
             } else {
                 failed++;
+                plugin.getLogger().warning("[DPM] Failed to update " + record.getName() + ".");
                 msg = ChatColor.RED + "Failed to update " + record.getName() + ".";
             }
             Bukkit.getScheduler().runTask(plugin, () -> sender.sendMessage(msg));

--- a/src/main/java/dansplugins/dpm/services/VersionStore.java
+++ b/src/main/java/dansplugins/dpm/services/VersionStore.java
@@ -1,19 +1,20 @@
 package dansplugins.dpm.services;
 
+import dansplugins.dpm.utils.Logger;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Properties;
-import java.util.logging.Logger;
 
 public class VersionStore {
-    private static final Logger LOGGER = Logger.getLogger(VersionStore.class.getName());
-
+    private final Logger logger;
     private final File storeFile;
     private final Properties props = new Properties();
 
-    public VersionStore(File storeFile) {
+    public VersionStore(File storeFile, Logger logger) {
+        this.logger = logger;
         this.storeFile = storeFile;
         load();
     }
@@ -40,8 +41,8 @@ public class VersionStore {
         try (FileInputStream in = new FileInputStream(storeFile)) {
             props.load(in);
         } catch (IOException e) {
-            LOGGER.warning("Failed to load " + storeFile.getName() + ": " + e.getMessage()
-                    + " — stored plugin versions will not be available this session.");
+            logger.warn("[DPM] Could not load version store (" + e.getMessage()
+                    + ") — all plugins will be treated as unversioned this session.");
         }
     }
 
@@ -50,8 +51,8 @@ public class VersionStore {
         try (FileOutputStream out = new FileOutputStream(storeFile)) {
             props.store(out, null);
         } catch (IOException e) {
-            LOGGER.warning("Failed to save " + storeFile.getName() + ": " + e.getMessage()
-                    + " — plugin version data will not persist across restarts.");
+            logger.warn("[DPM] Could not save version store (" + e.getMessage()
+                    + ") — plugin version data will not persist across restarts.");
         }
     }
 }

--- a/src/main/java/dansplugins/dpm/services/VersionStore.java
+++ b/src/main/java/dansplugins/dpm/services/VersionStore.java
@@ -41,7 +41,7 @@ public class VersionStore {
         try (FileInputStream in = new FileInputStream(storeFile)) {
             props.load(in);
         } catch (IOException e) {
-            logger.warn("[DPM] Could not load version store (" + e.getMessage()
+            logger.warn("Could not load version store (" + e.getMessage()
                     + ") — all plugins will be treated as unversioned this session.");
         }
     }
@@ -51,7 +51,7 @@ public class VersionStore {
         try (FileOutputStream out = new FileOutputStream(storeFile)) {
             props.store(out, null);
         } catch (IOException e) {
-            logger.warn("[DPM] Could not save version store (" + e.getMessage()
+            logger.warn("Could not save version store (" + e.getMessage()
                     + ") — plugin version data will not persist across restarts.");
         }
     }

--- a/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
@@ -280,7 +280,11 @@ class DownloadServiceTest {
     // -------------------------------------------------------------------------
 
     private VersionStore versionStore(Path tempDir) {
-        return new VersionStore(tempDir.resolve("dpm-versions.properties").toFile());
+        Logger noOp = new Logger(null) {
+            @Override public void log(String m) {}
+            @Override public void warn(String m) {}
+        };
+        return new VersionStore(tempDir.resolve("dpm-versions.properties").toFile(), noOp);
     }
 
     private GitHubReleaseService fakeRelease(String tag, String jarUrl) {

--- a/src/test/java/dansplugins/dpm/services/VersionStoreTest.java
+++ b/src/test/java/dansplugins/dpm/services/VersionStoreTest.java
@@ -1,10 +1,13 @@
 package dansplugins.dpm.services;
 
+import dansplugins.dpm.utils.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -60,6 +63,26 @@ class VersionStoreTest {
     }
 
     // -------------------------------------------------------------------------
+    // load failure warning
+    // -------------------------------------------------------------------------
+
+    @Test
+    void load_emitsWarn_whenStoreFileIsUnreadable(@TempDir Path tempDir) {
+        // A directory at the expected file path causes FileInputStream to throw
+        File notAFile = tempDir.resolve("dpm-versions.properties").toFile();
+        notAFile.mkdir();
+
+        List<String> warnings = new ArrayList<>();
+        Logger capturing = new Logger(null) {
+            @Override public void log(String m) {}
+            @Override public void warn(String m) { warnings.add(m); }
+        };
+        new VersionStore(notAFile, capturing);
+        assertFalse(warnings.isEmpty(), "load failure must emit a warn");
+        assertTrue(warnings.get(0).contains("version store"), "warn must mention version store");
+    }
+
+    // -------------------------------------------------------------------------
     // persistence across instances
     // -------------------------------------------------------------------------
 
@@ -67,9 +90,9 @@ class VersionStoreTest {
     void tagsPersistedToDisk_survivesNewInstance(@TempDir Path tempDir) {
         File storeFile = tempDir.resolve("dpm-versions.properties").toFile();
 
-        new VersionStore(storeFile).setTag("currencies", "v2.1.0");
+        new VersionStore(storeFile, noOpLogger()).setTag("currencies", "v2.1.0");
 
-        assertEquals("v2.1.0", new VersionStore(storeFile).getStoredTag("currencies"));
+        assertEquals("v2.1.0", new VersionStore(storeFile, noOpLogger()).getStoredTag("currencies"));
     }
 
     // -------------------------------------------------------------------------
@@ -77,6 +100,13 @@ class VersionStoreTest {
     // -------------------------------------------------------------------------
 
     private VersionStore store(Path tempDir) {
-        return new VersionStore(tempDir.resolve("dpm-versions.properties").toFile());
+        return new VersionStore(tempDir.resolve("dpm-versions.properties").toFile(), noOpLogger());
+    }
+
+    private Logger noOpLogger() {
+        return new Logger(null) {
+            @Override public void log(String m) {}
+            @Override public void warn(String m) {}
+        };
     }
 }


### PR DESCRIPTION
## Summary

- A server-console audit trail has been added to `/dpm get`, `/dpm update`, `/dpm remove`, and `/dpm clean --confirm`: `plugin.getLogger().info()` is emitted on success and `.warning()` on failure, so server logs capture every significant DPM action (#81, #87).
- A `Plugin` reference has been added to `RemoveCommand` (previously missing) to support audit logging.
- `VersionStore` has been refactored to accept an injected `dansplugins.dpm.utils.Logger` instead of using a static JUL logger; load and save failures now emit a clearly prefixed warning that always appears in the server console (#82).
- `VersionStoreTest` and `DownloadServiceTest` have been updated for the new constructor signature, and a new regression test covers the load-failure warning path.

## Test plan

- [x] `mvn test` passes (145 tests, 0 failures)
- [x] `VersionStoreTest.load_emitsWarn_whenStoreFileIsUnreadable` — verifies a warning is emitted when the store file cannot be loaded
- [x] Existing VersionStore and DownloadService tests pass with the updated constructor

Closes #81
Closes #82
Closes #87

---
*Generated by [Claude Code](https://claude.com/claude-code)*

---

_drafted by Claude on behalf of Daniel Stephenson_