### PR TITLE
Introduce GetController: extract /dpm get orchestration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Reclassified `PluginFolderService` as `PluginFileRepository` and `GitHubReleaseService` as `GitHubReleaseRepository`, moving both into the `repositories/` package — both are data-access classes (filesystem scanning, GitHub API calls), not business logic, per the layering proposed in #94. No behavior change.
 - Split `ConfigService` into `ConfigRepository` (`repositories/` package — plain config I/O) and `ConfigController` (`controllers/` package — option validation, `CommandSender` messaging, the `hasBeenAltered` flag), per the layering proposed in #94. `DansPluginManager` and `DiscordNotificationService` now depend on `ConfigRepository`. No behavior change.
+- Introduced `GetController` (`controllers/` package), which now owns `/dpm get`'s dependency resolution and download-loop orchestration, returning plain per-plugin result data (`GetController.PluginResult`) instead of calling `sender.sendMessage()` directly. `GetCommand` is now a thin router that formats and sends the results; the async `runTaskAsynchronously`/`runTask` dispatch pattern is unchanged. This is the template for the remaining controllers proposed in #94. No user-visible behavior change.
 
 ## [0.6.0] - 2026-05-18
 

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -1,6 +1,7 @@
 package dansplugins.dpm;
 
 import dansplugins.dpm.commands.*;
+import dansplugins.dpm.controllers.GetController;
 import dansplugins.dpm.repositories.ConfigRepository;
 import dansplugins.dpm.repositories.GitHubReleaseRepository;
 import dansplugins.dpm.repositories.PluginFileRepository;
@@ -44,6 +45,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     private final DiscordNotificationService discordNotificationService = new DiscordNotificationService(configRepository);
     private VersionRepository versionRepository;
     private DownloadService downloadService;
+    private GetController getController;
     private RemoveCommand removeCommand;
     private UpdateCommand updateCommand;
 
@@ -53,6 +55,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
         gitHubReleaseRepository.setApiToken(configRepository.getStringOrDefault("githubToken", ""));
         versionRepository = new VersionRepository(new File(getDataFolder(), "dpm-versions.properties"), logger);
         downloadService = new DownloadService(logger, gitHubReleaseRepository, pluginFileRepository, versionRepository);
+        getController = new GetController(downloadService, dependencyResolutionService, versionRepository, discordNotificationService, getLogger());
         initializeCommandService();
         projectRecordInitializer.initializeProjectRecords();
     }
