### PR TITLE
Reclassify VersionStore as VersionRepository

### DIFF
--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -2,6 +2,7 @@ package dansplugins.dpm;
 
 import dansplugins.dpm.commands.*;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
+import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.factories.ProjectRecordFactory;
 import dansplugins.dpm.services.ConfigService;
@@ -10,7 +11,6 @@ import dansplugins.dpm.services.DiscordNotificationService;
 import dansplugins.dpm.services.DownloadService;
 import dansplugins.dpm.services.GitHubReleaseService;
 import dansplugins.dpm.services.PluginFolderService;
-import dansplugins.dpm.services.VersionStore;
 import dansplugins.dpm.utils.Logger;
 import dansplugins.dpm.utils.ProjectRecordInitializer;
 import dansplugins.dpm.utils.TabCompleter;
@@ -42,7 +42,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     private final PluginFolderService pluginFolderService = new PluginFolderService();
     private final DependencyResolutionService dependencyResolutionService = new DependencyResolutionService(projectRecordRepository, pluginFolderService);
     private final DiscordNotificationService discordNotificationService = new DiscordNotificationService(configService);
-    private VersionStore versionStore;
+    private VersionRepository versionRepository;
     private DownloadService downloadService;
     private RemoveCommand removeCommand;
     private UpdateCommand updateCommand;
@@ -51,8 +51,8 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     public void onEnable() {
         initializeConfig();
         gitHubReleaseService.setApiToken(configService.getStringOrDefault("githubToken", ""));
-        versionStore = new VersionStore(new File(getDataFolder(), "dpm-versions.properties"), logger);
-        downloadService = new DownloadService(logger, gitHubReleaseService, pluginFolderService, versionStore);
+        versionRepository = new VersionRepository(new File(getDataFolder(), "dpm-versions.properties"), logger);
+        downloadService = new DownloadService(logger, gitHubReleaseService, pluginFolderService, versionRepository);
         initializeCommandService();
         projectRecordInitializer.initializeProjectRecords();
     }
@@ -155,15 +155,15 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     private void initializeCommandService() {
         ArrayList<AbstractPluginCommand> commands = new ArrayList<>(Arrays.asList(
                 new HelpCommand(),
-                new GetCommand(projectRecordRepository, downloadService, dependencyResolutionService, versionStore, discordNotificationService, this),
-                new ListCommand(projectRecordRepository, pluginFolderService, versionStore),
+                new GetCommand(projectRecordRepository, downloadService, dependencyResolutionService, versionRepository, discordNotificationService, this),
+                new ListCommand(projectRecordRepository, pluginFolderService, versionRepository),
                 new StatsCommand(projectRecordRepository, pluginFolderService),
                 new CleanCommand(projectRecordRepository, pluginFolderService, this),
-                updateCommand = new UpdateCommand(projectRecordRepository, downloadService, pluginFolderService, versionStore, discordNotificationService, this),
-                new InfoCommand(projectRecordRepository, gitHubReleaseService, pluginFolderService, versionStore, this),
+                updateCommand = new UpdateCommand(projectRecordRepository, downloadService, pluginFolderService, versionRepository, discordNotificationService, this),
+                new InfoCommand(projectRecordRepository, gitHubReleaseService, pluginFolderService, versionRepository, this),
                 new ReloadCommand(this),
-                removeCommand = new RemoveCommand(projectRecordRepository, pluginFolderService, versionStore, dependencyResolutionService, this),
-                new SearchCommand(projectRecordRepository, pluginFolderService, versionStore)
+                removeCommand = new RemoveCommand(projectRecordRepository, pluginFolderService, versionRepository, dependencyResolutionService, this),
+                new SearchCommand(projectRecordRepository, pluginFolderService, versionRepository)
         ));
         commandService.initialize(commands, "That command wasn't found.");
     }

--- a/src/main/java/dansplugins/dpm/commands/GetCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/GetCommand.java
@@ -1,11 +1,11 @@
 package dansplugins.dpm.commands;
 
 import dansplugins.dpm.repositories.ProjectRecordRepository;
+import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.services.DependencyResolutionService;
 import dansplugins.dpm.services.DiscordNotificationService;
 import dansplugins.dpm.services.DownloadService;
