### PR TITLE
Reclassify PluginFolderService and GitHubReleaseService as repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Local test server scripts (`up.sh`, `down.sh`, `reload-plugin.sh`, `dpm-cmd.sh`, `test-integration.sh`) that drive [OMCSI](https://github.com/dmccoystephenson/open-mc-server-infrastructure) for manual plugin testing during development — same Spigot stack and plugin-deploy API used by the CI integration tests
 - `sample.env` documenting the env vars used by the local test server scripts
 
+### Changed
+- Reclassified `PluginFolderService` as `PluginFileRepository` and `GitHubReleaseService` as `GitHubReleaseRepository`, moving both into the `repositories/` package — both are data-access classes (filesystem scanning, GitHub API calls), not business logic, per the layering proposed in #94. No behavior change.
+
 ## [0.6.0] - 2026-05-18
 
 ### Added

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -1,6 +1,8 @@
 package dansplugins.dpm;
 
 import dansplugins.dpm.commands.*;
+import dansplugins.dpm.repositories.GitHubReleaseRepository;
+import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
 import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
@@ -9,8 +11,6 @@ import dansplugins.dpm.services.ConfigService;
 import dansplugins.dpm.services.DependencyResolutionService;
 import dansplugins.dpm.services.DiscordNotificationService;
 import dansplugins.dpm.services.DownloadService;
-import dansplugins.dpm.services.GitHubReleaseService;
-import dansplugins.dpm.services.PluginFolderService;
 import dansplugins.dpm.utils.Logger;
 import dansplugins.dpm.utils.ProjectRecordInitializer;
 import dansplugins.dpm.utils.TabCompleter;
@@ -38,9 +38,9 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     private final ProjectRecordInitializer projectRecordInitializer = new ProjectRecordInitializer(projectRecordFactory);
     private final ConfigService configService = new ConfigService(this);
     private final Logger logger = new Logger(this);
-    private final GitHubReleaseService gitHubReleaseService = new GitHubReleaseService(logger);
-    private final PluginFolderService pluginFolderService = new PluginFolderService();
-    private final DependencyResolutionService dependencyResolutionService = new DependencyResolutionService(projectRecordRepository, pluginFolderService);
+    private final GitHubReleaseRepository gitHubReleaseRepository = new GitHubReleaseRepository(logger);
+    private final PluginFileRepository pluginFileRepository = new PluginFileRepository();
+    private final DependencyResolutionService dependencyResolutionService = new DependencyResolutionService(projectRecordRepository, pluginFileRepository);
     private final DiscordNotificationService discordNotificationService = new DiscordNotificationService(configService);
     private VersionRepository versionRepository;
     private DownloadService downloadService;
@@ -50,9 +50,9 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     @Override
     public void onEnable() {
         initializeConfig();
-        gitHubReleaseService.setApiToken(configService.getStringOrDefault("githubToken", ""));
+        gitHubReleaseRepository.setApiToken(configService.getStringOrDefault("githubToken", ""));
         versionRepository = new VersionRepository(new File(getDataFolder(), "dpm-versions.properties"), logger);
-        downloadService = new DownloadService(logger, gitHubReleaseService, pluginFolderService, versionRepository);
+        downloadService = new DownloadService(logger, gitHubReleaseRepository, pluginFileRepository, versionRepository);
         initializeCommandService();
         projectRecordInitializer.initializeProjectRecords();
     }
@@ -128,8 +128,8 @@ public final class DansPluginManager extends PonderBukkitPlugin {
 
     public void reloadDpm() {
         reloadConfig();
-        gitHubReleaseService.setApiToken(configService.getStringOrDefault("githubToken", ""));
-        gitHubReleaseService.clearCache();
+        gitHubReleaseRepository.setApiToken(configService.getStringOrDefault("githubToken", ""));
+        gitHubReleaseRepository.clearCache();
     }
 
     private void initializeConfig() {
@@ -156,14 +156,14 @@ public final class DansPluginManager extends PonderBukkitPlugin {
         ArrayList<AbstractPluginCommand> commands = new ArrayList<>(Arrays.asList(
                 new HelpCommand(),
                 new GetCommand(projectRecordRepository, downloadService, dependencyResolutionService, versionRepository, discordNotificationService, this),
-                new ListCommand(projectRecordRepository, pluginFolderService, versionRepository),
-                new StatsCommand(projectRecordRepository, pluginFolderService),
-                new CleanCommand(projectRecordRepository, pluginFolderService, this),
-                updateCommand = new UpdateCommand(projectRecordRepository, downloadService, pluginFolderService, versionRepository, discordNotificationService, this),
-                new InfoCommand(projectRecordRepository, gitHubReleaseService, pluginFolderService, versionRepository, this),
+                new ListCommand(projectRecordRepository, pluginFileRepository, versionRepository),
+                new StatsCommand(projectRecordRepository, pluginFileRepository),
+                new CleanCommand(projectRecordRepository, pluginFileRepository, this),
+                updateCommand = new UpdateCommand(projectRecordRepository, downloadService, pluginFileRepository, versionRepository, discordNotificationService, this),
+                new InfoCommand(projectRecordRepository, gitHubReleaseRepository, pluginFileRepository, versionRepository, this),
                 new ReloadCommand(this),
-                removeCommand = new RemoveCommand(projectRecordRepository, pluginFolderService, versionRepository, dependencyResolutionService, this),
-                new SearchCommand(projectRecordRepository, pluginFolderService, versionRepository)
+                removeCommand = new RemoveCommand(projectRecordRepository, pluginFileRepository, versionRepository, dependencyResolutionService, this),
+                new SearchCommand(projectRecordRepository, pluginFileRepository, versionRepository)
         ));
         commandService.initialize(commands, "That command wasn't found.");
     }

--- a/src/main/java/dansplugins/dpm/commands/CleanCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/CleanCommand.java
@@ -1,7 +1,7 @@
 package dansplugins.dpm.commands;
 
+import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
-import dansplugins.dpm.services.PluginFolderService;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -15,13 +15,13 @@ import java.util.Map;
 
 public class CleanCommand extends AbstractPluginCommand {
     private final ProjectRecordRepository projectRecordRepository;
-    private final PluginFolderService pluginFolderService;
+    private final PluginFileRepository pluginFileRepository;
     private final Plugin plugin;
 
-    public CleanCommand(ProjectRecordRepository projectRecordRepository, PluginFolderService pluginFolderService, Plugin plugin) {
+    public CleanCommand(ProjectRecordRepository projectRecordRepository, PluginFileRepository pluginFileRepository, Plugin plugin) {
         super(new ArrayList<>(List.of("clean")), new ArrayList<>(List.of("dpm.clean")));
         this.projectRecordRepository = projectRecordRepository;
-        this.pluginFolderService = pluginFolderService;
+        this.pluginFileRepository = pluginFileRepository;
         this.plugin = plugin;
     }
 
@@ -30,7 +30,7 @@ public class CleanCommand extends AbstractPluginCommand {
         sender.sendMessage(ChatColor.AQUA + "Scanning for duplicate plugin JARs...");
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             List<String> conflicts = buildConflictLabels(
-                    pluginFolderService.findAllConflictingJars(projectRecordRepository.getAllProjectRecords()));
+                    pluginFileRepository.findAllConflictingJars(projectRecordRepository.getAllProjectRecords()));
             Bukkit.getScheduler().runTask(plugin, () -> {
                 if (conflicts.isEmpty()) {
                     sender.sendMessage(ChatColor.GREEN + "No duplicate JARs found.");
@@ -52,7 +52,7 @@ public class CleanCommand extends AbstractPluginCommand {
             sender.sendMessage(ChatColor.AQUA + "Removing duplicate plugin JARs...");
             Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
                 Map<String, List<File>> conflictMap =
-                        pluginFolderService.findAllConflictingJars(projectRecordRepository.getAllProjectRecords());
+                        pluginFileRepository.findAllConflictingJars(projectRecordRepository.getAllProjectRecords());
                 List<String> removed = new ArrayList<>();
                 List<String> failed = new ArrayList<>();
                 for (Map.Entry<String, List<File>> entry : conflictMap.entrySet()) {

--- a/src/main/java/dansplugins/dpm/commands/InfoCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/InfoCommand.java
@@ -1,11 +1,11 @@
 package dansplugins.dpm.commands;
 
+import dansplugins.dpm.repositories.GitHubReleaseRepository;
+import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
 import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.objects.ReleaseInfo;
-import dansplugins.dpm.services.GitHubReleaseService;
-import dansplugins.dpm.services.PluginFolderService;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -19,18 +19,18 @@ import java.util.Set;
 
 public class InfoCommand extends AbstractPluginCommand {
     private final ProjectRecordRepository projectRecordRepository;
-    private final GitHubReleaseService gitHubReleaseService;
-    private final PluginFolderService pluginFolderService;
+    private final GitHubReleaseRepository gitHubReleaseRepository;
+    private final PluginFileRepository pluginFileRepository;
     private final VersionRepository versionRepository;
     private final Plugin plugin;
 
-    public InfoCommand(ProjectRecordRepository projectRecordRepository, GitHubReleaseService gitHubReleaseService,
-                       PluginFolderService pluginFolderService, VersionRepository versionRepository,
+    public InfoCommand(ProjectRecordRepository projectRecordRepository, GitHubReleaseRepository gitHubReleaseRepository,
+                       PluginFileRepository pluginFileRepository, VersionRepository versionRepository,
                        Plugin plugin) {
         super(new ArrayList<>(List.of("info")), new ArrayList<>(List.of("dpm.info")));
         this.projectRecordRepository = projectRecordRepository;
-        this.gitHubReleaseService = gitHubReleaseService;
-        this.pluginFolderService = pluginFolderService;
+        this.gitHubReleaseRepository = gitHubReleaseRepository;
+        this.pluginFileRepository = pluginFileRepository;
         this.versionRepository = versionRepository;
         this.plugin = plugin;
     }
@@ -51,7 +51,7 @@ public class InfoCommand extends AbstractPluginCommand {
         }
         sender.sendMessage(ChatColor.AQUA + "Fetching release info for " + record.getName() + "...");
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            ReleaseInfo release = gitHubReleaseService.getLatestReleaseMetadata(record.getOwner(), record.getRepo());
+            ReleaseInfo release = gitHubReleaseRepository.getLatestReleaseMetadata(record.getOwner(), record.getRepo());
             Bukkit.getScheduler().runTask(plugin, () -> showInfo(sender, record, release));
         });
         return true;
@@ -112,7 +112,7 @@ public class InfoCommand extends AbstractPluginCommand {
             if (r != null) toScan.add(r);
         }
         Set<String> names = new HashSet<>();
-        for (ProjectRecord r : pluginFolderService.filterInstalled(toScan)) {
+        for (ProjectRecord r : pluginFileRepository.filterInstalled(toScan)) {
             names.add(r.getName());
         }
         return names;

--- a/src/main/java/dansplugins/dpm/commands/ListCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/ListCommand.java
@@ -1,9 +1,9 @@
 package dansplugins.dpm.commands;
 
+import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
 import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
-import dansplugins.dpm.services.PluginFolderService;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
@@ -15,14 +15,14 @@ import java.util.Set;
 
 public class ListCommand extends AbstractPluginCommand {
     private final ProjectRecordRepository projectRecordRepository;
-    private final PluginFolderService pluginFolderService;
+    private final PluginFileRepository pluginFileRepository;
     private final VersionRepository versionRepository;
 
-    public ListCommand(ProjectRecordRepository projectRecordRepository, PluginFolderService pluginFolderService,
+    public ListCommand(ProjectRecordRepository projectRecordRepository, PluginFileRepository pluginFileRepository,
                        VersionRepository versionRepository) {
         super(new ArrayList<>(List.of("list")), new ArrayList<>(List.of("dpm.list")));
         this.projectRecordRepository = projectRecordRepository;
-        this.pluginFolderService = pluginFolderService;
+        this.pluginFileRepository = pluginFileRepository;
         this.versionRepository = versionRepository;
     }
 
@@ -30,7 +30,7 @@ public class ListCommand extends AbstractPluginCommand {
     public boolean execute(CommandSender sender) {
         List<ProjectRecord> records = projectRecordRepository.getAllProjectRecords();
         Set<String> installedNames = new HashSet<>();
-        for (ProjectRecord r : pluginFolderService.filterInstalled(records)) {
+        for (ProjectRecord r : pluginFileRepository.filterInstalled(records)) {
             installedNames.add(r.getName());
         }
         sender.sendMessage(ChatColor.AQUA + "=== Plugins (" + records.size() + ") ===");
@@ -60,7 +60,7 @@ public class ListCommand extends AbstractPluginCommand {
     }
 
     private boolean executeInstalled(CommandSender sender) {
-        List<ProjectRecord> installed = pluginFolderService.filterInstalled(projectRecordRepository.getAllProjectRecords());
+        List<ProjectRecord> installed = pluginFileRepository.filterInstalled(projectRecordRepository.getAllProjectRecords());
         sender.sendMessage(ChatColor.AQUA + "=== Installed Plugins (" + installed.size() + ") ===");
         for (ProjectRecord record : installed) {
             String tag = versionRepository.getStoredTag(record.getName());
@@ -73,7 +73,7 @@ public class ListCommand extends AbstractPluginCommand {
     private boolean executeAvailable(CommandSender sender) {
         List<ProjectRecord> all = projectRecordRepository.getAllProjectRecords();
         Set<String> installedNames = new HashSet<>();
-        for (ProjectRecord r : pluginFolderService.filterInstalled(all)) {
+        for (ProjectRecord r : pluginFileRepository.filterInstalled(all)) {
             installedNames.add(r.getName());
         }
         List<ProjectRecord> available = new ArrayList<>();

--- a/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/RemoveCommand.java
@@ -1,10 +1,10 @@
 package dansplugins.dpm.commands;
 
+import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
 import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.services.DependencyResolutionService;
-import dansplugins.dpm.services.PluginFolderService;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
@@ -16,17 +16,17 @@ import java.util.List;
 
 public class RemoveCommand extends AbstractPluginCommand {
     private final ProjectRecordRepository projectRecordRepository;
-    private final PluginFolderService pluginFolderService;
+    private final PluginFileRepository pluginFileRepository;
     private final VersionRepository versionRepository;
     private final DependencyResolutionService dependencyResolutionService;
     private final Plugin plugin;
 
-    public RemoveCommand(ProjectRecordRepository projectRecordRepository, PluginFolderService pluginFolderService,
+    public RemoveCommand(ProjectRecordRepository projectRecordRepository, PluginFileRepository pluginFileRepository,
                          VersionRepository versionRepository, DependencyResolutionService dependencyResolutionService,
                          Plugin plugin) {
         super(new ArrayList<>(List.of("remove")), new ArrayList<>(List.of("dpm.remove")));
         this.projectRecordRepository = projectRecordRepository;
-        this.pluginFolderService = pluginFolderService;
+        this.pluginFileRepository = pluginFileRepository;
         this.versionRepository = versionRepository;
         this.dependencyResolutionService = dependencyResolutionService;
         this.plugin = plugin;
@@ -46,13 +46,13 @@ public class RemoveCommand extends AbstractPluginCommand {
             sender.sendMessage(ChatColor.RED + "Plugin not found: " + name + ". Use /dpm search <keyword> to find the right name.");
             return false;
         }
-        File jar = pluginFolderService.getInstalledFile(record);
+        File jar = pluginFileRepository.getInstalledFile(record);
         if (jar == null) {
             sender.sendMessage(ChatColor.YELLOW + record.getName() + " is not installed.");
             return true;
         }
 
-        List<ProjectRecord> installed = pluginFolderService.filterInstalled(projectRecordRepository.getAllProjectRecords());
+        List<ProjectRecord> installed = pluginFileRepository.filterInstalled(projectRecordRepository.getAllProjectRecords());
         List<String> dependents = dependencyResolutionService.findDependents(record.getName(), installed);
 
         boolean confirmed = args.length >= 2 && args[1].equalsIgnoreCase("--confirm");
@@ -87,7 +87,7 @@ public class RemoveCommand extends AbstractPluginCommand {
 
     public List<String> getInstalledPluginNames() {
         List<String> names = new ArrayList<>();
-        for (ProjectRecord record : pluginFolderService.filterInstalled(projectRecordRepository.getAllProjectRecords())) {
+        for (ProjectRecord record : pluginFileRepository.filterInstalled(projectRecordRepository.getAllProjectRecords())) {
             names.add(record.getName());
         }
         return names;

--- a/src/main/java/dansplugins/dpm/commands/SearchCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/SearchCommand.java
@@ -1,9 +1,9 @@
 package dansplugins.dpm.commands;
 
+import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
 import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
-import dansplugins.dpm.services.PluginFolderService;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
@@ -15,14 +15,14 @@ import java.util.Set;
 
 public class SearchCommand extends AbstractPluginCommand {
     private final ProjectRecordRepository projectRecordRepository;
-    private final PluginFolderService pluginFolderService;
+    private final PluginFileRepository pluginFileRepository;
     private final VersionRepository versionRepository;
 
-    public SearchCommand(ProjectRecordRepository projectRecordRepository, PluginFolderService pluginFolderService,
+    public SearchCommand(ProjectRecordRepository projectRecordRepository, PluginFileRepository pluginFileRepository,
                          VersionRepository versionRepository) {
         super(new ArrayList<>(List.of("search")), new ArrayList<>(List.of("dpm.list")));
         this.projectRecordRepository = projectRecordRepository;
-        this.pluginFolderService = pluginFolderService;
+        this.pluginFileRepository = pluginFileRepository;
         this.versionRepository = versionRepository;
     }
 
@@ -44,7 +44,7 @@ public class SearchCommand extends AbstractPluginCommand {
             return true;
         }
         Set<String> installedNames = new HashSet<>();
-        for (ProjectRecord r : pluginFolderService.filterInstalled(matches)) {
+        for (ProjectRecord r : pluginFileRepository.filterInstalled(matches)) {
             installedNames.add(r.getName());
         }
         sender.sendMessage(ChatColor.AQUA + "=== Search Results (" + matches.size() + ") ===");

--- a/src/main/java/dansplugins/dpm/commands/StatsCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/StatsCommand.java
@@ -1,7 +1,7 @@
 package dansplugins.dpm.commands;
 
+import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
-import dansplugins.dpm.services.PluginFolderService;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
@@ -11,18 +11,18 @@ import java.util.List;
 
 public class StatsCommand extends AbstractPluginCommand {
     private final ProjectRecordRepository projectRecordRepository;
-    private final PluginFolderService pluginFolderService;
+    private final PluginFileRepository pluginFileRepository;
 
-    public StatsCommand(ProjectRecordRepository projectRecordRepository, PluginFolderService pluginFolderService) {
+    public StatsCommand(ProjectRecordRepository projectRecordRepository, PluginFileRepository pluginFileRepository) {
         super(new ArrayList<>(List.of("stats")), new ArrayList<>(List.of("dpm.stats")));
         this.projectRecordRepository = projectRecordRepository;
-        this.pluginFolderService = pluginFolderService;
+        this.pluginFileRepository = pluginFileRepository;
     }
 
     @Override
     public boolean execute(CommandSender commandSender) {
         int total = projectRecordRepository.getNumProjectRecords();
-        int installed = pluginFolderService.filterInstalled(projectRecordRepository.getAllProjectRecords()).size();
+        int installed = pluginFileRepository.filterInstalled(projectRecordRepository.getAllProjectRecords()).size();
         int available = total - installed;
         commandSender.sendMessage(ChatColor.AQUA + "=== DPM Stats ===");
         commandSender.sendMessage(ChatColor.AQUA + "Registered plugins: " + total);

--- a/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
@@ -1,11 +1,11 @@
 package dansplugins.dpm.commands;
 
+import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
 import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.services.DiscordNotificationService;
 import dansplugins.dpm.services.DownloadService;
-import dansplugins.dpm.services.PluginFolderService;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -20,18 +20,18 @@ import java.util.stream.Collectors;
 public class UpdateCommand extends AbstractPluginCommand {
     private final ProjectRecordRepository projectRecordRepository;
     private final DownloadService downloadService;
-    private final PluginFolderService pluginFolderService;
+    private final PluginFileRepository pluginFileRepository;
     private final VersionRepository versionRepository;
     private final DiscordNotificationService discordNotificationService;
     private final Plugin plugin;
 
     public UpdateCommand(ProjectRecordRepository projectRecordRepository, DownloadService downloadService,
-                         PluginFolderService pluginFolderService, VersionRepository versionRepository,
+                         PluginFileRepository pluginFileRepository, VersionRepository versionRepository,
                          DiscordNotificationService discordNotificationService, Plugin plugin) {
         super(new ArrayList<>(List.of("update")), new ArrayList<>(List.of("dpm.update")));
         this.projectRecordRepository = projectRecordRepository;
         this.downloadService = downloadService;
-        this.pluginFolderService = pluginFolderService;
+        this.pluginFileRepository = pluginFileRepository;
         this.versionRepository = versionRepository;
         this.discordNotificationService = discordNotificationService;
         this.plugin = plugin;
@@ -65,7 +65,7 @@ public class UpdateCommand extends AbstractPluginCommand {
                 candidates.add(record);
             }
         }
-        Set<String> installedNames = pluginFolderService.filterInstalled(candidates)
+        Set<String> installedNames = pluginFileRepository.filterInstalled(candidates)
                 .stream().map(ProjectRecord::getName).collect(Collectors.toSet());
         List<ProjectRecord> toUpdate = new ArrayList<>();
         for (ProjectRecord r : candidates) {
@@ -82,12 +82,12 @@ public class UpdateCommand extends AbstractPluginCommand {
     }
 
     public List<String> getInstalledPluginNames() {
-        return pluginFolderService.filterInstalled(projectRecordRepository.getAllProjectRecords())
+        return pluginFileRepository.filterInstalled(projectRecordRepository.getAllProjectRecords())
                 .stream().map(ProjectRecord::getName).collect(Collectors.toList());
     }
 
     private List<ProjectRecord> getInstalledPlugins() {
-        return pluginFolderService.filterInstalled(projectRecordRepository.getAllProjectRecords());
+        return pluginFileRepository.filterInstalled(projectRecordRepository.getAllProjectRecords());
     }
 
     private void runUpdates(CommandSender sender, List<ProjectRecord> records) {

--- a/src/main/java/dansplugins/dpm/repositories/GitHubReleaseRepository.java
+++ b/src/main/java/dansplugins/dpm/repositories/GitHubReleaseRepository.java
@@ -1,4 +1,4 @@
-package dansplugins.dpm.services;
+package dansplugins.dpm.repositories;
 
 import dansplugins.dpm.objects.ReleaseInfo;
 import dansplugins.dpm.utils.Logger;
@@ -13,7 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class GitHubReleaseService {
+public class GitHubReleaseRepository {
     private static final String API_URL = "https://api.github.com/repos/%s/%s/releases/latest";
 
     private final Logger logger;
@@ -21,7 +21,7 @@ public class GitHubReleaseService {
     private final ConcurrentHashMap<String, ReleaseInfo> releaseCache = new ConcurrentHashMap<>();
     private final AtomicInteger cacheGeneration = new AtomicInteger(0);
 
-    public GitHubReleaseService(Logger logger) {
+    public GitHubReleaseRepository(Logger logger) {
         this.logger = logger;
     }
 

--- a/src/main/java/dansplugins/dpm/repositories/PluginFileRepository.java
+++ b/src/main/java/dansplugins/dpm/repositories/PluginFileRepository.java
@@ -1,4 +1,4 @@
-package dansplugins.dpm.services;
+package dansplugins.dpm.repositories;
 
 import dansplugins.dpm.objects.ProjectRecord;
 
@@ -10,18 +10,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class PluginFolderService {
+public class PluginFileRepository {
     private final String pluginsFolder;
 
-    public PluginFolderService() {
+    public PluginFileRepository() {
         this("./plugins/");
     }
 
-    PluginFolderService(String pluginsFolder) {
+    public PluginFileRepository(String pluginsFolder) {
         this.pluginsFolder = pluginsFolder;
     }
 
-    String getPluginsFolder() {
+    public String getPluginsFolder() {
         return pluginsFolder;
     }
 

--- a/src/main/java/dansplugins/dpm/services/DependencyResolutionService.java
+++ b/src/main/java/dansplugins/dpm/services/DependencyResolutionService.java
@@ -1,5 +1,6 @@
 package dansplugins.dpm.services;
 
+import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
 import dansplugins.dpm.objects.ProjectRecord;
 
@@ -12,11 +13,11 @@ import java.util.stream.Collectors;
 
 public class DependencyResolutionService {
     private final ProjectRecordRepository projectRecordRepository;
-    private final PluginFolderService pluginFolderService;
+    private final PluginFileRepository pluginFileRepository;
 
-    public DependencyResolutionService(ProjectRecordRepository projectRecordRepository, PluginFolderService pluginFolderService) {
+    public DependencyResolutionService(ProjectRecordRepository projectRecordRepository, PluginFileRepository pluginFileRepository) {
         this.projectRecordRepository = projectRecordRepository;
-        this.pluginFolderService = pluginFolderService;
+        this.pluginFileRepository = pluginFileRepository;
     }
 
     // Caller supplies the pre-filtered installed list so no extra directory scan happens here.
@@ -37,7 +38,7 @@ public class DependencyResolutionService {
     // resolved must be pre-seeded with lowercase names already in the batch; prevents circular re-processing
     public void resolve(List<ProjectRecord> toProcess, Set<String> resolved,
                         List<ProjectRecord> depsToFetch, List<String> unknownDeps) {
-        Set<String> installedLower = pluginFolderService.filterInstalled(projectRecordRepository.getAllProjectRecords())
+        Set<String> installedLower = pluginFileRepository.filterInstalled(projectRecordRepository.getAllProjectRecords())
                 .stream().map(r -> r.getName().toLowerCase()).collect(Collectors.toSet());
 
         Queue<ProjectRecord> queue = new ArrayDeque<>(toProcess);

--- a/src/main/java/dansplugins/dpm/services/DownloadService.java
+++ b/src/main/java/dansplugins/dpm/services/DownloadService.java
@@ -2,6 +2,8 @@ package dansplugins.dpm.services;
 
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.objects.ReleaseInfo;
+import dansplugins.dpm.repositories.GitHubReleaseRepository;
+import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.utils.Logger;
 
@@ -24,26 +26,26 @@ public class DownloadService {
     public static final int FILE_ERROR = -5;
 
     private final Logger logger;
-    private final GitHubReleaseService gitHubReleaseService;
-    private final PluginFolderService pluginFolderService;
+    private final GitHubReleaseRepository gitHubReleaseRepository;
+    private final PluginFileRepository pluginFileRepository;
     private final VersionRepository versionRepository;
 
-    public DownloadService(Logger logger, GitHubReleaseService gitHubReleaseService,
-                           PluginFolderService pluginFolderService, VersionRepository versionRepository) {
+    public DownloadService(Logger logger, GitHubReleaseRepository gitHubReleaseRepository,
+                           PluginFileRepository pluginFileRepository, VersionRepository versionRepository) {
         this.logger = logger;
-        this.gitHubReleaseService = gitHubReleaseService;
-        this.pluginFolderService = pluginFolderService;
+        this.gitHubReleaseRepository = gitHubReleaseRepository;
+        this.pluginFileRepository = pluginFileRepository;
         this.versionRepository = versionRepository;
     }
 
     public int downloadLatest(ProjectRecord projectRecord) {
-        return downloadLatest(projectRecord, pluginFolderService.isInstalled(projectRecord));
+        return downloadLatest(projectRecord, pluginFileRepository.isInstalled(projectRecord));
     }
 
     // physicallyInstalled lets callers that have already confirmed the JAR is present (e.g. via
     // filterInstalled()) skip the per-call isInstalled() directory scan.
     public int downloadLatest(ProjectRecord projectRecord, boolean physicallyInstalled) {
-        ReleaseInfo release = gitHubReleaseService.getLatestRelease(projectRecord.getOwner(), projectRecord.getRepo());
+        ReleaseInfo release = gitHubReleaseRepository.getLatestRelease(projectRecord.getOwner(), projectRecord.getRepo());
         if (release == ReleaseInfo.NO_RELEASE) {
             return NO_RELEASE;
         }
@@ -59,7 +61,7 @@ public class DownloadService {
             return ALREADY_UP_TO_DATE;
         }
 
-        String dest = pluginFolderService.getPluginsFolder() + projectRecord.getName() + ".jar";
+        String dest = pluginFileRepository.getPluginsFolder() + projectRecord.getName() + ".jar";
         int bytes = downloadFromUrl(release.getJarUrl(), dest);
         if (bytes > 0) {
             removeConflictingJars(projectRecord);
@@ -71,7 +73,7 @@ public class DownloadService {
     }
 
     private void removeConflictingJars(ProjectRecord projectRecord) {
-        List<File> conflicts = pluginFolderService.findConflictingJars(projectRecord);
+        List<File> conflicts = pluginFileRepository.findConflictingJars(projectRecord);
         for (File conflict : conflicts) {
             if (conflict.delete()) {
                 logger.log("Removed older JAR after download: " + conflict.getName());

--- a/src/test/java/dansplugins/dpm/repositories/GitHubReleaseRepositoryTest.java
+++ b/src/test/java/dansplugins/dpm/repositories/GitHubReleaseRepositoryTest.java
@@ -1,4 +1,4 @@
-package dansplugins.dpm.services;
+package dansplugins.dpm.repositories;
 
 import dansplugins.dpm.objects.ReleaseInfo;
 import dansplugins.dpm.utils.Logger;
@@ -15,10 +15,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class GitHubReleaseServiceTest {
+class GitHubReleaseRepositoryTest {
 
     // Logger is only used for HTTP errors; null is safe for pure parsing tests.
-    private final GitHubReleaseService service = new GitHubReleaseService(null);
+    private final GitHubReleaseRepository service = new GitHubReleaseRepository(null);
 
     // -------------------------------------------------------------------------
     // parseJarUrlFromAssets()
@@ -152,7 +152,7 @@ class GitHubReleaseServiceTest {
     @Test
     void getLatestRelease_returnsCachedResultOnSecondCall() {
         AtomicInteger fetchCount = new AtomicInteger(0);
-        GitHubReleaseService svc = new GitHubReleaseService(null) {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null) {
             @Override
             ReleaseInfo doFetch(String owner, String repo) {
                 fetchCount.incrementAndGet();
@@ -167,7 +167,7 @@ class GitHubReleaseServiceTest {
     @Test
     void clearCache_causesRefetchOnNextCall() {
         AtomicInteger fetchCount = new AtomicInteger(0);
-        GitHubReleaseService svc = new GitHubReleaseService(null) {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null) {
             @Override
             ReleaseInfo doFetch(String owner, String repo) {
                 fetchCount.incrementAndGet();
@@ -183,7 +183,7 @@ class GitHubReleaseServiceTest {
     @Test
     void differentRepos_eachFetchedOnce() {
         AtomicInteger fetchCount = new AtomicInteger(0);
-        GitHubReleaseService svc = new GitHubReleaseService(null) {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null) {
             @Override
             ReleaseInfo doFetch(String owner, String repo) {
                 fetchCount.incrementAndGet();
@@ -200,7 +200,7 @@ class GitHubReleaseServiceTest {
     @Test
     void noRelease_isCached() {
         AtomicInteger fetchCount = new AtomicInteger(0);
-        GitHubReleaseService svc = new GitHubReleaseService(null) {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null) {
             @Override
             ReleaseInfo doFetch(String owner, String repo) {
                 fetchCount.incrementAndGet();
@@ -215,7 +215,7 @@ class GitHubReleaseServiceTest {
     @Test
     void networkError_isNotCached() {
         AtomicInteger fetchCount = new AtomicInteger(0);
-        GitHubReleaseService svc = new GitHubReleaseService(null) {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null) {
             @Override
             ReleaseInfo doFetch(String owner, String repo) {
                 fetchCount.incrementAndGet();
@@ -263,7 +263,7 @@ class GitHubReleaseServiceTest {
     @Test
     void doFetch_returnsNull_andWarns_onHttp401() throws IOException {
         List<String> warnings = new ArrayList<>();
-        GitHubReleaseService svc = new GitHubReleaseService(capturingLogger(warnings)) {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(capturingLogger(warnings)) {
             @Override
             HttpURLConnection openConnection(String url) throws IOException {
                 return fakeConnection(401, null);
@@ -277,7 +277,7 @@ class GitHubReleaseServiceTest {
     @Test
     void doFetch_returnsNull_andWarns_onHttp429RateLimit() throws IOException {
         List<String> warnings = new ArrayList<>();
-        GitHubReleaseService svc = new GitHubReleaseService(capturingLogger(warnings)) {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(capturingLogger(warnings)) {
             @Override
             HttpURLConnection openConnection(String url) throws IOException {
                 return fakeConnection(429, null);
@@ -291,7 +291,7 @@ class GitHubReleaseServiceTest {
     @Test
     void doFetch_returnsNull_andWarns_onHttp403WithZeroRateLimitRemaining() throws IOException {
         List<String> warnings = new ArrayList<>();
-        GitHubReleaseService svc = new GitHubReleaseService(capturingLogger(warnings)) {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(capturingLogger(warnings)) {
             @Override
             HttpURLConnection openConnection(String url) throws IOException {
                 return fakeConnection(403, "0");
@@ -305,7 +305,7 @@ class GitHubReleaseServiceTest {
     @Test
     void doFetch_returnsNull_andWarns_onGenericNon200() throws IOException {
         List<String> warnings = new ArrayList<>();
-        GitHubReleaseService svc = new GitHubReleaseService(capturingLogger(warnings)) {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(capturingLogger(warnings)) {
             @Override
             HttpURLConnection openConnection(String url) throws IOException {
                 return fakeConnection(500, null);
@@ -325,7 +325,7 @@ class GitHubReleaseServiceTest {
         int[] callCount = {0};
         String successJson = "{\"tag_name\":\"v1.0\",\"published_at\":\"2024-01-01T00:00:00Z\"," +
                 "\"assets\":[{\"browser_download_url\":\"https://example.com/plugin.jar\"}]}";
-        GitHubReleaseService svc = new GitHubReleaseService(null) {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null) {
             @Override void sleepMs(long ms) {}
             @Override
             HttpURLConnection openConnection(String url) throws IOException {
@@ -344,7 +344,7 @@ class GitHubReleaseServiceTest {
         int[] callCount = {0};
         String successJson = "{\"tag_name\":\"v2.0\",\"published_at\":\"2024-01-01T00:00:00Z\"," +
                 "\"assets\":[{\"browser_download_url\":\"https://example.com/plugin.jar\"}]}";
-        GitHubReleaseService svc = new GitHubReleaseService(null) {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null) {
             @Override void sleepMs(long ms) {}
             @Override
             HttpURLConnection openConnection(String url) throws IOException {
@@ -361,7 +361,7 @@ class GitHubReleaseServiceTest {
     void doFetch_doesNotRetryOn4xxClientError() throws IOException {
         int[] callCount = {0};
         List<String> warnings = new ArrayList<>();
-        GitHubReleaseService svc = new GitHubReleaseService(capturingLogger(warnings)) {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(capturingLogger(warnings)) {
             @Override void sleepMs(long ms) {}
             @Override
             HttpURLConnection openConnection(String url) throws IOException {
@@ -377,7 +377,7 @@ class GitHubReleaseServiceTest {
     void doFetch_returnsNull_afterBothAttemptsFailWithIoException() throws IOException {
         int[] callCount = {0};
         List<String> warnings = new ArrayList<>();
-        GitHubReleaseService svc = new GitHubReleaseService(capturingLogger(warnings)) {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(capturingLogger(warnings)) {
             @Override void sleepMs(long ms) {}
             @Override
             HttpURLConnection openConnection(String url) throws IOException {
@@ -394,7 +394,7 @@ class GitHubReleaseServiceTest {
     void doFetch_returnsNull_afterBoth5xxAttemptsFail() throws IOException {
         int[] callCount = {0};
         List<String> warnings = new ArrayList<>();
-        GitHubReleaseService svc = new GitHubReleaseService(capturingLogger(warnings)) {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(capturingLogger(warnings)) {
             @Override void sleepMs(long ms) {}
             @Override
             HttpURLConnection openConnection(String url) throws IOException {

--- a/src/test/java/dansplugins/dpm/repositories/PluginFileRepositoryTest.java
+++ b/src/test/java/dansplugins/dpm/repositories/PluginFileRepositoryTest.java
@@ -1,4 +1,4 @@
-package dansplugins.dpm.services;
+package dansplugins.dpm.repositories;
 
 import dansplugins.dpm.objects.ProjectRecord;
 import org.junit.jupiter.api.Test;
@@ -12,9 +12,9 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class PluginFolderServiceTest {
+class PluginFileRepositoryTest {
 
-    private final PluginFolderService service = new PluginFolderService();
+    private final PluginFileRepository service = new PluginFileRepository();
 
     // -------------------------------------------------------------------------
     // normalize()
@@ -101,7 +101,7 @@ class PluginFolderServiceTest {
         createFile(tempDir, "Medieval-Factions-4.6.3.jar");
         createFile(tempDir, "medievalfactions.jar");
 
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
 
         List<File> conflicts = svc.findConflictingJars(record);
@@ -113,7 +113,7 @@ class PluginFolderServiceTest {
     void findConflictingJars_ignoresManagedFile(@TempDir Path tempDir) throws IOException {
         createFile(tempDir, "medievalfactions.jar");
 
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
 
         assertTrue(svc.findConflictingJars(record).isEmpty());
@@ -123,7 +123,7 @@ class PluginFolderServiceTest {
     void findConflictingJars_ignoresDifferentPlugin(@TempDir Path tempDir) throws IOException {
         createFile(tempDir, "Medieval-Factions-4.6.3.jar");
 
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         ProjectRecord record = ProjectRecord.forGitHub("currencies", "Dans-Plugins", "Currencies");
 
         assertTrue(svc.findConflictingJars(record).isEmpty());
@@ -135,7 +135,7 @@ class PluginFolderServiceTest {
         createFile(tempDir, "Medieval-Factions-4.6.3.jar");
         createFile(tempDir, "medievalfactions.jar");
 
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
 
         assertEquals(2, svc.findConflictingJars(record).size());
@@ -143,7 +143,7 @@ class PluginFolderServiceTest {
 
     @Test
     void findConflictingJars_emptyFolder(@TempDir Path tempDir) {
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
 
         assertTrue(svc.findConflictingJars(record).isEmpty());
@@ -154,7 +154,7 @@ class PluginFolderServiceTest {
         createFile(tempDir, "Medieval-Factions-4.6.3.zip");
         createFile(tempDir, "Medieval-Factions-4.6.3.txt");
 
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
 
         assertTrue(svc.findConflictingJars(record).isEmpty());
@@ -167,7 +167,7 @@ class PluginFolderServiceTest {
         createFile(tempDir, "MEDIEVALFACTIONS.JAR");
         createFile(tempDir, "Medieval-Factions-4.6.3.jar");
 
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
 
         List<File> conflicts = svc.findConflictingJars(record);
@@ -177,7 +177,7 @@ class PluginFolderServiceTest {
 
     @Test
     void findConflictingJars_nonExistentFolderReturnsEmpty() {
-        PluginFolderService svc = new PluginFolderService("/this/path/does/not/exist");
+        PluginFileRepository svc = new PluginFileRepository("/this/path/does/not/exist");
         ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
 
         assertTrue(svc.findConflictingJars(record).isEmpty());
@@ -190,14 +190,14 @@ class PluginFolderServiceTest {
     @Test
     void isInstalled_returnsTrueWhenManagedJarExists(@TempDir Path tempDir) throws IOException {
         createFile(tempDir, "medievalfactions.jar");
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
         assertTrue(svc.isInstalled(record));
     }
 
     @Test
     void isInstalled_returnsFalseWhenManagedJarAbsent(@TempDir Path tempDir) {
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
         assertFalse(svc.isInstalled(record));
     }
@@ -206,7 +206,7 @@ class PluginFolderServiceTest {
     void isInstalled_returnsFalseWhenOnlyVersionedJarPresent(@TempDir Path tempDir) throws IOException {
         // The versioned copy is a conflict, not the managed file
         createFile(tempDir, "Medieval-Factions-4.6.3.jar");
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
         assertFalse(svc.isInstalled(record));
     }
@@ -218,7 +218,7 @@ class PluginFolderServiceTest {
     @Test
     void filterInstalled_returnsOnlyInstalledRecords(@TempDir Path tempDir) throws IOException {
         createFile(tempDir, "medievalfactions.jar");
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         List<ProjectRecord> records = List.of(
                 ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions"),
                 ProjectRecord.forGitHub("currencies", "Dans-Plugins", "Currencies")
@@ -232,7 +232,7 @@ class PluginFolderServiceTest {
     void filterInstalled_returnsAllWhenAllInstalled(@TempDir Path tempDir) throws IOException {
         createFile(tempDir, "medievalfactions.jar");
         createFile(tempDir, "currencies.jar");
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         List<ProjectRecord> records = List.of(
                 ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions"),
                 ProjectRecord.forGitHub("currencies", "Dans-Plugins", "Currencies")
@@ -242,7 +242,7 @@ class PluginFolderServiceTest {
 
     @Test
     void filterInstalled_returnsEmptyWhenNoneInstalled(@TempDir Path tempDir) {
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         List<ProjectRecord> records = List.of(
                 ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions")
         );
@@ -252,14 +252,14 @@ class PluginFolderServiceTest {
     @Test
     void filterInstalled_returnsEmptyForEmptyInput(@TempDir Path tempDir) throws IOException {
         createFile(tempDir, "medievalfactions.jar");
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         assertTrue(svc.filterInstalled(List.of()).isEmpty());
     }
 
     @Test
     void filterInstalled_isCaseInsensitive(@TempDir Path tempDir) throws IOException {
         createFile(tempDir, "MedievalFactions.jar");
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         List<ProjectRecord> records = List.of(
                 ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions")
         );
@@ -268,7 +268,7 @@ class PluginFolderServiceTest {
 
     @Test
     void filterInstalled_nonExistentFolderReturnsEmpty() {
-        PluginFolderService svc = new PluginFolderService("/this/path/does/not/exist");
+        PluginFileRepository svc = new PluginFileRepository("/this/path/does/not/exist");
         List<ProjectRecord> records = List.of(
                 ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions")
         );
@@ -282,7 +282,7 @@ class PluginFolderServiceTest {
     @Test
     void getInstalledFile_returnsFileWhenPresent(@TempDir Path tempDir) throws IOException {
         createFile(tempDir, "medievalfactions.jar");
-        PluginFolderService svc = new PluginFolderService(tempDir.toString() + "/");
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString() + "/");
         ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
         File result = svc.getInstalledFile(record);
         assertNotNull(result);
@@ -291,7 +291,7 @@ class PluginFolderServiceTest {
 
     @Test
     void getInstalledFile_returnsNullWhenAbsent(@TempDir Path tempDir) {
-        PluginFolderService svc = new PluginFolderService(tempDir.toString() + "/");
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString() + "/");
         ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
         assertNull(svc.getInstalledFile(record));
     }
@@ -299,7 +299,7 @@ class PluginFolderServiceTest {
     @Test
     void getInstalledFile_caseInsensitiveMatch(@TempDir Path tempDir) throws IOException {
         createFile(tempDir, "MedievalFactions.jar");
-        PluginFolderService svc = new PluginFolderService(tempDir.toString() + "/");
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString() + "/");
         ProjectRecord record = ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions");
         assertNotNull(svc.getInstalledFile(record));
     }
@@ -313,7 +313,7 @@ class PluginFolderServiceTest {
         createFile(tempDir, "Medieval-Factions-4.6.3.jar");
         createFile(tempDir, "medievalfactions.jar");
 
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         List<ProjectRecord> records = List.of(
                 ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions"),
                 ProjectRecord.forGitHub("currencies", "Dans-Plugins", "Currencies")
@@ -330,7 +330,7 @@ class PluginFolderServiceTest {
     void findAllConflictingJars_emptyWhenNoConflicts(@TempDir Path tempDir) throws IOException {
         createFile(tempDir, "medievalfactions.jar");
 
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         List<ProjectRecord> records = List.of(
                 ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions")
         );
@@ -345,7 +345,7 @@ class PluginFolderServiceTest {
         createFile(tempDir, "Currencies-2.1.jar");
         createFile(tempDir, "currencies.jar");
 
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         List<ProjectRecord> records = List.of(
                 ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions"),
                 ProjectRecord.forGitHub("currencies", "Dans-Plugins", "Currencies")
@@ -359,7 +359,7 @@ class PluginFolderServiceTest {
 
     @Test
     void findAllConflictingJars_emptyFolder(@TempDir Path tempDir) {
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         List<ProjectRecord> records = List.of(
                 ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions")
         );
@@ -368,7 +368,7 @@ class PluginFolderServiceTest {
 
     @Test
     void findAllConflictingJars_nonExistentFolderReturnsEmpty() {
-        PluginFolderService svc = new PluginFolderService("/this/path/does/not/exist");
+        PluginFileRepository svc = new PluginFileRepository("/this/path/does/not/exist");
         List<ProjectRecord> records = List.of(
                 ProjectRecord.forGitHub("medievalfactions", "Dans-Plugins", "Medieval-Factions")
         );
@@ -378,7 +378,7 @@ class PluginFolderServiceTest {
     @Test
     void findAllConflictingJars_emptyInputReturnsEmpty(@TempDir Path tempDir) throws IOException {
         createFile(tempDir, "Medieval-Factions-4.6.3.jar");
-        PluginFolderService svc = new PluginFolderService(tempDir.toString());
+        PluginFileRepository svc = new PluginFileRepository(tempDir.toString());
         assertTrue(svc.findAllConflictingJars(List.of()).isEmpty());
     }
 

--- a/src/test/java/dansplugins/dpm/services/DependencyResolutionServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/DependencyResolutionServiceTest.java
@@ -1,5 +1,6 @@
 package dansplugins.dpm.services;
 
+import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
 import dansplugins.dpm.objects.ProjectRecord;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,14 +24,14 @@ class DependencyResolutionServiceTest {
     Path tempDir;
 
     private ProjectRecordRepository projectRecordRepository;
-    private PluginFolderService pluginFolderService;
+    private PluginFileRepository pluginFileRepository;
     private DependencyResolutionService service;
 
     @BeforeEach
     void setUp() {
         projectRecordRepository = new ProjectRecordRepository();
-        pluginFolderService = new PluginFolderService(tempDir.toString());
-        service = new DependencyResolutionService(projectRecordRepository, pluginFolderService);
+        pluginFileRepository = new PluginFileRepository(tempDir.toString());
+        service = new DependencyResolutionService(projectRecordRepository, pluginFileRepository);
     }
 
     private ProjectRecord registerRecord(String name, List<String> hardDeps) {

--- a/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
@@ -2,6 +2,8 @@ package dansplugins.dpm.services;
 
 import dansplugins.dpm.objects.ProjectRecord;
 import dansplugins.dpm.objects.ReleaseInfo;
+import dansplugins.dpm.repositories.GitHubReleaseRepository;
+import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.utils.Logger;
 import org.junit.jupiter.api.Test;
@@ -22,8 +24,8 @@ class DownloadServiceTest {
     // sleepMs is overridden to a no-op so retry tests don't add real delays.
     private final DownloadService service = noSleepService(null, null, null, null);
 
-    private static DownloadService noSleepService(Logger logger, GitHubReleaseService ghrs,
-                                                   PluginFolderService pfs, VersionRepository vr) {
+    private static DownloadService noSleepService(Logger logger, GitHubReleaseRepository ghrs,
+                                                   PluginFileRepository pfs, VersionRepository vr) {
         return new DownloadService(logger, ghrs, pfs, vr) {
             @Override void sleepMs(long ms) {}
         };
@@ -91,9 +93,9 @@ class DownloadServiceTest {
         Files.write(src.toPath(), content);
 
         VersionRepository versionRepository = versionRepository(tempDir);
-        PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         DownloadService svc = noSleepService(null, fakeRelease("v1.0.0", src.toURI().toString()),
-                pluginFolderService, versionRepository);
+                pluginFileRepository, versionRepository);
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         int result = svc.downloadLatest(record);
@@ -108,9 +110,9 @@ class DownloadServiceTest {
         versionRepository.setTag("testplugin", "v1.0.0");
         Files.write(tempDir.resolve("testplugin.jar"), new byte[]{1});
 
-        PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         DownloadService svc = new DownloadService(null, fakeRelease("v1.0.0", "http://unused"),
-                pluginFolderService, versionRepository);
+                pluginFileRepository, versionRepository);
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertEquals(DownloadService.ALREADY_UP_TO_DATE, svc.downloadLatest(record));
@@ -125,9 +127,9 @@ class DownloadServiceTest {
         File src = tempDir.resolve("source.jar").toFile();
         Files.write(src.toPath(), new byte[]{1, 2, 3});
 
-        PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         DownloadService svc = new DownloadService(null, fakeRelease("v1.0.0", src.toURI().toString()),
-                pluginFolderService, versionRepository);
+                pluginFileRepository, versionRepository);
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertTrue(svc.downloadLatest(record) > 0, "Should re-download when JAR is absent despite matching tag");
@@ -135,14 +137,14 @@ class DownloadServiceTest {
 
     @Test
     void downloadLatest_returnsNoRelease_whenGitHubReportsNone(@TempDir Path tempDir) {
-        PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
-        GitHubReleaseService noReleaseService = new GitHubReleaseService(null) {
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
+        GitHubReleaseRepository noReleaseService = new GitHubReleaseRepository(null) {
             @Override
             public ReleaseInfo getLatestRelease(String owner, String repo) {
                 return ReleaseInfo.NO_RELEASE;
             }
         };
-        DownloadService svc = new DownloadService(null, noReleaseService, pluginFolderService, versionRepository(tempDir));
+        DownloadService svc = new DownloadService(null, noReleaseService, pluginFileRepository, versionRepository(tempDir));
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertEquals(DownloadService.NO_RELEASE, svc.downloadLatest(record));
@@ -157,9 +159,9 @@ class DownloadServiceTest {
         VersionRepository versionRepository = versionRepository(tempDir);
         versionRepository.setTag("testplugin", "v1.0.0");
 
-        // PluginFolderService with a non-existent folder — isInstalled() would return false
+        // PluginFileRepository with a non-existent folder — isInstalled() would return false
         // if called, but the hint bypasses the scan entirely.
-        PluginFolderService noScanService = new PluginFolderService("/this/path/does/not/exist");
+        PluginFileRepository noScanService = new PluginFileRepository("/this/path/does/not/exist");
         DownloadService svc = new DownloadService(null, fakeRelease("v1.0.0", "http://unused"),
                 noScanService, versionRepository);
 
@@ -175,9 +177,9 @@ class DownloadServiceTest {
         File src = tempDir.resolve("source.jar").toFile();
         Files.write(src.toPath(), new byte[]{1, 2, 3});
 
-        PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         DownloadService svc = new DownloadService(null, fakeRelease("v1.0.0", src.toURI().toString()),
-                pluginFolderService, versionRepository);
+                pluginFileRepository, versionRepository);
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertTrue(svc.downloadLatest(record, false) > 0,
@@ -190,9 +192,9 @@ class DownloadServiceTest {
         versionRepository.setTag("testplugin", "v1.0.0");
         Files.write(tempDir.resolve("testplugin.jar"), new byte[]{1});
 
-        PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         DownloadService svc = new DownloadService(null, fakeRelease("v1.0.0", "http://unused"),
-                pluginFolderService, versionRepository);
+                pluginFileRepository, versionRepository);
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertEquals(DownloadService.ALREADY_UP_TO_DATE, svc.downloadLatest(record));
@@ -211,10 +213,10 @@ class DownloadServiceTest {
             @Override public void log(String message) {}
             @Override public void warn(String message) {}
         };
-        PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         DownloadService svc = noSleepService(noOpLogger,
                 fakeRelease("v2.0.0", "http://localhost:1/nonexistent.jar"),
-                pluginFolderService, versionRepository(tempDir));
+                pluginFileRepository, versionRepository(tempDir));
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertEquals(DownloadService.NETWORK_ERROR, svc.downloadLatest(record));
@@ -233,10 +235,10 @@ class DownloadServiceTest {
             @Override public void log(String message) {}
             @Override public void warn(String message) {}
         };
-        PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         DownloadService svc = new DownloadService(noOpLogger,
                 fakeRelease("v2.0.0", src.toURI().toString()),
-                pluginFolderService, versionRepository(tempDir));
+                pluginFileRepository, versionRepository(tempDir));
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertTrue(svc.downloadLatest(record) > 0);
@@ -253,10 +255,10 @@ class DownloadServiceTest {
             @Override public void log(String message) {}
             @Override public void warn(String message) {}
         };
-        PluginFolderService pluginFolderService = new PluginFolderService(tempDir.toString());
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         DownloadService svc = noSleepService(noOpLogger,
                 fakeRelease("v1.0.0", "http://localhost:1/nonexistent.jar"),
-                pluginFolderService, versionRepository(tempDir));
+                pluginFileRepository, versionRepository(tempDir));
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertEquals(DownloadService.NETWORK_ERROR, svc.downloadLatest(record));
@@ -276,10 +278,10 @@ class DownloadServiceTest {
             @Override public void log(String message) {}
             @Override public void warn(String message) {}
         };
-        PluginFolderService pluginFolderService = new PluginFolderService(readOnlyDir.getAbsolutePath() + "/");
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(readOnlyDir.getAbsolutePath() + "/");
         DownloadService svc = new DownloadService(noOpLogger,
                 fakeRelease("v1.0.0", src.toURI().toString()),
-                pluginFolderService, versionRepository(tempDir));
+                pluginFileRepository, versionRepository(tempDir));
 
         ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
         assertEquals(DownloadService.FILE_ERROR, svc.downloadLatest(record));
@@ -336,8 +338,8 @@ class DownloadServiceTest {
         return new VersionRepository(tempDir.resolve("dpm-versions.properties").toFile(), noOp);
     }
 
-    private GitHubReleaseService fakeRelease(String tag, String jarUrl) {
-        return new GitHubReleaseService(null) {
+    private GitHubReleaseRepository fakeRelease(String tag, String jarUrl) {
+        return new GitHubReleaseRepository(null) {
             @Override
             public ReleaseInfo getLatestRelease(String owner, String repo) {
                 return new ReleaseInfo(tag, jarUrl);


### PR DESCRIPTION
## Summary

- Moves `PluginFolderService` -> `repositories/PluginFileRepository` and `GitHubReleaseService` -> `repositories/GitHubReleaseRepository`. Both are data-access classes (filesystem scanning, GitHub REST calls) rather than business logic, per the layering proposed in #94 and the pattern already applied to `EphemeralData -> ProjectRecordRepository` (#102) and `VersionStore -> VersionRepository` (#104).
- Pure rename/move — no logic changes. `filterInstalled(records)` is untouched (still the batch method; the O(N×M) loop pattern in `UpdateCommand`, tracked separately in issue #37, was left as-is).
- `PluginFileRepository`'s test-support constructor and `getPluginsFolder()` were widened from package-private to `public` — required because callers (`DownloadService`, and package-private-constructor usages in `DownloadServiceTest`/`DependencyResolutionServiceTest`) now live in a different package than the class. No other visibility or behavior changes.
- Updated every call site: `DownloadService`, `DependencyResolutionService`, `DansPluginManager`, `RemoveCommand`, `ListCommand`, `UpdateCommand`, `CleanCommand`, `InfoCommand`, `StatsCommand`, `SearchCommand`, and the corresponding test files.
- Added a `CHANGELOG.md` `[Unreleased]` entry for the reclassification (the two prior renames toward #94, #102 and #104, did not add one — not addressed here, out of scope for this PR).

## Doc-drift note (not applied — needs separate authorization)

`CLAUDE.md` references the old name `PluginFolderService` in three places (test-style guidance, and the O(N×M)-scan code-pattern note). Per this dev loop's standing rule, editing agent-loaded config (`CLAUDE.md`) requires explicit separate authorization, so it was not changed here. A human should update those three mentions to `PluginFileRepository` once this PR merges.

## Test plan

- [x] `mvn compile` — clean
- [x] `mvn test` — 155/156 pass. The one failure, `DownloadServiceTest.downloadLatest_returnsFileError_whenDestinationUnwritable`, is a pre-existing environment flake unrelated to this change (the test's `assumeTrue(readOnlyDir.setWritable(false), ...)` guard doesn't catch that a root-user process can still write to a "read-only" directory; confirmed identical failure on unmodified `main` in this sandbox, which runs as root — GitHub Actions runners are non-root, so CI is expected to pass).
- [x] No command syntax, permission node, or user-visible behavior changed — `HelpCommand.java`, `COMMANDS.md`, and `USER_GUIDE.md` require no updates.

Closes #98
Closes #99

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
