### PR TITLE
Document HttpURLConnection field-shadow and sleepMs override patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,10 @@ Filesystem tests use `@TempDir Path tempDir` and construct a `PluginFolderServic
 - Command classes depend on Bukkit and cannot be unit tested here. Cover the underlying services instead.
 - When a bug is fixed, add a regression test that would have caught it.
 
+**`HttpURLConnection` parameter-shadow gotcha**: when creating anonymous `HttpURLConnection` subclasses in tests, never name a parameter or local `responseCode` — `HttpURLConnection` has a protected `int responseCode` field that shadows it, so a `getResponseCode()` override returns the field (`-1`) instead of the value you passed in. Use `statusCode` or similar. The code compiles cleanly and the failure messages don't point at the root cause, so this can waste a full compile-test cycle.
+
+**Retry/sleep override pattern**: when adding retry logic with `Thread.sleep` (or equivalent) to a service method, extract the sleep into a package-private `void sleepMs(long ms)` method — same anonymous-subclass pattern as `doFetch()`/`openNetworkStream()`. Tests override it to a no-op so retries execute immediately. When you add retry to an *existing* method, audit tests that call it with always-failing URLs (e.g. `localhost:1`) — they will now incur the retry delay unless they also override `sleepMs`.
+
 ## Integration test suite
 
 `integration-test/test_dpm.py` runs DPM commands against a live Spigot server and asserts on console output. See `integration-test/README.md` for the full coverage picture.


### PR DESCRIPTION
## Summary

Two test-style gotchas that have come up while writing tests for this repo, now documented in \`CLAUDE.md\`:

- **\`HttpURLConnection\` parameter-shadow.** Anonymous \`HttpURLConnection\` subclasses with a constructor parameter named \`responseCode\` silently shadow the protected \`int responseCode\` field, so \`getResponseCode()\` returns \`-1\` instead of the passed value. Compiles cleanly; failure messages don't point at root cause. Use \`statusCode\`.
- **Retry/sleep override pattern.** When adding retry logic to a service method, extract \`Thread.sleep\` into a package-private \`sleepMs(long ms)\` method so tests can override it to a no-op. When retry is added to an *existing* method, audit always-failing-URL tests (\`localhost:1\` etc.) that will now incur the retry delay.

Both findings originated in the \`dpm-dev-loop\` self-audits ([dpm-dev-loop#4](https://github.com/dmccoystephenson/dpm-dev-loop/issues/4) and [dpm-dev-loop#17](https://github.com/dmccoystephenson/dpm-dev-loop/issues/17)) but belong here because they're project-specific test patterns, not dev-loop instructions. The dev-loop issues will be closed with a pointer to this PR.

## Test plan
- [ ] Visual review of the two new bullets under "Coverage expectations"
- [ ] Confirm they read naturally alongside the existing test-style guidance

---

_drafted by Claude on behalf of Daniel Stephenson_