### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-18
+
 ### Added
 - `discordWebhook` config key — when set, DPM posts a summary notification to the specified Discord channel after each `/dpm update` run (with per-plugin version diffs) and on any download failure from `/dpm get` (#83)
 - `DiscordNotificationService` — sends optional Discord webhook notifications; exceptions are silently swallowed so a failed webhook never affects the command result (#83)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dansplugins</groupId>
     <artifactId>DansPluginManager</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0</version>
     <packaging>jar</packaging>
 
     <name>Dan's Plugin Manager</name>


### PR DESCRIPTION
## Summary

- Bumps version to `0.6.0` in `pom.xml`
- Moves the `[Unreleased]` changelog block to `[0.6.0] - 2026-05-18`

## What's in 0.6.0

**Added**
- `discordWebhook` config key — posts update/failure summaries to a Discord channel after `/dpm update` runs (#83)
- `DiscordNotificationService` for optional webhook notifications (#83)
- Single retry with 2 s delay on transient network failures in `GitHubReleaseService` and `DownloadService` (#85)
- `Logger.warn()` — always prints regardless of `debugMode` (#80)
- Server-console audit trail on success/failure for `get`, `update`, `remove`, `clean --confirm` (#81, #87)

**Fixed**
- `VersionStore` now uses injected logger; load/save failures emit a clearly-prefixed warning (#82)
- GitHub rate-limit (429 / 403 + `X-RateLimit-Remaining: 0`) now produces a specific advisory message (#79)
- GitHub 401 now identified as a token problem, not a generic error (#88)
- Network/download errors always visible via `Logger.warn()` even when `debugMode` is off (#80)
- JAR download now has 10 s connect / 30 s read timeout
- Conflicting JARs removed only after a successful download
- JAR write buffer increased from 1 KiB to 8 KiB

**Changed**
- `/dpm stats` shows available plugin count as a third stat line
- `/dpm list available` appends each plugin's description after an em-dash
- `/dpm remove --confirm` prints a reinstall hint after removal
- `/dpm update` success now shows `old → new` version tags
- "Plugin not found" errors now append a `Use /dpm search` hint
- `/dpm remove` preview warns when other installed plugins hard-depend on the target
- Download failures distinguish network errors from file-write errors

## Test plan
- [ ] CI passes (Maven unit tests + integration tests)
- [ ] After merge, tag `v0.6.0` is pushed and a GitHub Release is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_