-import dansplugins.dpm.services.VersionStore;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -22,19 +22,19 @@ public class GetCommand extends AbstractPluginCommand {
     private final ProjectRecordRepository projectRecordRepository;
     private final DownloadService downloadService;
     private final DependencyResolutionService dependencyResolutionService;
-    private final VersionStore versionStore;
+    private final VersionRepository versionRepository;
     private final DiscordNotificationService discordNotificationService;
     private final Plugin plugin;
 
     public GetCommand(ProjectRecordRepository projectRecordRepository, DownloadService downloadService,
                       DependencyResolutionService dependencyResolutionService,
-                      VersionStore versionStore, DiscordNotificationService discordNotificationService,
+                      VersionRepository versionRepository, DiscordNotificationService discordNotificationService,
                       Plugin plugin) {
         super(new ArrayList<>(List.of("get")), new ArrayList<>(List.of("dpm.get")));
         this.projectRecordRepository = projectRecordRepository;
         this.downloadService = downloadService;
         this.dependencyResolutionService = dependencyResolutionService;
-        this.versionStore = versionStore;
+        this.versionRepository = versionRepository;
         this.discordNotificationService = discordNotificationService;
         this.plugin = plugin;
     }
@@ -142,7 +142,7 @@ public class GetCommand extends AbstractPluginCommand {
                 msg = ChatColor.YELLOW + record.getName() + " has no published release yet.";
             } else if (result == DownloadService.ALREADY_UP_TO_DATE) {
                 upToDate++;
-                String tag = versionStore.getStoredTag(record.getName());
+                String tag = versionRepository.getStoredTag(record.getName());
                 msg = ChatColor.GREEN + record.getName() + (tag != null ? " " + tag : "") + " already up to date.";
             } else if (result == DownloadService.NETWORK_ERROR) {
                 failed++;
@@ -160,7 +160,7 @@ public class GetCommand extends AbstractPluginCommand {
                 msg = ChatColor.RED + "Failed to download " + record.getName() + ".";
             } else {
                 downloaded++;
-                String tag = versionStore.getStoredTag(record.getName());
+                String tag = versionRepository.getStoredTag(record.getName());
                 String version = tag != null ? " " + tag : "";
                 plugin.getLogger().info("[DPM] Installed " + record.getName() + version + ".");
                 msg = ChatColor.GREEN + "Downloaded " + record.getName() + version + " (" + (result / 1024) + " KB).";
@@ -188,7 +188,7 @@ public class GetCommand extends AbstractPluginCommand {
         if (result == DownloadService.NO_RELEASE) {
             sender.sendMessage(ChatColor.YELLOW + record.getName() + " has no published release yet. Try again later.");
         } else if (result == DownloadService.ALREADY_UP_TO_DATE) {
-            String tag = versionStore.getStoredTag(record.getName());
+            String tag = versionRepository.getStoredTag(record.getName());
             String version = tag != null ? " (" + tag + ")" : "";
             sender.sendMessage(ChatColor.GREEN + record.getName() + " is already up to date" + version + ".");
         } else if (result == DownloadService.NETWORK_ERROR) {
@@ -201,7 +201,7 @@ public class GetCommand extends AbstractPluginCommand {
             plugin.getLogger().warning("[DPM] Failed to install " + record.getName() + ".");
             sender.sendMessage(ChatColor.RED + "Something went wrong downloading " + record.getName() + ".");
         } else {
-            String tag = versionStore.getStoredTag(record.getName());
+            String tag = versionRepository.getStoredTag(record.getName());
             String version = tag != null ? " " + tag : "";
             plugin.getLogger().info("[DPM] Installed " + record.getName() + version + ".");
             sender.sendMessage(ChatColor.GREEN + "Downloaded" + version + " (" + (result / 1024) + " KB). Restart the server to enable " + record.getName() + ".");

--- a/src/main/java/dansplugins/dpm/commands/InfoCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/InfoCommand.java
@@ -1,11 +1,11 @@
 package dansplugins.dpm.commands;
 
 import dansplugins.dpm.repositories.ProjectRecordRepository;
+import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.objects.ReleaseInfo;
 import dansplugins.dpm.services.GitHubReleaseService;
 import dansplugins.dpm.services.PluginFolderService;
-import dansplugins.dpm.services.VersionStore;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -21,17 +21,17 @@ public class InfoCommand extends AbstractPluginCommand {
     private final ProjectRecordRepository projectRecordRepository;
     private final GitHubReleaseService gitHubReleaseService;
     private final PluginFolderService pluginFolderService;
-    private final VersionStore versionStore;
+    private final VersionRepository versionRepository;
     private final Plugin plugin;
 
     public InfoCommand(ProjectRecordRepository projectRecordRepository, GitHubReleaseService gitHubReleaseService,
-                       PluginFolderService pluginFolderService, VersionStore versionStore,
+                       PluginFolderService pluginFolderService, VersionRepository versionRepository,
                        Plugin plugin) {
         super(new ArrayList<>(List.of("info")), new ArrayList<>(List.of("dpm.info")));
         this.projectRecordRepository = projectRecordRepository;
         this.gitHubReleaseService = gitHubReleaseService;
         this.pluginFolderService = pluginFolderService;
-        this.versionStore = versionStore;
+        this.versionRepository = versionRepository;
         this.plugin = plugin;
     }
 
@@ -80,7 +80,7 @@ public class InfoCommand extends AbstractPluginCommand {
 
         Set<String> installedNames = installedNamesFor(record);
         boolean installed = installedNames.contains(record.getName());
-        String storedTag = versionStore.getStoredTag(record.getName());
+        String storedTag = versionRepository.getStoredTag(record.getName());
 
         if (installed) {
             String version = storedTag != null ? storedTag : "(version unknown)";

--- a/src/main/java/dansplugins/dpm/commands/ListCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/ListCommand.java
@@ -1,9 +1,9 @@
 package dansplugins.dpm.commands;
 
 import dansplugins.dpm.repositories.ProjectRecordRepository;
+import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.services.PluginFolderService;
-import dansplugins.dpm.services.VersionStore;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
@@ -16,14 +16,14 @@ import java.util.Set;
 public class ListCommand extends AbstractPluginCommand {
     private final ProjectRecordRepository projectRecordRepository;
     private final PluginFolderService pluginFolderService;
-    private final VersionStore versionStore;
+    private final VersionRepository versionRepository;
 
     public ListCommand(ProjectRecordRepository projectRecordRepository, PluginFolderService pluginFolderService,
-                       VersionStore versionStore) {
+                       VersionRepository versionRepository) {
         super(new ArrayList<>(List.of("list")), new ArrayList<>(List.of("dpm.list")));
         this.projectRecordRepository = projectRecordRepository;
         this.pluginFolderService = pluginFolderService;
-        this.versionStore = versionStore;
+        this.versionRepository = versionRepository;
     }
 
     @Override
@@ -36,7 +36,7 @@ public class ListCommand extends AbstractPluginCommand {
         sender.sendMessage(ChatColor.AQUA + "=== Plugins (" + records.size() + ") ===");
         for (ProjectRecord record : records) {
             if (installedNames.contains(record.getName())) {
-                String tag = versionStore.getStoredTag(record.getName());
+                String tag = versionRepository.getStoredTag(record.getName());
                 String version = tag != null ? " " + tag : "";
                 sender.sendMessage(ChatColor.GREEN + record.getName() + version);
             } else {
@@ -63,7 +63,7 @@ public class ListCommand extends AbstractPluginCommand {
         List<ProjectRecord> installed = pluginFolderService.filterInstalled(projectRecordRepository.getAllProjectRecords());
         sender.sendMessage(ChatColor.AQUA + "=== Installed Plugins (" + installed.size() + ") ===");
         for (ProjectRecord record : installed) {
-            String tag = versionStore.getStoredTag(record.getName());
+            String tag = versionRepository.getStoredTag(record.getName());
             String version = tag != null ? " " + tag : "";
             sender.sendMessage(ChatColor.GREEN + record.getName() + version);
         }

--- a/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
@@ -1,10 +1,10 @@
 package dansplugins.dpm.commands;
 
 import dansplugins.dpm.repositories.ProjectRecordRepository;
+import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.services.DependencyResolutionService;
 import dansplugins.dpm.services.PluginFolderService;
-import dansplugins.dpm.services.VersionStore;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
@@ -17,17 +17,17 @@ import java.util.List;
 public class RemoveCommand extends AbstractPluginCommand {
     private final ProjectRecordRepository projectRecordRepository;
     private final PluginFolderService pluginFolderService;
-    private final VersionStore versionStore;
+    private final VersionRepository versionRepository;
     private final DependencyResolutionService dependencyResolutionService;
     private final Plugin plugin;
 
     public RemoveCommand(ProjectRecordRepository projectRecordRepository, PluginFolderService pluginFolderService,
-                         VersionStore versionStore, DependencyResolutionService dependencyResolutionService,
+                         VersionRepository versionRepository, DependencyResolutionService dependencyResolutionService,
                          Plugin plugin) {
         super(new ArrayList<>(List.of("remove")), new ArrayList<>(List.of("dpm.remove")));
         this.projectRecordRepository = projectRecordRepository;
         this.pluginFolderService = pluginFolderService;
-        this.versionStore = versionStore;
+        this.versionRepository = versionRepository;
         this.dependencyResolutionService = dependencyResolutionService;
         this.plugin = plugin;
     }
@@ -73,7 +73,7 @@ public class RemoveCommand extends AbstractPluginCommand {
                     + " declare a hard dependency on " + record.getName() + " and may stop working.");
         }
         if (jar.delete()) {
-            versionStore.removeTag(record.getName());
+            versionRepository.removeTag(record.getName());
             plugin.getLogger().info("[DPM] Removed " + record.getName() + ".");
             sender.sendMessage(ChatColor.GREEN + "Removed " + record.getName() + ".");
             sender.sendMessage(ChatColor.YELLOW + "Restart the server for the removal to take effect.");

--- a/src/main/java/dansplugins/dpm/commands/SearchCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/SearchCommand.java
@@ -1,9 +1,9 @@
 package dansplugins.dpm.commands;
 
 import dansplugins.dpm.repositories.ProjectRecordRepository;
+import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.services.PluginFolderService;
-import dansplugins.dpm.services.VersionStore;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
@@ -16,14 +16,14 @@ import java.util.Set;
 public class SearchCommand extends AbstractPluginCommand {
     private final ProjectRecordRepository projectRecordRepository;
     private final PluginFolderService pluginFolderService;
-    private final VersionStore versionStore;
+    private final VersionRepository versionRepository;
 
     public SearchCommand(ProjectRecordRepository projectRecordRepository, PluginFolderService pluginFolderService,
-                         VersionStore versionStore) {
+                         VersionRepository versionRepository) {
         super(new ArrayList<>(List.of("search")), new ArrayList<>(List.of("dpm.list")));
         this.projectRecordRepository = projectRecordRepository;
         this.pluginFolderService = pluginFolderService;
-        this.versionStore = versionStore;
+        this.versionRepository = versionRepository;
     }
 
     @Override
@@ -51,7 +51,7 @@ public class SearchCommand extends AbstractPluginCommand {
         for (ProjectRecord record : matches) {
             String desc = record.getDescription() != null ? ChatColor.GRAY + " — " + record.getDescription() : "";
             if (installedNames.contains(record.getName())) {
-                String tag = versionStore.getStoredTag(record.getName());
+                String tag = versionRepository.getStoredTag(record.getName());
                 String version = tag != null ? " " + tag : "";
                 sender.sendMessage(ChatColor.GREEN + record.getName() + version + desc);
             } else {

--- a/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
@@ -1,11 +1,11 @@
 package dansplugins.dpm.commands;
 
 import dansplugins.dpm.repositories.ProjectRecordRepository;
+import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.services.DiscordNotificationService;
 import dansplugins.dpm.services.DownloadService;
 import dansplugins.dpm.services.PluginFolderService;
-import dansplugins.dpm.services.VersionStore;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -21,18 +21,18 @@ public class UpdateCommand extends AbstractPluginCommand {
     private final ProjectRecordRepository projectRecordRepository;
     private final DownloadService downloadService;
     private final PluginFolderService pluginFolderService;
-    private final VersionStore versionStore;
+    private final VersionRepository versionRepository;
     private final DiscordNotificationService discordNotificationService;
     private final Plugin plugin;
 
     public UpdateCommand(ProjectRecordRepository projectRecordRepository, DownloadService downloadService,
-                         PluginFolderService pluginFolderService, VersionStore versionStore,
+                         PluginFolderService pluginFolderService, VersionRepository versionRepository,
                          DiscordNotificationService discordNotificationService, Plugin plugin) {
         super(new ArrayList<>(List.of("update")), new ArrayList<>(List.of("dpm.update")));
         this.projectRecordRepository = projectRecordRepository;
         this.downloadService = downloadService;
         this.pluginFolderService = pluginFolderService;
-        this.versionStore = versionStore;
+        this.versionRepository = versionRepository;
         this.discordNotificationService = discordNotificationService;
         this.plugin = plugin;
     }
@@ -98,7 +98,7 @@ public class UpdateCommand extends AbstractPluginCommand {
         List<String> versionDiffs = new ArrayList<>();
 
         for (ProjectRecord record : records) {
-            String oldTag = versionStore.getStoredTag(record.getName());
+            String oldTag = versionRepository.getStoredTag(record.getName());
             int result = downloadService.downloadLatest(record, true);
             final String msg;
             if (result == DownloadService.ALREADY_UP_TO_DATE) {
@@ -109,7 +109,7 @@ public class UpdateCommand extends AbstractPluginCommand {
                 msg = ChatColor.YELLOW + record.getName() + " has no published release yet.";
             } else if (result > 0) {
                 updated++;
-                String newTag = versionStore.getStoredTag(record.getName());
+                String newTag = versionRepository.getStoredTag(record.getName());
                 String versionDiff = oldTag != null && newTag != null
                         ? " " + oldTag + " → " + newTag
                         : newTag != null ? " " + newTag : "";

--- a/src/main/java/dansplugins/dpm/repositories/VersionRepository.java
+++ b/src/main/java/dansplugins/dpm/repositories/VersionRepository.java
@@ -1,4 +1,4 @@
-package dansplugins.dpm.services;
+package dansplugins.dpm.repositories;
 
 import dansplugins.dpm.utils.Logger;
 
@@ -8,12 +8,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Properties;
 
-public class VersionStore {
+public class VersionRepository {
     private final Logger logger;
     private final File storeFile;
     private final Properties props = new Properties();
 
-    public VersionStore(File storeFile, Logger logger) {
+    public VersionRepository(File storeFile, Logger logger) {
         this.logger = logger;
         this.storeFile = storeFile;
         load();

--- a/src/main/java/dansplugins/dpm/services/DownloadService.java
+++ b/src/main/java/dansplugins/dpm/services/DownloadService.java
@@ -2,6 +2,7 @@ package dansplugins.dpm.services;
 
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.objects.ReleaseInfo;
+import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.utils.Logger;
 
 import java.io.BufferedInputStream;
@@ -25,14 +26,14 @@ public class DownloadService {
     private final Logger logger;
     private final GitHubReleaseService gitHubReleaseService;
     private final PluginFolderService pluginFolderService;
-    private final VersionStore versionStore;
+    private final VersionRepository versionRepository;
 
     public DownloadService(Logger logger, GitHubReleaseService gitHubReleaseService,
-                           PluginFolderService pluginFolderService, VersionStore versionStore) {
+                           PluginFolderService pluginFolderService, VersionRepository versionRepository) {
         this.logger = logger;
         this.gitHubReleaseService = gitHubReleaseService;
         this.pluginFolderService = pluginFolderService;
-        this.versionStore = versionStore;
+        this.versionRepository = versionRepository;
     }
 
     public int downloadLatest(ProjectRecord projectRecord) {
@@ -53,7 +54,7 @@ public class DownloadService {
 
         String latestTag = release.getTagName();
         if (latestTag != null
-                && latestTag.equals(versionStore.getStoredTag(projectRecord.getName()))
+                && latestTag.equals(versionRepository.getStoredTag(projectRecord.getName()))
                 && physicallyInstalled) {
             return ALREADY_UP_TO_DATE;
         }
@@ -63,7 +64,7 @@ public class DownloadService {
         if (bytes > 0) {
             removeConflictingJars(projectRecord);
             if (latestTag != null) {
-                versionStore.setTag(projectRecord.getName(), latestTag);
+                versionRepository.setTag(projectRecord.getName(), latestTag);
             }
         }
         return bytes;

--- a/src/test/java/dansplugins/dpm/repositories/VersionRepositoryTest.java
+++ b/src/test/java/dansplugins/dpm/repositories/VersionRepositoryTest.java
@@ -1,4 +1,4 @@
-package dansplugins.dpm.services;
+package dansplugins.dpm.repositories;
 
 import dansplugins.dpm.utils.Logger;
 import org.junit.jupiter.api.Test;
@@ -11,7 +11,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class VersionStoreTest {
+class VersionRepositoryTest {
 
     // -------------------------------------------------------------------------
     // getStoredTag / setTag
@@ -19,7 +19,7 @@ class VersionStoreTest {
 
     @Test
     void setTag_thenGetStoredTag_returnsTag(@TempDir Path tempDir) {
-        VersionStore store = store(tempDir);
+        VersionRepository store = store(tempDir);
         store.setTag("medievalfactions", "v4.6.3");
         assertEquals("v4.6.3", store.getStoredTag("medievalfactions"));
     }
@@ -31,7 +31,7 @@ class VersionStoreTest {
 
     @Test
     void setTag_keyIsCaseInsensitive(@TempDir Path tempDir) {
-        VersionStore store = store(tempDir);
+        VersionRepository store = store(tempDir);
         store.setTag("MedievalFactions", "v4.6.3");
         assertEquals("v4.6.3", store.getStoredTag("medievalfactions"));
         assertEquals("v4.6.3", store.getStoredTag("MEDIEVALFACTIONS"));
@@ -39,7 +39,7 @@ class VersionStoreTest {
 
     @Test
     void setTag_overwritesPreviousValue(@TempDir Path tempDir) {
-        VersionStore store = store(tempDir);
+        VersionRepository store = store(tempDir);
         store.setTag("medievalfactions", "v4.6.2");
         store.setTag("medievalfactions", "v4.6.3");
         assertEquals("v4.6.3", store.getStoredTag("medievalfactions"));
@@ -51,7 +51,7 @@ class VersionStoreTest {
 
     @Test
     void removeTag_erasesStoredValue(@TempDir Path tempDir) {
-        VersionStore store = store(tempDir);
+        VersionRepository store = store(tempDir);
         store.setTag("medievalfactions", "v4.6.3");
         store.removeTag("medievalfactions");
         assertNull(store.getStoredTag("medievalfactions"));
@@ -77,7 +77,7 @@ class VersionStoreTest {
             @Override public void log(String m) {}
             @Override public void warn(String m) { warnings.add(m); }
         };
-        new VersionStore(notAFile, capturing);
+        new VersionRepository(notAFile, capturing);
         assertFalse(warnings.isEmpty(), "load failure must emit a warn");
         assertTrue(warnings.get(0).contains("version store"), "warn must mention version store");
     }
@@ -90,17 +90,17 @@ class VersionStoreTest {
     void tagsPersistedToDisk_survivesNewInstance(@TempDir Path tempDir) {
         File storeFile = tempDir.resolve("dpm-versions.properties").toFile();
 
-        new VersionStore(storeFile, noOpLogger()).setTag("currencies", "v2.1.0");
+        new VersionRepository(storeFile, noOpLogger()).setTag("currencies", "v2.1.0");
 
-        assertEquals("v2.1.0", new VersionStore(storeFile, noOpLogger()).getStoredTag("currencies"));
+        assertEquals("v2.1.0", new VersionRepository(storeFile, noOpLogger()).getStoredTag("currencies"));
     }
 
     // -------------------------------------------------------------------------
     // helpers
     // -------------------------------------------------------------------------
 
-    private VersionStore store(Path tempDir) {
-        return new VersionStore(tempDir.resolve("dpm-versions.properties").toFile(), noOpLogger());
+    private VersionRepository store(Path tempDir) {
+        return new VersionRepository(tempDir.resolve("dpm-versions.properties").toFile(), noOpLogger());
     }
 
     private Logger noOpLogger() {

--- a/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
@@ -2,6 +2,7 @@ package dansplugins.dpm.services;
 
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.objects.ReleaseInfo;
+import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.utils.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -22,8 +23,8 @@ class DownloadServiceTest {
     private final DownloadService service = noSleepService(null, null, null, null);
 
     private static DownloadService noSleepService(Logger logger, GitHubReleaseService ghrs,
-                                                   PluginFolderService pfs, VersionStore vs) {
-        return new DownloadService(logger, ghrs, pfs, vs) {
+                                                   PluginFolderService pfs, VersionRepository vr) {
+        return new DownloadService(logger, ghrs, pfs, vr) {
             @Override void sleepMs(long ms) {}
         };
     }
@@ -89,27 +90,27 @@ class DownloadServiceTest {
         File src = tempDir.resolve("plugin.jar").toFile();
         Files.write(src.toPath(), content);
 
-        VersionStore versionStore = versionStore(tempDir);
+        VersionRepository versionRepository = versionRepository(tempDir);
         PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
         DownloadService svc = noSleepService(null, fakeRelease("v1.0.0", src.toURI().toString()),
-                pluginFolderService, versionStore);
+                pluginFolderService, versionRepository);
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         int result = svc.downloadLatest(record);
 
         assertTrue(result > 0);
-        assertEquals("v1.0.0", versionStore.getStoredTag("testplugin"));
+        assertEquals("v1.0.0", versionRepository.getStoredTag("testplugin"));
     }
 
     @Test
     void downloadLatest_returnsAlreadyUpToDate_whenTagMatchesAndJarPresent(@TempDir Path tempDir) throws IOException {
-        VersionStore versionStore = versionStore(tempDir);
-        versionStore.setTag("testplugin", "v1.0.0");
+        VersionRepository versionRepository = versionRepository(tempDir);
+        versionRepository.setTag("testplugin", "v1.0.0");
         Files.write(tempDir.resolve("testplugin.jar"), new byte[]{1});
 
         PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
         DownloadService svc = new DownloadService(null, fakeRelease("v1.0.0", "http://unused"),
-                pluginFolderService, versionStore);
+                pluginFolderService, versionRepository);
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertEquals(DownloadService.ALREADY_UP_TO_DATE, svc.downloadLatest(record));
@@ -118,15 +119,15 @@ class DownloadServiceTest {
     @Test
     void downloadLatest_reDownloads_whenTagMatchesButJarMissing(@TempDir Path tempDir) throws IOException {
         // JAR was manually deleted — must re-download even though the stored tag matches.
-        VersionStore versionStore = versionStore(tempDir);
-        versionStore.setTag("testplugin", "v1.0.0");
+        VersionRepository versionRepository = versionRepository(tempDir);
+        versionRepository.setTag("testplugin", "v1.0.0");
 
         File src = tempDir.resolve("source.jar").toFile();
         Files.write(src.toPath(), new byte[]{1, 2, 3});
 
         PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
         DownloadService svc = new DownloadService(null, fakeRelease("v1.0.0", src.toURI().toString()),
-                pluginFolderService, versionStore);
+                pluginFolderService, versionRepository);
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertTrue(svc.downloadLatest(record) > 0, "Should re-download when JAR is absent despite matching tag");
@@ -141,7 +142,7 @@ class DownloadServiceTest {
                 return ReleaseInfo.NO_RELEASE;
             }
         };
-        DownloadService svc = new DownloadService(null, noReleaseService, pluginFolderService, versionStore(tempDir));
+        DownloadService svc = new DownloadService(null, noReleaseService, pluginFolderService, versionRepository(tempDir));
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertEquals(DownloadService.NO_RELEASE, svc.downloadLatest(record));
@@ -153,14 +154,14 @@ class DownloadServiceTest {
 
     @Test
     void downloadLatest_withTrueHint_returnsAlreadyUpToDate_withoutDirectoryScan(@TempDir Path tempDir) {
-        VersionStore versionStore = versionStore(tempDir);
-        versionStore.setTag("testplugin", "v1.0.0");
+        VersionRepository versionRepository = versionRepository(tempDir);
+        versionRepository.setTag("testplugin", "v1.0.0");
 
         // PluginFolderService with a non-existent folder — isInstalled() would return false
         // if called, but the hint bypasses the scan entirely.
         PluginFolderService noScanService = new PluginFolderService("/this/path/does/not/exist");
         DownloadService svc = new DownloadService(null, fakeRelease("v1.0.0", "http://unused"),
-                noScanService, versionStore);
+                noScanService, versionRepository);
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertEquals(DownloadService.ALREADY_UP_TO_DATE, svc.downloadLatest(record, true));
@@ -168,15 +169,15 @@ class DownloadServiceTest {
 
     @Test
     void downloadLatest_withFalseHint_downloadsEvenWhenTagMatches(@TempDir Path tempDir) throws IOException {
-        VersionStore versionStore = versionStore(tempDir);
-        versionStore.setTag("testplugin", "v1.0.0");
+        VersionRepository versionRepository = versionRepository(tempDir);
+        versionRepository.setTag("testplugin", "v1.0.0");
 
         File src = tempDir.resolve("source.jar").toFile();
         Files.write(src.toPath(), new byte[]{1, 2, 3});
 
         PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
         DownloadService svc = new DownloadService(null, fakeRelease("v1.0.0", src.toURI().toString()),
-                pluginFolderService, versionStore);
+                pluginFolderService, versionRepository);
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertTrue(svc.downloadLatest(record, false) > 0,
@@ -185,13 +186,13 @@ class DownloadServiceTest {
 
     @Test
     void downloadLatest_noArgOverload_callsIsInstalledViaScan(@TempDir Path tempDir) throws IOException {
-        VersionStore versionStore = versionStore(tempDir);
-        versionStore.setTag("testplugin", "v1.0.0");
+        VersionRepository versionRepository = versionRepository(tempDir);
+        versionRepository.setTag("testplugin", "v1.0.0");
         Files.write(tempDir.resolve("testplugin.jar"), new byte[]{1});
 
         PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
         DownloadService svc = new DownloadService(null, fakeRelease("v1.0.0", "http://unused"),
-                pluginFolderService, versionStore);
+                pluginFolderService, versionRepository);
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertEquals(DownloadService.ALREADY_UP_TO_DATE, svc.downloadLatest(record));
@@ -213,7 +214,7 @@ class DownloadServiceTest {
         PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
         DownloadService svc = noSleepService(noOpLogger,
                 fakeRelease("v2.0.0", "http://localhost:1/nonexistent.jar"),
-                pluginFolderService, versionStore(tempDir));
+                pluginFolderService, versionRepository(tempDir));
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertEquals(DownloadService.NETWORK_ERROR, svc.downloadLatest(record));
@@ -235,7 +236,7 @@ class DownloadServiceTest {
         PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
         DownloadService svc = new DownloadService(noOpLogger,
                 fakeRelease("v2.0.0", src.toURI().toString()),
-                pluginFolderService, versionStore(tempDir));
+                pluginFolderService, versionRepository(tempDir));
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertTrue(svc.downloadLatest(record) > 0);
@@ -255,7 +256,7 @@ class DownloadServiceTest {
         PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
         DownloadService svc = noSleepService(noOpLogger,
                 fakeRelease("v1.0.0", "http://localhost:1/nonexistent.jar"),
-                pluginFolderService, versionStore(tempDir));
+                pluginFolderService, versionRepository(tempDir));
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertEquals(DownloadService.NETWORK_ERROR, svc.downloadLatest(record));
@@ -278,7 +279,7 @@ class DownloadServiceTest {
         PluginFolderService pluginFolderService = new PluginFolderService(readOnlyDir.getAbsolutePath() + "/");
         DownloadService svc = new DownloadService(noOpLogger,
                 fakeRelease("v1.0.0", src.toURI().toString()),
-                pluginFolderService, versionStore(tempDir));
+                pluginFolderService, versionRepository(tempDir));
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertEquals(DownloadService.FILE_ERROR, svc.downloadLatest(record));
@@ -327,12 +328,12 @@ class DownloadServiceTest {
     // helpers
     // -------------------------------------------------------------------------
 
-    private VersionStore versionStore(Path tempDir) {
+    private VersionRepository versionRepository(Path tempDir) {
         Logger noOp = new Logger(null) {
             @Override public void log(String m) {}
             @Override public void warn(String m) {}
         };
-        return new VersionStore(tempDir.resolve("dpm-versions.properties").toFile(), noOp);
+        return new VersionRepository(tempDir.resolve("dpm-versions.properties").toFile(), noOp);
     }
 
     private GitHubReleaseService fakeRelease(String tag, String jarUrl) {


### PR DESCRIPTION
## Summary
- `VersionStore` reads/writes `dpm-versions.properties` to disk — it is a data-access class, not a service, per the layering proposed in #94.
- Moves it to `dansplugins.dpm.repositories.VersionRepository`, mirroring the pattern already applied to `EphemeralData` -> `ProjectRecordRepository` in #102.
- Updates all call sites: `DansPluginManager`, `DownloadService`, `GetCommand`, `RemoveCommand`, `ListCommand`, `UpdateCommand`, `InfoCommand`, `SearchCommand` (and their field/parameter names, `versionStore` -> `versionRepository`, for consistency with the established rename pattern).
- Renames `VersionStoreTest` -> `VersionRepositoryTest` and updates `DownloadServiceTest`'s references.
- Pure rename/move — no logic changes to any method.
- No command syntax changed, so `HelpCommand.java`, `COMMANDS.md`, `USER_GUIDE.md`, and `CHANGELOG.md` don't need updates (consistent with #102, which also didn't touch them for the same reason).

## Test plan
- [x] `mvn compile` — clean
- [x] `mvn test` — 155/156 pass. The one failure (`DownloadServiceTest#downloadLatest_returnsFileError_whenDestinationUnwritable`) is a pre-existing environment flake unrelated to this change: it fails identically on `main` before this rename when run as root (`setWritable(false)` is a no-op for root, so the `assumeTrue` guard doesn't trigger and the write unexpectedly succeeds). CI does not run as root, so this passes there.
- [x] Confirmed via `grep -rn VersionStore src` that no references remain outside historical `CHANGELOG.md` entries (which correctly describe past releases and are left untouched).

Closes #97

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