@@ -155,7 +158,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     private void initializeCommandService() {
         ArrayList<AbstractPluginCommand> commands = new ArrayList<>(Arrays.asList(
                 new HelpCommand(),
-                new GetCommand(projectRecordRepository, downloadService, dependencyResolutionService, versionRepository, discordNotificationService, this),
+                new GetCommand(projectRecordRepository, getController, this),
                 new ListCommand(projectRecordRepository, pluginFileRepository, versionRepository),
                 new StatsCommand(projectRecordRepository, pluginFileRepository),
                 new CleanCommand(projectRecordRepository, pluginFileRepository, this),

--- a/src/main/java/dansplugins/dpm/commands/GetCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/GetCommand.java
@@ -1,11 +1,10 @@
 package dansplugins.dpm.commands;
 
+import dansplugins.dpm.controllers.GetController;
+import dansplugins.dpm.controllers.GetController.DependencyResolutionResult;
+import dansplugins.dpm.controllers.GetController.PluginResult;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
-import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
-import dansplugins.dpm.services.DependencyResolutionService;
-import dansplugins.dpm.services.DiscordNotificationService;
-import dansplugins.dpm.services.DownloadService;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -13,29 +12,17 @@ import org.bukkit.plugin.Plugin;
 import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public class GetCommand extends AbstractPluginCommand {
     private final ProjectRecordRepository projectRecordRepository;
-    private final DownloadService downloadService;
-    private final DependencyResolutionService dependencyResolutionService;
-    private final VersionRepository versionRepository;
-    private final DiscordNotificationService discordNotificationService;
+    private final GetController getController;
     private final Plugin plugin;
 
-    public GetCommand(ProjectRecordRepository projectRecordRepository, DownloadService downloadService,
-                      DependencyResolutionService dependencyResolutionService,
-                      VersionRepository versionRepository, DiscordNotificationService discordNotificationService,
-                      Plugin plugin) {
+    public GetCommand(ProjectRecordRepository projectRecordRepository, GetController getController, Plugin plugin) {
         super(new ArrayList<>(List.of("get")), new ArrayList<>(List.of("dpm.get")));
         this.projectRecordRepository = projectRecordRepository;
-        this.downloadService = downloadService;
-        this.dependencyResolutionService = dependencyResolutionService;
-        this.versionRepository = versionRepository;
-        this.discordNotificationService = discordNotificationService;
+        this.getController = getController;
         this.plugin = plugin;
     }
 
@@ -60,27 +47,18 @@ public class GetCommand extends AbstractPluginCommand {
             return false;
         }
 
-        List<ProjectRecord> depsToFetch = new ArrayList<>();
-        List<String> unknownDeps = new ArrayList<>();
-        Set<String> resolved = new HashSet<>();
-        resolved.add(record.getName().toLowerCase());
-        dependencyResolutionService.resolve(List.of(record), resolved, depsToFetch, unknownDeps);
-
-        for (String dep : unknownDeps) {
+        DependencyResolutionResult resolution = getController.resolveDependencies(List.of(record));
+        for (String dep : resolution.getUnknownDeps()) {
             sender.sendMessage(ChatColor.YELLOW + "Warning: " + record.getName()
                     + " requires " + dep + ", which is not installed and is not a managed DPC plugin.");
         }
 
+        List<ProjectRecord> depsToFetch = resolution.getDepsToFetch();
         if (depsToFetch.isEmpty()) {
             sender.sendMessage(ChatColor.AQUA + "Fetching " + record.getName() + "...");
             Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-                int result = downloadService.downloadLatest(record);
-                if (result == DownloadService.NETWORK_ERROR) {
-                    discordNotificationService.send("[DPM] Failed to install " + record.getName() + ": network error");
-                } else if (result == DownloadService.FILE_ERROR) {
-                    discordNotificationService.send("[DPM] Failed to install " + record.getName() + ": file write error");
-                }
-                Bukkit.getScheduler().runTask(plugin, () -> reportSingleResult(sender, record, result));
+                PluginResult result = getController.download(record);
+                Bukkit.getScheduler().runTask(plugin, () -> reportSingleResult(sender, result));
             });
         } else {
             for (ProjectRecord dep : depsToFetch) {
@@ -107,18 +85,13 @@ public class GetCommand extends AbstractPluginCommand {
             }
         }
 
-        Set<String> resolved = records.stream()
-                .map(r -> r.getName().toLowerCase())
-                .collect(Collectors.toCollection(HashSet::new));
-        List<ProjectRecord> depsToFetch = new ArrayList<>();
-        List<String> unknownDeps = new ArrayList<>();
-        dependencyResolutionService.resolve(records, resolved, depsToFetch, unknownDeps);
-
-        for (String dep : unknownDeps) {
+        DependencyResolutionResult resolution = getController.resolveDependencies(records);
+        for (String dep : resolution.getUnknownDeps()) {
             sender.sendMessage(ChatColor.YELLOW + "Warning: required dependency '" + dep
                     + "' is not installed and is not a managed DPC plugin.");
         }
 
+        List<ProjectRecord> depsToFetch = resolution.getDepsToFetch();
         List<ProjectRecord> allToFetch = new ArrayList<>(depsToFetch);
         for (ProjectRecord dep : depsToFetch) {
             sender.sendMessage(ChatColor.AQUA + "Info: Also downloading required dependency " + dep.getName() + ".");
@@ -133,39 +106,41 @@ public class GetCommand extends AbstractPluginCommand {
     }
 
     private void runBatch(CommandSender sender, List<ProjectRecord> records, int notFound) {
+        List<PluginResult> results = getController.runBatch(records);
         int downloaded = 0, upToDate = 0, skipped = 0, failed = 0;
-        for (ProjectRecord record : records) {
-            int result = downloadService.downloadLatest(record);
-            final String msg;
-            if (result == DownloadService.NO_RELEASE) {
-                skipped++;
-                msg = ChatColor.YELLOW + record.getName() + " has no published release yet.";
-            } else if (result == DownloadService.ALREADY_UP_TO_DATE) {
-                upToDate++;
-                String tag = versionRepository.getStoredTag(record.getName());
-                msg = ChatColor.GREEN + record.getName() + (tag != null ? " " + tag : "") + " already up to date.";
-            } else if (result == DownloadService.NETWORK_ERROR) {
-                failed++;
-                plugin.getLogger().warning("[DPM] Failed to install " + record.getName() + " — could not reach GitHub.");
-                discordNotificationService.send("[DPM] Failed to install " + record.getName() + ": network error");
-                msg = ChatColor.RED + "Failed to download " + record.getName() + " (could not reach GitHub — check console for details).";
-            } else if (result == DownloadService.FILE_ERROR) {
-                failed++;
-                plugin.getLogger().warning("[DPM] Failed to install " + record.getName() + " — could not write to plugins folder.");
-                discordNotificationService.send("[DPM] Failed to install " + record.getName() + ": file write error");
-                msg = ChatColor.RED + "Failed to download " + record.getName() + " (could not write to plugins folder — check server file permissions).";
-            } else if (result < 0) {
-                failed++;
-                plugin.getLogger().warning("[DPM] Failed to install " + record.getName() + ".");
-                msg = ChatColor.RED + "Failed to download " + record.getName() + ".";
-            } else {
-                downloaded++;
-                String tag = versionRepository.getStoredTag(record.getName());
-                String version = tag != null ? " " + tag : "";
-                plugin.getLogger().info("[DPM] Installed " + record.getName() + version + ".");
-                msg = ChatColor.GREEN + "Downloaded " + record.getName() + version + " (" + (result / 1024) + " KB).";
+        for (PluginResult result : results) {
+            ProjectRecord record = result.getRecord();
+            String msg;
+            switch (result.getOutcome()) {
+                case NO_RELEASE:
+                    skipped++;
+                    msg = ChatColor.YELLOW + record.getName() + " has no published release yet.";
+                    break;
+                case ALREADY_UP_TO_DATE:
+                    upToDate++;
+                    String tag = result.getStoredTag();
+                    msg = ChatColor.GREEN + record.getName() + (tag != null ? " " + tag : "") + " already up to date.";
+                    break;
+                case NETWORK_ERROR:
+                    failed++;
+                    msg = ChatColor.RED + "Failed to download " + record.getName() + " (could not reach GitHub — check console for details).";
+                    break;
+                case FILE_ERROR:
+                    failed++;
+                    msg = ChatColor.RED + "Failed to download " + record.getName() + " (could not write to plugins folder — check server file permissions).";
+                    break;
+                case DOWNLOADED:
+                    downloaded++;
+                    String version = result.getStoredTag() != null ? " " + result.getStoredTag() : "";
+                    msg = ChatColor.GREEN + "Downloaded " + record.getName() + version + " (" + (result.getDownloadedBytes() / 1024) + " KB).";
+                    break;
+                default:
+                    failed++;
+                    msg = ChatColor.RED + "Failed to download " + record.getName() + ".";
+                    break;
             }
-            Bukkit.getScheduler().runTask(plugin, () -> sender.sendMessage(msg));
+            final String fmsg = msg;
+            Bukkit.getScheduler().runTask(plugin, () -> sender.sendMessage(fmsg));
         }
         final int fd = downloaded, fu = upToDate, fs = skipped, ff = failed;
         Bukkit.getScheduler().runTask(plugin, () -> {
@@ -184,27 +159,30 @@ public class GetCommand extends AbstractPluginCommand {
         });
     }
 
-    private void reportSingleResult(CommandSender sender, ProjectRecord record, int result) {
-        if (result == DownloadService.NO_RELEASE) {
-            sender.sendMessage(ChatColor.YELLOW + record.getName() + " has no published release yet. Try again later.");
-        } else if (result == DownloadService.ALREADY_UP_TO_DATE) {
-            String tag = versionRepository.getStoredTag(record.getName());
-            String version = tag != null ? " (" + tag + ")" : "";
-            sender.sendMessage(ChatColor.GREEN + record.getName() + " is already up to date" + version + ".");
-        } else if (result == DownloadService.NETWORK_ERROR) {
-            plugin.getLogger().warning("[DPM] Failed to install " + record.getName() + " — could not reach GitHub.");
-            sender.sendMessage(ChatColor.RED + "Could not reach GitHub when downloading " + record.getName() + " — check console for details.");
-        } else if (result == DownloadService.FILE_ERROR) {
-            plugin.getLogger().warning("[DPM] Failed to install " + record.getName() + " — could not write to plugins folder.");
-            sender.sendMessage(ChatColor.RED + "Could not write " + record.getName() + " to the plugins folder — check server file permissions.");
-        } else if (result < 0) {
-            plugin.getLogger().warning("[DPM] Failed to install " + record.getName() + ".");
-            sender.sendMessage(ChatColor.RED + "Something went wrong downloading " + record.getName() + ".");
-        } else {
-            String tag = versionRepository.getStoredTag(record.getName());
-            String version = tag != null ? " " + tag : "";
-            plugin.getLogger().info("[DPM] Installed " + record.getName() + version + ".");
-            sender.sendMessage(ChatColor.GREEN + "Downloaded" + version + " (" + (result / 1024) + " KB). Restart the server to enable " + record.getName() + ".");
+    private void reportSingleResult(CommandSender sender, PluginResult result) {
+        ProjectRecord record = result.getRecord();
+        switch (result.getOutcome()) {
+            case NO_RELEASE:
+                sender.sendMessage(ChatColor.YELLOW + record.getName() + " has no published release yet. Try again later.");
+                break;
+            case ALREADY_UP_TO_DATE:
+                String tag = result.getStoredTag();
+                String upToDateVersion = tag != null ? " (" + tag + ")" : "";
+                sender.sendMessage(ChatColor.GREEN + record.getName() + " is already up to date" + upToDateVersion + ".");
+                break;
+            case NETWORK_ERROR:
+                sender.sendMessage(ChatColor.RED + "Could not reach GitHub when downloading " + record.getName() + " — check console for details.");
+                break;
+            case FILE_ERROR:
+                sender.sendMessage(ChatColor.RED + "Could not write " + record.getName() + " to the plugins folder — check server file permissions.");
+                break;
+            case DOWNLOADED:
+                String downloadedVersion = result.getStoredTag() != null ? " " + result.getStoredTag() : "";
+                sender.sendMessage(ChatColor.GREEN + "Downloaded" + downloadedVersion + " (" + (result.getDownloadedBytes() / 1024) + " KB). Restart the server to enable " + record.getName() + ".");
+                break;
+            default:
+                sender.sendMessage(ChatColor.RED + "Something went wrong downloading " + record.getName() + ".");
+                break;
         }
     }
 }

--- a/src/main/java/dansplugins/dpm/controllers/GetController.java
+++ b/src/main/java/dansplugins/dpm/controllers/GetController.java
@@ -1,0 +1,114 @@
+package dansplugins.dpm.controllers;
+
+import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.repositories.VersionRepository;
+import dansplugins.dpm.services.DependencyResolutionService;
+import dansplugins.dpm.services.DiscordNotificationService;
+import dansplugins.dpm.services.DownloadService;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+// Orchestrates /dpm get: dependency resolution and the download loop, returning plain
+// result data rather than sending messages. GetCommand formats and sends the results.
+public class GetController {
+
+    public enum Outcome { NO_RELEASE, ALREADY_UP_TO_DATE, NETWORK_ERROR, FILE_ERROR, OTHER_FAILURE, DOWNLOADED }
+
+    public static final class PluginResult {
+        private final ProjectRecord record;
+        private final Outcome outcome;
+        private final int downloadedBytes;
+        private final String storedTag;
+
+        PluginResult(ProjectRecord record, Outcome outcome, int downloadedBytes, String storedTag) {
+            this.record = record;
+            this.outcome = outcome;
+            this.downloadedBytes = downloadedBytes;
+            this.storedTag = storedTag;
+        }
+
+        public ProjectRecord getRecord() { return record; }
+        public Outcome getOutcome() { return outcome; }
+        public int getDownloadedBytes() { return downloadedBytes; }
+        public String getStoredTag() { return storedTag; }
+    }
+
+    public static final class DependencyResolutionResult {
+        private final List<ProjectRecord> depsToFetch;
+        private final List<String> unknownDeps;
+
+        DependencyResolutionResult(List<ProjectRecord> depsToFetch, List<String> unknownDeps) {
+            this.depsToFetch = depsToFetch;
+            this.unknownDeps = unknownDeps;
+        }
+
+        public List<ProjectRecord> getDepsToFetch() { return depsToFetch; }
+        public List<String> getUnknownDeps() { return unknownDeps; }
+    }
+
+    private final DownloadService downloadService;
+    private final DependencyResolutionService dependencyResolutionService;
+    private final VersionRepository versionRepository;
+    private final DiscordNotificationService discordNotificationService;
+    private final Logger logger;
+
+    public GetController(DownloadService downloadService, DependencyResolutionService dependencyResolutionService,
+                         VersionRepository versionRepository, DiscordNotificationService discordNotificationService,
+                         Logger logger) {
+        this.downloadService = downloadService;
+        this.dependencyResolutionService = dependencyResolutionService;
+        this.versionRepository = versionRepository;
+        this.discordNotificationService = discordNotificationService;
+        this.logger = logger;
+    }
+
+    public DependencyResolutionResult resolveDependencies(List<ProjectRecord> records) {
+        Set<String> resolved = records.stream()
+                .map(r -> r.getName().toLowerCase())
+                .collect(Collectors.toCollection(HashSet::new));
+        List<ProjectRecord> depsToFetch = new ArrayList<>();
+        List<String> unknownDeps = new ArrayList<>();
+        dependencyResolutionService.resolve(records, resolved, depsToFetch, unknownDeps);
+        return new DependencyResolutionResult(depsToFetch, unknownDeps);
+    }
+
+    public List<PluginResult> runBatch(List<ProjectRecord> records) {
+        List<PluginResult> results = new ArrayList<>();
+        for (ProjectRecord record : records) {
+            results.add(download(record));
+        }
+        return results;
+    }
+
+    public PluginResult download(ProjectRecord record) {
+        int result = downloadService.downloadLatest(record);
+        if (result == DownloadService.NO_RELEASE) {
+            return new PluginResult(record, Outcome.NO_RELEASE, 0, null);
+        }
+        if (result == DownloadService.ALREADY_UP_TO_DATE) {
+            return new PluginResult(record, Outcome.ALREADY_UP_TO_DATE, 0, versionRepository.getStoredTag(record.getName()));
+        }
+        if (result == DownloadService.NETWORK_ERROR) {
+            logger.warning("[DPM] Failed to install " + record.getName() + " — could not reach GitHub.");
+            discordNotificationService.send("[DPM] Failed to install " + record.getName() + ": network error");
+            return new PluginResult(record, Outcome.NETWORK_ERROR, 0, null);
+        }
+        if (result == DownloadService.FILE_ERROR) {
+            logger.warning("[DPM] Failed to install " + record.getName() + " — could not write to plugins folder.");
+            discordNotificationService.send("[DPM] Failed to install " + record.getName() + ": file write error");
+            return new PluginResult(record, Outcome.FILE_ERROR, 0, null);
+        }
+        if (result < 0) {
+            logger.warning("[DPM] Failed to install " + record.getName() + ".");
+            return new PluginResult(record, Outcome.OTHER_FAILURE, 0, null);
+        }
+        String tag = versionRepository.getStoredTag(record.getName());
+        logger.info("[DPM] Installed " + record.getName() + (tag != null ? " " + tag : "") + ".");
+        return new PluginResult(record, Outcome.DOWNLOADED, result, tag);
+    }
+}

--- a/src/test/java/dansplugins/dpm/controllers/GetControllerTest.java
+++ b/src/test/java/dansplugins/dpm/controllers/GetControllerTest.java
@@ -1,0 +1,213 @@
+package dansplugins.dpm.controllers;
+
+import dansplugins.dpm.controllers.GetController.DependencyResolutionResult;
+import dansplugins.dpm.controllers.GetController.Outcome;
+import dansplugins.dpm.controllers.GetController.PluginResult;
+import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.repositories.ConfigRepository;
+import dansplugins.dpm.repositories.VersionRepository;
+import dansplugins.dpm.services.DependencyResolutionService;
+import dansplugins.dpm.services.DiscordNotificationService;
+import dansplugins.dpm.services.DownloadService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GetControllerTest {
+
+    private static ProjectRecord record(String name) {
+        return ProjectRecord.forGitHub(name, "Dans-Plugins", name);
+    }
+
+    private static VersionRepository versionRepository(Path tempDir) {
+        return new VersionRepository(new File(tempDir.toFile(), "dpm-versions.properties"), null);
+    }
+
+    private static DiscordNotificationService recordingDiscordService(List<String> sent) {
+        return new DiscordNotificationService((ConfigRepository) null) {
+            @Override
+            public void send(String message) {
+                sent.add(message);
+            }
+        };
+    }
+
+    private static DownloadService stubDownloadService(Map<String, Integer> resultsByName) {
+        return new DownloadService(null, null, null, null) {
+            @Override
+            public int downloadLatest(ProjectRecord projectRecord) {
+                return resultsByName.get(projectRecord.getName());
+            }
+        };
+    }
+
+    private static GetController controller(Map<String, Integer> resultsByName, VersionRepository versionRepository, List<String> sentDiscordMessages) {
+        return new GetController(
+                stubDownloadService(resultsByName),
+                new DependencyResolutionService(null, null),
+                versionRepository,
+                recordingDiscordService(sentDiscordMessages),
+                Logger.getLogger("GetControllerTest"));
+    }
+
+    // -------------------------------------------------------------------------
+    // resolveDependencies()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void resolveDependencies_seedsResolvedSetWithLowercaseRecordNames(@TempDir Path tempDir) {
+        List<Set<String>> capturedResolvedSets = new ArrayList<>();
+        DependencyResolutionService fakeResolution = new DependencyResolutionService(null, null) {
+            @Override
+            public void resolve(List<ProjectRecord> toProcess, Set<String> resolved,
+                                List<ProjectRecord> depsToFetch, List<String> unknownDeps) {
+                capturedResolvedSets.add(new java.util.HashSet<>(resolved));
+            }
+        };
+        GetController controller = new GetController(
+                stubDownloadService(new HashMap<>()), fakeResolution, versionRepository(tempDir),
+                recordingDiscordService(new ArrayList<>()), Logger.getLogger("GetControllerTest"));
+
+        controller.resolveDependencies(List.of(record("MedievalFactions")));
+
+        assertEquals(1, capturedResolvedSets.size());
+        assertTrue(capturedResolvedSets.get(0).contains("medievalfactions"));
+    }
+
+    @Test
+    void resolveDependencies_returnsDepsToFetchAndUnknownDepsFromService(@TempDir Path tempDir) {
+        ProjectRecord dep = record("Currencies");
+        DependencyResolutionService fakeResolution = new DependencyResolutionService(null, null) {
+            @Override
+            public void resolve(List<ProjectRecord> toProcess, Set<String> resolved,
+                                List<ProjectRecord> depsToFetch, List<String> unknownDeps) {
+                depsToFetch.add(dep);
+                unknownDeps.add("SomeUnmanagedPlugin");
+            }
+        };
+        GetController controller = new GetController(
+                stubDownloadService(new HashMap<>()), fakeResolution, versionRepository(tempDir),
+                recordingDiscordService(new ArrayList<>()), Logger.getLogger("GetControllerTest"));
+
+        DependencyResolutionResult result = controller.resolveDependencies(List.of(record("MedievalFactions")));
+
+        assertEquals(List.of(dep), result.getDepsToFetch());
+        assertEquals(List.of("SomeUnmanagedPlugin"), result.getUnknownDeps());
+    }
+
+    // -------------------------------------------------------------------------
+    // download()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void download_returnsNoReleaseOutcomeWhenNoPublishedRelease(@TempDir Path tempDir) {
+        Map<String, Integer> results = new HashMap<>();
+        results.put("MyPlugin", DownloadService.NO_RELEASE);
+        GetController controller = controller(results, versionRepository(tempDir), new ArrayList<>());
+
+        PluginResult result = controller.download(record("MyPlugin"));
+
+        assertEquals(Outcome.NO_RELEASE, result.getOutcome());
+        assertNull(result.getStoredTag());
+    }
+
+    @Test
+    void download_returnsAlreadyUpToDateOutcomeWithStoredTag(@TempDir Path tempDir) throws Exception {
+        VersionRepository versionRepository = versionRepository(tempDir);
+        versionRepository.setTag("MyPlugin", "v1.2.3");
+        Map<String, Integer> results = new HashMap<>();
+        results.put("MyPlugin", DownloadService.ALREADY_UP_TO_DATE);
+        GetController controller = controller(results, versionRepository, new ArrayList<>());
+
+        PluginResult result = controller.download(record("MyPlugin"));
+
+        assertEquals(Outcome.ALREADY_UP_TO_DATE, result.getOutcome());
+        assertEquals("v1.2.3", result.getStoredTag());
+    }
+
+    @Test
+    void download_returnsNetworkErrorOutcomeAndSendsDiscordNotification(@TempDir Path tempDir) {
+        Map<String, Integer> results = new HashMap<>();
+        results.put("MyPlugin", DownloadService.NETWORK_ERROR);
+        List<String> sent = new ArrayList<>();
+        GetController controller = controller(results, versionRepository(tempDir), sent);
+
+        PluginResult result = controller.download(record("MyPlugin"));
+
+        assertEquals(Outcome.NETWORK_ERROR, result.getOutcome());
+        assertEquals(1, sent.size());
+        assertTrue(sent.get(0).contains("network error"));
+    }
+
+    @Test
+    void download_returnsFileErrorOutcomeAndSendsDiscordNotification(@TempDir Path tempDir) {
+        Map<String, Integer> results = new HashMap<>();
+        results.put("MyPlugin", DownloadService.FILE_ERROR);
+        List<String> sent = new ArrayList<>();
+        GetController controller = controller(results, versionRepository(tempDir), sent);
+
+        PluginResult result = controller.download(record("MyPlugin"));
+
+        assertEquals(Outcome.FILE_ERROR, result.getOutcome());
+        assertEquals(1, sent.size());
+        assertTrue(sent.get(0).contains("file write error"));
+    }
+
+    @Test
+    void download_returnsOtherFailureOutcomeForUnrecognizedNegativeResult(@TempDir Path tempDir) {
+        Map<String, Integer> results = new HashMap<>();
+        results.put("MyPlugin", -99);
+        List<String> sent = new ArrayList<>();
+        GetController controller = controller(results, versionRepository(tempDir), sent);
+
+        PluginResult result = controller.download(record("MyPlugin"));
+
+        assertEquals(Outcome.OTHER_FAILURE, result.getOutcome());
+        assertTrue(sent.isEmpty(), "no Discord notification for unrecognized failures");
+    }
+
+    @Test
+    void download_returnsDownloadedOutcomeWithBytesAndStoredTagOnSuccess(@TempDir Path tempDir) {
+        VersionRepository versionRepository = versionRepository(tempDir);
+        versionRepository.setTag("MyPlugin", "v2.0.0");
+        Map<String, Integer> results = new HashMap<>();
+        results.put("MyPlugin", 4096);
+        GetController controller = controller(results, versionRepository, new ArrayList<>());
+
+        PluginResult result = controller.download(record("MyPlugin"));
+
+        assertEquals(Outcome.DOWNLOADED, result.getOutcome());
+        assertEquals(4096, result.getDownloadedBytes());
+        assertEquals("v2.0.0", result.getStoredTag());
+    }
+
+    // -------------------------------------------------------------------------
+    // runBatch()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void runBatch_returnsOneResultPerRecordInOrder(@TempDir Path tempDir) {
+        Map<String, Integer> results = new HashMap<>();
+        results.put("PluginA", DownloadService.ALREADY_UP_TO_DATE);
+        results.put("PluginB", DownloadService.NO_RELEASE);
+        GetController controller = controller(results, versionRepository(tempDir), new ArrayList<>());
+
+        List<PluginResult> batchResults = controller.runBatch(List.of(record("PluginA"), record("PluginB")));
+
+        assertEquals(2, batchResults.size());
+        assertEquals("PluginA", batchResults.get(0).getRecord().getName());
+        assertEquals(Outcome.ALREADY_UP_TO_DATE, batchResults.get(0).getOutcome());
+        assertEquals("PluginB", batchResults.get(1).getRecord().getName());
+        assertEquals(Outcome.NO_RELEASE, batchResults.get(1).getOutcome());
+    }
+}


### PR DESCRIPTION
## Summary
- `GetCommand` handled argument parsing, dependency resolution, async scheduling, the download loop, and result formatting all in one class extending `AbstractPluginCommand`, so none of that orchestration was unit-testable (it depends on Bukkit's `CommandSender`/scheduler).
- Introduces a `GetController` (`controllers/` package) that owns dependency resolution (`resolveDependencies`) and the download loop (`runBatch`/`download`), returning plain `PluginResult` data (`Outcome` enum + downloaded bytes + stored tag) instead of calling `sender.sendMessage()` directly.
- `GetCommand` is now a thin router: parse args, call `GetController`, format and send the response. The `runTaskAsynchronously` → `runTask` dispatch pattern is unchanged and stays in the command per CLAUDE.md's async pattern.
- No user-visible behavior or message-text change — verified message string-for-string against the previous implementation.
- This is the template controller for the remaining layering proposed in #94 (`UpdateController`, `RemoveController`, `CleanController`, `SearchController`, `InfoController`, `ListController`, `StatsController`, `ReloadController`), per #101's own suggestion. Filing those 8 as separate follow-up issues now that this one has landed, rather than batching them here.

Closes #101

## Test plan
- [x] `mvn test` — full suite passes except the pre-existing, environment-specific `DownloadServiceTest.downloadLatest_returnsFileError_whenDestinationUnwritable` failure (fails identically on `main` before this change — it assumes a `chmod`-unwritable file blocks writes, which doesn't hold when tests run as `root`; unrelated to this PR, not introduced by it).
- [x] Added `GetControllerTest` covering `resolveDependencies()` (resolved-set seeding, deps/unknown-deps passthrough) and `download()`/`runBatch()` (all five outcomes: `NO_RELEASE`, `ALREADY_UP_TO_DATE`, `NETWORK_ERROR`, `FILE_ERROR`, `OTHER_FAILURE`, `DOWNLOADED`), including Discord-notification side effects.
- [x] `mvn clean package` (CI `Build` workflow equivalent) — will confirm on CI.
- Not covered by unit tests: real Bukkit command routing through `GetCommand` (unchanged async pattern, unit-untestable per CLAUDE.md) — covered by the existing `integration-test/test_dpm.py` `/dpm get` steps, which exercise the exact same message strings (unchanged by this PR), so no new integration test step was added.

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
