### PR TITLE
feat: add experimental (main-branch) release channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+- Experimental release channel. `/dpm get <plugin-name> --experimental` installs a build of the plugin's `main` branch instead of its latest published release, so changes can be picked up as soon as they are merged. The choice is remembered per plugin: plain `/dpm get` and `/dpm update` then keep that plugin on experimental builds until `/dpm get <plugin-name> --stable` switches it back. Experimental builds are read from a rolling `dev` prerelease published by each plugin repository's CI, and are unreleased, unreviewed code — see the Release channels section of `USER_GUIDE.md`
+- `ReleaseChannel` and `ChannelRepository` — the per-plugin channel is persisted in `dpm-channels.properties` alongside the existing `dpm-versions.properties`, whose format is unchanged. Plugins with no stored channel are treated as stable, so existing installations are unaffected
+- `GitHubReleaseRepository.getExperimentalRelease()` — fetches `releases/tags/<experimentalReleaseTag>`, caches per channel so the two channels cannot serve each other's releases, and synthesises a version identity of `dev-<short commit sha>` from the release's `target_commitish` (falling back to `dev@<published_at>`). Without this every experimental build would share the tag `dev` and report as already up to date forever
+- `experimentalReleaseTag` config option (default `dev`) — the release tag experimental builds are read from. Applied on `/dpm reload`
+
+### Changed
+- `/dpm update` now updates each plugin on the channel it is pinned to, rather than always using the latest published release. It takes no channel flags — channels are switched with `/dpm get`
+- `/dpm info` now shows a `Channel:` line and reports the latest build on that plugin's channel, so the "Update available" status matches what `/dpm update` would install
+- `/dpm list` and `/dpm list installed` now mark plugins on experimental builds with a trailing `[experimental]`
+- `/dpm remove --confirm` now clears the stored release channel along with the stored version tag, so a later reinstall starts on stable
+- Tab completion for `/dpm get` now suggests `--experimental` and `--stable` alongside plugin names
+
 ## [0.7.0-SNAPSHOT-8-8-2026] – 2026-08-08
 
 ### Changed

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -6,11 +6,11 @@ All commands use `/dpm` or `/danspluginmanager` as the base.
 |---------|-------------|------------|
 | `/dpm help` | View a list of commands. | `dpm.help` |
 | `/dpm list [installed\|available]` | List DPC plugins. Pass `installed` or `available` to filter. | `dpm.list` |
-| `/dpm get <plugin-name> [plugin-name ...]` | Download one or more DPC plugins to the server. | `dpm.get` |
+| `/dpm get <plugin-name> [plugin-name ...] [--experimental\|--stable]` | Download one or more DPC plugins to the server. `--experimental` switches the named plugins to main-branch builds and keeps them there; `--stable` switches them back to published releases. See [Release channels](USER_GUIDE.md#release-channels). | `dpm.get` |
 | `/dpm clean [--confirm]` | Preview duplicate plugin JARs, or delete them when `--confirm` is passed. | `dpm.clean` |
 | `/dpm stats` | View plugin statistics. | `dpm.stats` |
-| `/dpm update [plugin-name ...]` | Update all installed managed plugins to their latest release. Pass one or more names to update only those plugins. | `dpm.update` |
-| `/dpm info <plugin-name>` | Show description, GitHub owner, repo, latest release tag, publish date, install status, and dependency status for a plugin. | `dpm.info` |
+| `/dpm update [plugin-name ...]` | Update all installed managed plugins to the latest build on the channel each one is set to. Pass one or more names to update only those plugins. Takes no channel flags — use `/dpm get` to switch channels. | `dpm.update` |
+| `/dpm info <plugin-name>` | Show description, GitHub owner, repo, release channel, latest build on that channel, publish date, install status, and dependency status for a plugin. | `dpm.info` |
 | `/dpm reload` | Reload `config.yml` and re-apply settings (e.g. `githubToken`). | `dpm.reload` |
 | `/dpm remove <plugin-name> [--confirm]` | Preview removal of an installed plugin, or delete it when `--confirm` is passed. | `dpm.remove` |
 | `/dpm search <keyword>` | Search registered plugins by name or description. Results show install status and version. | `dpm.list` |

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -7,4 +7,5 @@ A `config.yml` is generated in `plugins/DansPluginManager/` on first run.
 | `version` | String | *(plugin version)* | Plugin version. Do not edit manually. |
 | `debugMode` | Boolean | `false` | Enables verbose debug logging to the console. |
 | `githubToken` | String | `""` | Personal access token for the GitHub API. When set, raises the rate limit from 60 to 5 000 requests per hour. Generate one at GitHub → Settings → Developer settings → Personal access tokens (no scopes required for public repos). |
+| `experimentalReleaseTag` | String | `"dev"` | The GitHub release tag experimental (main-branch) builds are published under. DPM fetches `releases/tags/<this value>` for plugins on the experimental channel. Only change this if the plugin repositories publish their rolling build under a different tag. Applied on `/dpm reload`. |
 | `discordWebhook` | String | `""` | Discord webhook URL. When set, DPM posts a summary to the channel after each `/dpm update` run and on any download failure from `/dpm get`. Leave empty to disable. Create one in your Discord server under channel settings → Integrations → Webhooks. |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ https://github.com/Dans-Plugins/Dans-Plugin-Manager/releases
 ## Usage
 - [User Guide](USER_GUIDE.md)
 - [Commands](COMMANDS.md)
+- [Release channels](USER_GUIDE.md#release-channels) — opt a plugin into main-branch builds with `/dpm get <plugin-name> --experimental`
 
 ## Support
 [Discord](https://discord.gg/xXtuAQ2) — [Bug reports](https://github.com/Dans-Plugins/Dans-Plugin-Manager/issues?q=is%3Aissue+is%3Aopen+label%3Abug)

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -13,13 +13,45 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 ## Getting Started
 
 1. Run `/dpm list` to see all DPC plugins. Green entries are installed (with version tag when known); grey entries are not yet installed. Pass `installed` or `available` to filter the list.
-2. Run `/dpm info <plugin-name>` to see a plugin's description, GitHub owner, repository, latest release tag, publish date, install status, and any required or optional dependencies.
-3. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). Multiple names are accepted: `/dpm get plugin1 plugin2`. If a plugin is already on the latest version, the download is skipped. Missing hard dependencies that are registered DPC plugins are automatically included in the download; dependencies that are not registered DPC plugins produce a warning.
-4. Run `/dpm update` to check every installed managed plugin against its latest GitHub release and download any that are out of date. Pass one or more plugin names to update only those: `/dpm update medievalfactions`.  
+2. Run `/dpm info <plugin-name>` to see a plugin's description, GitHub owner, repository, release channel, latest build on that channel, publish date, install status, and any required or optional dependencies.
+3. Run `/dpm get <plugin-name>` to download a plugin to your server's `plugins/` folder. The name must match the one shown by `/dpm list` (e.g. `medievalfactions`). Multiple names are accepted: `/dpm get plugin1 plugin2`. If a plugin is already on the latest version, the download is skipped. Missing hard dependencies that are registered DPC plugins are automatically included in the download; dependencies that are not registered DPC plugins produce a warning. Add `--experimental` to install main-branch builds instead of published releases — see [Release channels](#release-channels).
+4. Run `/dpm update` to check every installed managed plugin against the latest build on the channel it is set to, and download any that are out of date. Pass one or more plugin names to update only those: `/dpm update medievalfactions`.  
 5. Restart the server to activate downloaded or updated plugins.
 6. Run `/dpm search <keyword>` to find plugins by name or description (e.g. `/dpm search faction`). Green results are installed; grey are not.
 7. Run `/dpm clean` to preview duplicate plugin JARs (e.g. versioned copies left over from manual installs). Add `--confirm` to delete them.
-8. Run `/dpm remove <plugin-name>` to preview which JAR would be deleted. Add `--confirm` to remove it and clear its stored version tag.
+8. Run `/dpm remove <plugin-name>` to preview which JAR would be deleted. Add `--confirm` to remove it and clear its stored version tag and release channel.
+
+## Release channels
+
+Every managed plugin tracks one of two channels.
+
+| Channel | What you get | How it is published |
+|---------|--------------|---------------------|
+| **stable** (default) | The plugin's latest published GitHub release — the versions the maintainers have tagged and announced. | Manually, when maintainers cut a release. |
+| **experimental** | A build of the plugin's `main` branch, refreshed every time a change is merged. | Automatically by the plugin repository's CI, as a rolling `dev` prerelease. |
+
+**Experimental builds are unreleased, unreviewed code.** They have not been through a release check, they can contain half-finished work, and a broken build can stop your server from starting. Do not run them on a server you care about without a backup and a way to roll back.
+
+Switching a plugin to experimental builds:
+
+```
+/dpm get medievalfactions --experimental
+```
+
+The choice is remembered per plugin. From then on, plain `/dpm get medievalfactions` and `/dpm update` both keep that plugin on experimental builds — you do not need to repeat the flag. Switch it back with:
+
+```
+/dpm get medievalfactions --stable
+```
+
+Notes:
+
+- **Dependencies keep their own channel.** If an experimental plugin pulls in a dependency automatically, that dependency is installed from whatever channel *it* is set to. Putting a dependency on experimental builds takes its own `/dpm get <dependency> --experimental`.
+- **Version identity.** Experimental builds all carry the same `dev` tag, so DPM records them as `dev-<commit>` (e.g. `dev-abc1234`) to tell one build from the next. That is what `/dpm list` and `/dpm info` show.
+- **`/dpm list installed` marks them.** Plugins on experimental builds are shown with a trailing `[experimental]`.
+- **Switching channels always re-downloads**, because the two channels never share a version identity.
+- **Not every plugin publishes experimental builds.** If a repository has no rolling build, `/dpm get <plugin> --experimental` reports that no experimental build is published and leaves the plugin on its current channel.
+- **Removing a plugin resets it to stable**, so a later reinstall does not silently return to experimental builds.
 
 ## Permissions
 
@@ -28,7 +60,7 @@ Dans Plugin Manager (DPM) is a Spigot plugin that lets server operators browse a
 | `dpm.help` | `true` | View the help menu. |
 | `dpm.list` | `true` | Browse DPC plugins: list all/installed/available and search by keyword. |
 | `dpm.stats` | `true` | View plugin statistics. |
-| `dpm.get` | `op` | Download one or more plugins to the server. |
+| `dpm.get` | `op` | Download one or more plugins to the server, and switch them between the stable and experimental channels. |
 | `dpm.clean` | `op` | Preview or remove duplicate plugin JARs. |
 | `dpm.update` | `op` | Update all installed managed plugins, or specific ones by name. |
 | `dpm.info` | `true` | View description, release info, install status, and dependencies for a plugin. |
@@ -48,6 +80,8 @@ The most useful option for operators running frequent updates is `githubToken`. 
    githubToken: "ghp_your_token_here"
    ```
 4. Run `/dpm reload` to apply the change without restarting the server.
+
+`experimentalReleaseTag` controls which GitHub release tag experimental builds are read from. It defaults to `dev` and only needs changing if the plugin repositories publish their rolling build under a different tag. Run `/dpm reload` to apply a change.
 
 To receive Discord notifications when `/dpm update` completes or when a download fails, set `discordWebhook` in `config.yml` to a Discord webhook URL and run `/dpm reload`. Create a webhook in your Discord server under channel settings → Integrations → Webhooks. Leave the value empty to disable notifications.
 

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -26,11 +26,16 @@ These tests exercise the full stack: Maven build → JAR deploy → Spigot reloa
 | 10 | `dpm search faction` | `=== Search Results` — confirms registry search |
 | 11 | `dpm get nonexistentplugin` | `Plugin not found: nonexistentplugin` — confirms error path doesn't crash the server |
 | 12 | `dpm stats` | `Available plugins:` — confirms available count line renders after 0.6.0 stat addition |
+| 13 | `dpm get medievalfactions --experimental` | `has no experimental build published yet` / `Downloaded` / `already up to date` — confirms the experimental channel routes to the `dev` tag and handles a repository that publishes no main-branch build |
+| 14 | `dpm get medievalfactions --bogus` | `Unknown option: --bogus` — confirms unknown options are rejected rather than treated as plugin names |
+| 15 | `dpm get medievalfactions --experimental --stable` | `--experimental and --stable cannot be used together` — confirms conflicting channel flags are rejected |
 
 ## What is not yet covered
 
 | Area | Notes |
 |------|-------|
+| Successful experimental download | Step 13 accepts either outcome because no DPC repository publishes a rolling `dev` prerelease yet. Once one does, tighten the assertion to `Downloaded` and add a follow-up `dpm get <name> --stable` step asserting the switch back re-downloads |
+| `dpm list installed` experimental marker | The `[experimental]` marker cannot be asserted until a plugin can actually be installed from the experimental channel |
 | `dpm update` / `dpm update <name>` | Exercises the same download path as `dpm get` but with version comparison; low incremental value |
 | `dpm clean [--confirm]` | Requires duplicate JARs to be present; hard to set up reliably in CI |
 | `dpm info <name>` | Mainly a display command; low regression risk |

--- a/integration-test/test_dpm.py
+++ b/integration-test/test_dpm.py
@@ -177,6 +177,30 @@ def main():
     cursor = send_command("dpm stats")
     assert_log_contains("Available plugins:", cursor=cursor)
 
+    print("\n[13] /dpm get medievalfactions --experimental — confirm the experimental channel path...")
+    cursor = send_command("dpm get medievalfactions --experimental")
+    # Until every plugin repository publishes a rolling main-branch prerelease, the only outcome
+    # this can rely on is the "nothing published" path. Once a repo is publishing, "Downloaded"
+    # becomes reachable here too — both are accepted so this step does not break on the rollout.
+    assert_log_contains_any(
+        [
+            "has no experimental build published yet",
+            "Downloaded",
+            "already up to date",
+        ],
+        cursor=cursor,
+        retries=8,
+        delay=5,
+    )
+
+    print("\n[14] /dpm get medievalfactions --bogus — confirm unknown options are rejected...")
+    cursor = send_command("dpm get medievalfactions --bogus")
+    assert_log_contains("Unknown option: --bogus", cursor=cursor)
+
+    print("\n[15] /dpm get medievalfactions --experimental --stable — confirm conflicting flags are rejected...")
+    cursor = send_command("dpm get medievalfactions --experimental --stable")
+    assert_log_contains("--experimental and --stable cannot be used together", cursor=cursor)
+
     print("\n=== All integration tests passed ===")
 
 

--- a/src/main/java/dansplugins/dpm/DansPluginManager.java
+++ b/src/main/java/dansplugins/dpm/DansPluginManager.java
@@ -6,6 +6,7 @@ import dansplugins.dpm.controllers.RemoveController;
 import dansplugins.dpm.controllers.SearchController;
 import dansplugins.dpm.controllers.StatsController;
 import dansplugins.dpm.controllers.UpdateController;
+import dansplugins.dpm.repositories.ChannelRepository;
 import dansplugins.dpm.repositories.ConfigRepository;
 import dansplugins.dpm.repositories.GitHubReleaseRepository;
 import dansplugins.dpm.repositories.PluginFileRepository;
@@ -48,6 +49,7 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     private final DependencyResolutionService dependencyResolutionService = new DependencyResolutionService(projectRecordRepository, pluginFileRepository);
     private final DiscordNotificationService discordNotificationService = new DiscordNotificationService(configRepository);
     private VersionRepository versionRepository;
+    private ChannelRepository channelRepository;
     private DownloadService downloadService;
     private GetController getController;
     private UpdateController updateController;
@@ -61,11 +63,14 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     public void onEnable() {
         initializeConfig();
         gitHubReleaseRepository.setApiToken(configRepository.getStringOrDefault("githubToken", ""));
+        gitHubReleaseRepository.setExperimentalTag(configRepository.getStringOrDefault("experimentalReleaseTag",
+                GitHubReleaseRepository.DEFAULT_EXPERIMENTAL_TAG));
         versionRepository = new VersionRepository(new File(getDataFolder(), "dpm-versions.properties"), logger);
+        channelRepository = new ChannelRepository(new File(getDataFolder(), "dpm-channels.properties"), logger);
         downloadService = new DownloadService(logger, gitHubReleaseRepository, pluginFileRepository, versionRepository);
-        getController = new GetController(downloadService, dependencyResolutionService, versionRepository, discordNotificationService, getLogger());
-        updateController = new UpdateController(projectRecordRepository, pluginFileRepository, downloadService, versionRepository, discordNotificationService, getLogger());
-        removeController = new RemoveController(projectRecordRepository, pluginFileRepository, versionRepository, dependencyResolutionService, getLogger());
+        getController = new GetController(downloadService, dependencyResolutionService, versionRepository, channelRepository, discordNotificationService, getLogger());
+        updateController = new UpdateController(projectRecordRepository, pluginFileRepository, downloadService, versionRepository, channelRepository, discordNotificationService, getLogger());
+        removeController = new RemoveController(projectRecordRepository, pluginFileRepository, versionRepository, channelRepository, dependencyResolutionService, getLogger());
         searchController = new SearchController(projectRecordRepository, pluginFileRepository, versionRepository);
         initializeCommandService();
         projectRecordInitializer.initializeProjectRecords();
@@ -82,7 +87,8 @@ public final class DansPluginManager extends PonderBukkitPlugin {
             return TabCompleter.filterByPrefix(Arrays.asList("help", "list", "get", "clean", "stats", "update", "info", "reload", "remove", "search"), args[0]);
         }
         if (args.length >= 2 && args[0].equalsIgnoreCase("get")) {
-            return TabCompleter.filterByPrefix(allPluginNames(), args[args.length - 1]);
+            return TabCompleter.filterByPrefix(
+                    TabCompleter.pluginNamesWithChannelFlags(allPluginNames(), args), args[args.length - 1]);
         }
         if (args.length == 2 && args[0].equalsIgnoreCase("info")) {
             return TabCompleter.filterByPrefix(allPluginNames(), args[1]);
@@ -143,6 +149,8 @@ public final class DansPluginManager extends PonderBukkitPlugin {
     public void reloadDpm() {
         reloadConfig();
         gitHubReleaseRepository.setApiToken(configRepository.getStringOrDefault("githubToken", ""));
+        gitHubReleaseRepository.setExperimentalTag(configRepository.getStringOrDefault("experimentalReleaseTag",
+                GitHubReleaseRepository.DEFAULT_EXPERIMENTAL_TAG));
         gitHubReleaseRepository.clearCache();
     }
 
@@ -170,11 +178,11 @@ public final class DansPluginManager extends PonderBukkitPlugin {
         ArrayList<AbstractPluginCommand> commands = new ArrayList<>(Arrays.asList(
                 new HelpCommand(),
                 new GetCommand(projectRecordRepository, getController, this),
-                new ListCommand(projectRecordRepository, pluginFileRepository, versionRepository),
+                new ListCommand(projectRecordRepository, pluginFileRepository, versionRepository, channelRepository),
                 new StatsCommand(statsController),
                 new CleanCommand(projectRecordRepository, pluginFileRepository, this),
                 updateCommand = new UpdateCommand(updateController, this),
-                new InfoCommand(projectRecordRepository, gitHubReleaseRepository, pluginFileRepository, versionRepository, this),
+                new InfoCommand(projectRecordRepository, gitHubReleaseRepository, pluginFileRepository, versionRepository, channelRepository, this),
                 new ReloadCommand(this),
                 removeCommand = new RemoveCommand(projectRecordRepository, removeController),
                 new SearchCommand(searchController)

--- a/src/main/java/dansplugins/dpm/commands/GetCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/GetCommand.java
@@ -3,8 +3,10 @@ package dansplugins.dpm.commands;
 import dansplugins.dpm.controllers.GetController;
 import dansplugins.dpm.controllers.GetController.DependencyResolutionResult;
 import dansplugins.dpm.controllers.GetController.PluginResult;
+import dansplugins.dpm.controllers.GetController.Target;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
 import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.objects.ReleaseChannel;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -28,19 +30,59 @@ public class GetCommand extends AbstractPluginCommand {
 
     @Override
     public boolean execute(CommandSender sender) {
-        sender.sendMessage(ChatColor.RED + "Usage: /dpm get <plugin-name> [plugin-name ...]");
+        sender.sendMessage(ChatColor.RED + "Usage: /dpm get <plugin-name> [plugin-name ...] [--experimental|--stable]");
         return false;
     }
 
     @Override
     public boolean execute(CommandSender sender, String[] args) {
-        if (args.length == 1) {
-            return executeSingle(sender, args[0]);
+        ParsedArgs parsed = parseArgs(args);
+        if (parsed.error != null) {
+            sender.sendMessage(ChatColor.RED + parsed.error);
+            return false;
         }
-        return executeBatch(sender, args);
+        if (parsed.names.isEmpty()) {
+            return execute(sender);
+        }
+        if (parsed.names.size() == 1) {
+            return executeSingle(sender, parsed.names.get(0), parsed.requestedChannel);
+        }
+        return executeBatch(sender, parsed.names, parsed.requestedChannel);
     }
 
-    private boolean executeSingle(CommandSender sender, String name) {
+    // Flags may appear anywhere in the argument list, so they are stripped before name resolution.
+    static ParsedArgs parseArgs(String[] args) {
+        ParsedArgs parsed = new ParsedArgs();
+        for (String arg : args) {
+            if (!arg.startsWith("--")) {
+                parsed.names.add(arg);
+                continue;
+            }
+            ReleaseChannel flagged;
+            if (arg.equalsIgnoreCase("--experimental")) {
+                flagged = ReleaseChannel.EXPERIMENTAL;
+            } else if (arg.equalsIgnoreCase("--stable")) {
+                flagged = ReleaseChannel.STABLE;
+            } else {
+                parsed.error = "Unknown option: " + arg + ". Valid options are --experimental and --stable.";
+                return parsed;
+            }
+            if (parsed.requestedChannel != null && parsed.requestedChannel != flagged) {
+                parsed.error = "--experimental and --stable cannot be used together.";
+                return parsed;
+            }
+            parsed.requestedChannel = flagged;
+        }
+        return parsed;
+    }
+
+    static final class ParsedArgs {
+        final List<String> names = new ArrayList<>();
+        ReleaseChannel requestedChannel;
+        String error;
+    }
+
+    private boolean executeSingle(CommandSender sender, String name, ReleaseChannel requestedChannel) {
         ProjectRecord record = projectRecordRepository.getProjectRecord(name);
         if (record == null) {
             sender.sendMessage(ChatColor.RED + "Plugin not found: " + name + ". Use /dpm search <keyword> to find the right name.");
@@ -52,30 +94,33 @@ public class GetCommand extends AbstractPluginCommand {
             sender.sendMessage(ChatColor.YELLOW + "Warning: " + record.getName()
                     + " requires " + dep + ", which is not installed and is not a managed DPC plugin.");
         }
+        warnIfExperimental(sender, requestedChannel);
 
         List<ProjectRecord> depsToFetch = resolution.getDepsToFetch();
         if (depsToFetch.isEmpty()) {
-            sender.sendMessage(ChatColor.AQUA + "Fetching " + record.getName() + "...");
+            sender.sendMessage(ChatColor.AQUA + "Fetching " + record.getName() + channelSuffix(requestedChannel) + "...");
             Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-                PluginResult result = getController.download(record);
+                PluginResult result = getController.download(record, requestedChannel);
                 Bukkit.getScheduler().runTask(plugin, () -> reportSingleResult(sender, result));
             });
         } else {
+            List<Target> allToFetch = new ArrayList<>();
             for (ProjectRecord dep : depsToFetch) {
                 sender.sendMessage(ChatColor.AQUA + "Info: Also downloading required dependency " + dep.getName() + ".");
+                allToFetch.add(Target.usingStoredChannel(dep));
             }
-            List<ProjectRecord> allToFetch = new ArrayList<>(depsToFetch);
-            allToFetch.add(record);
-            sender.sendMessage(ChatColor.AQUA + "Fetching " + allToFetch.size() + " plugin(s)...");
+            allToFetch.add(Target.of(record, requestedChannel));
+            sender.sendMessage(ChatColor.AQUA + "Fetching " + allToFetch.size() + " plugin(s)"
+                    + channelSuffix(requestedChannel) + "...");
             Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> runBatch(sender, allToFetch, 0));
         }
         return true;
     }
 
-    private boolean executeBatch(CommandSender sender, String[] args) {
+    private boolean executeBatch(CommandSender sender, List<String> names, ReleaseChannel requestedChannel) {
         List<ProjectRecord> records = new ArrayList<>();
         int notFound = 0;
-        for (String name : args) {
+        for (String name : names) {
             ProjectRecord record = projectRecordRepository.getProjectRecord(name);
             if (record == null) {
                 sender.sendMessage(ChatColor.RED + "Plugin not found: " + name + " — skipping. Use /dpm search <keyword> to find the right name.");
@@ -90,23 +135,48 @@ public class GetCommand extends AbstractPluginCommand {
             sender.sendMessage(ChatColor.YELLOW + "Warning: required dependency '" + dep
                     + "' is not installed and is not a managed DPC plugin.");
         }
+        warnIfExperimental(sender, requestedChannel);
 
         List<ProjectRecord> depsToFetch = resolution.getDepsToFetch();
-        List<ProjectRecord> allToFetch = new ArrayList<>(depsToFetch);
+        List<Target> allToFetch = new ArrayList<>();
         for (ProjectRecord dep : depsToFetch) {
             sender.sendMessage(ChatColor.AQUA + "Info: Also downloading required dependency " + dep.getName() + ".");
+            // Dependencies keep their own channel — the flag applies only to the named plugins.
+            allToFetch.add(Target.usingStoredChannel(dep));
         }
-        allToFetch.addAll(records);
+        for (ProjectRecord record : records) {
+            allToFetch.add(Target.of(record, requestedChannel));
+        }
 
         if (allToFetch.isEmpty()) return false;
-        sender.sendMessage(ChatColor.AQUA + "Fetching " + allToFetch.size() + " plugin(s)...");
+        sender.sendMessage(ChatColor.AQUA + "Fetching " + allToFetch.size() + " plugin(s)"
+                + channelSuffix(requestedChannel) + "...");
         final int fn = notFound;
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> runBatch(sender, allToFetch, fn));
         return true;
     }
 
-    private void runBatch(CommandSender sender, List<ProjectRecord> records, int notFound) {
-        List<PluginResult> results = getController.runBatch(records);
+    private void warnIfExperimental(CommandSender sender, ReleaseChannel requestedChannel) {
+        if (requestedChannel != ReleaseChannel.EXPERIMENTAL) return;
+        sender.sendMessage(ChatColor.YELLOW + "Warning: experimental builds are unreleased main-branch code. "
+                + "They are not tested and a broken build can stop the server from starting. "
+                + "Use /dpm get <plugin-name> --stable to switch back.");
+    }
+
+    private String channelSuffix(ReleaseChannel requestedChannel) {
+        return requestedChannel == ReleaseChannel.EXPERIMENTAL ? " (experimental)" : "";
+    }
+
+    // On the experimental channel a 404 means the repository publishes no main-branch build, which
+    // is a different situation from a project that has simply never cut a release.
+    private String noReleaseSuffix(PluginResult result) {
+        return result.getChannel() == ReleaseChannel.EXPERIMENTAL
+                ? " has no experimental build published yet."
+                : " has no published release yet.";
+    }
+
+    private void runBatch(CommandSender sender, List<Target> targets, int notFound) {
+        List<PluginResult> results = getController.runTargets(targets);
         int downloaded = 0, upToDate = 0, skipped = 0, failed = 0;
         for (PluginResult result : results) {
             ProjectRecord record = result.getRecord();
@@ -114,7 +184,7 @@ public class GetCommand extends AbstractPluginCommand {
             switch (result.getOutcome()) {
                 case NO_RELEASE:
                     skipped++;
-                    msg = ChatColor.YELLOW + record.getName() + " has no published release yet.";
+                    msg = ChatColor.YELLOW + record.getName() + noReleaseSuffix(result);
                     break;
                 case ALREADY_UP_TO_DATE:
                     upToDate++;
@@ -163,7 +233,7 @@ public class GetCommand extends AbstractPluginCommand {
         ProjectRecord record = result.getRecord();
         switch (result.getOutcome()) {
             case NO_RELEASE:
-                sender.sendMessage(ChatColor.YELLOW + record.getName() + " has no published release yet. Try again later.");
+                sender.sendMessage(ChatColor.YELLOW + record.getName() + noReleaseSuffix(result) + " Try again later.");
                 break;
             case ALREADY_UP_TO_DATE:
                 String tag = result.getStoredTag();

--- a/src/main/java/dansplugins/dpm/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/HelpCommand.java
@@ -18,7 +18,7 @@ public class HelpCommand extends AbstractPluginCommand {
         commandSender.sendMessage(ChatColor.AQUA + "=== DPM Commands ===");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm help - View this list of commands.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm list [installed|available] - List plugins, optionally filtered.");
-        commandSender.sendMessage(ChatColor.AQUA + "/dpm get <plugin-name> [plugin-name ...] - Download one or more plugins.");
+        commandSender.sendMessage(ChatColor.AQUA + "/dpm get <plugin-name> [plugin-name ...] [--experimental|--stable] - Download one or more plugins, optionally switching release channel.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm clean [--confirm] - Preview or remove duplicate plugin JARs.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm stats - View plugin statistics.");
         commandSender.sendMessage(ChatColor.AQUA + "/dpm update [plugin-name ...] - Update all installed plugins, or specific ones.");

--- a/src/main/java/dansplugins/dpm/commands/InfoCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/InfoCommand.java
@@ -1,10 +1,12 @@
 package dansplugins.dpm.commands;
 
+import dansplugins.dpm.repositories.ChannelRepository;
 import dansplugins.dpm.repositories.GitHubReleaseRepository;
 import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
 import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.objects.ReleaseChannel;
 import dansplugins.dpm.objects.ReleaseInfo;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -22,16 +24,18 @@ public class InfoCommand extends AbstractPluginCommand {
     private final GitHubReleaseRepository gitHubReleaseRepository;
     private final PluginFileRepository pluginFileRepository;
     private final VersionRepository versionRepository;
+    private final ChannelRepository channelRepository;
     private final Plugin plugin;
 
     public InfoCommand(ProjectRecordRepository projectRecordRepository, GitHubReleaseRepository gitHubReleaseRepository,
                        PluginFileRepository pluginFileRepository, VersionRepository versionRepository,
-                       Plugin plugin) {
+                       ChannelRepository channelRepository, Plugin plugin) {
         super(new ArrayList<>(List.of("info")), new ArrayList<>(List.of("dpm.info")));
         this.projectRecordRepository = projectRecordRepository;
         this.gitHubReleaseRepository = gitHubReleaseRepository;
         this.pluginFileRepository = pluginFileRepository;
         this.versionRepository = versionRepository;
+        this.channelRepository = channelRepository;
         this.plugin = plugin;
     }
 
@@ -50,14 +54,17 @@ public class InfoCommand extends AbstractPluginCommand {
             return false;
         }
         sender.sendMessage(ChatColor.AQUA + "Fetching release info for " + record.getName() + "...");
+        // Report against the channel this plugin tracks, so "Update available" reflects what
+        // /dpm update would actually install.
+        ReleaseChannel channel = channelRepository.getChannel(record.getName());
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            ReleaseInfo release = gitHubReleaseRepository.getLatestReleaseMetadata(record.getOwner(), record.getRepo());
-            Bukkit.getScheduler().runTask(plugin, () -> showInfo(sender, record, release));
+            ReleaseInfo release = gitHubReleaseRepository.getReleaseMetadata(record.getOwner(), record.getRepo(), channel);
+            Bukkit.getScheduler().runTask(plugin, () -> showInfo(sender, record, release, channel));
         });
         return true;
     }
 
-    private void showInfo(CommandSender sender, ProjectRecord record, ReleaseInfo release) {
+    private void showInfo(CommandSender sender, ProjectRecord record, ReleaseInfo release, ReleaseChannel channel) {
         sender.sendMessage(ChatColor.AQUA + "=== " + record.getName() + " ===");
 
         if (record.getDescription() != null) {
@@ -66,13 +73,17 @@ public class InfoCommand extends AbstractPluginCommand {
 
         sender.sendMessage(ChatColor.WHITE + "Owner: " + ChatColor.AQUA + record.getOwner());
         sender.sendMessage(ChatColor.WHITE + "Repository: " + ChatColor.AQUA + record.getRepo());
+        sender.sendMessage(ChatColor.WHITE + "Channel: "
+                + (channel == ReleaseChannel.EXPERIMENTAL ? ChatColor.YELLOW : ChatColor.AQUA)
+                + channel.getDisplayName());
 
+        String releaseLabel = channel == ReleaseChannel.EXPERIMENTAL ? "Latest experimental build" : "Latest release";
         if (release == ReleaseInfo.NO_RELEASE) {
-            sender.sendMessage(ChatColor.YELLOW + "Latest release: None published yet");
+            sender.sendMessage(ChatColor.YELLOW + releaseLabel + ": None published yet");
         } else if (release == null) {
-            sender.sendMessage(ChatColor.RED + "Latest release: (could not fetch — check console for details)");
+            sender.sendMessage(ChatColor.RED + releaseLabel + ": (could not fetch — check console for details)");
         } else {
-            sender.sendMessage(ChatColor.WHITE + "Latest release: " + ChatColor.GREEN + release.getTagName());
+            sender.sendMessage(ChatColor.WHITE + releaseLabel + ": " + ChatColor.GREEN + release.getTagName());
             if (release.getPublishedAt() != null) {
                 sender.sendMessage(ChatColor.WHITE + "Published: " + ChatColor.AQUA + formatDate(release.getPublishedAt()));
             }

--- a/src/main/java/dansplugins/dpm/commands/ListCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/ListCommand.java
@@ -1,9 +1,11 @@
 package dansplugins.dpm.commands;
 
+import dansplugins.dpm.repositories.ChannelRepository;
 import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
 import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.objects.ReleaseChannel;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import preponderous.ponder.minecraft.bukkit.abs.AbstractPluginCommand;
@@ -17,13 +19,22 @@ public class ListCommand extends AbstractPluginCommand {
     private final ProjectRecordRepository projectRecordRepository;
     private final PluginFileRepository pluginFileRepository;
     private final VersionRepository versionRepository;
+    private final ChannelRepository channelRepository;
 
     public ListCommand(ProjectRecordRepository projectRecordRepository, PluginFileRepository pluginFileRepository,
-                       VersionRepository versionRepository) {
+                       VersionRepository versionRepository, ChannelRepository channelRepository) {
         super(new ArrayList<>(List.of("list")), new ArrayList<>(List.of("dpm.list")));
         this.projectRecordRepository = projectRecordRepository;
         this.pluginFileRepository = pluginFileRepository;
         this.versionRepository = versionRepository;
+        this.channelRepository = channelRepository;
+    }
+
+    /** Appends an [experimental] marker to plugins pinned to the experimental channel. */
+    private String channelMarker(ProjectRecord record) {
+        return channelRepository.getChannel(record.getName()) == ReleaseChannel.EXPERIMENTAL
+                ? ChatColor.YELLOW + " [experimental]"
+                : "";
     }
 
     @Override
@@ -38,7 +49,7 @@ public class ListCommand extends AbstractPluginCommand {
             if (installedNames.contains(record.getName())) {
                 String tag = versionRepository.getStoredTag(record.getName());
                 String version = tag != null ? " " + tag : "";
-                sender.sendMessage(ChatColor.GREEN + record.getName() + version);
+                sender.sendMessage(ChatColor.GREEN + record.getName() + version + channelMarker(record));
             } else {
                 sender.sendMessage(ChatColor.GRAY + record.getName() + " (not installed)");
             }
@@ -65,7 +76,7 @@ public class ListCommand extends AbstractPluginCommand {
         for (ProjectRecord record : installed) {
             String tag = versionRepository.getStoredTag(record.getName());
             String version = tag != null ? " " + tag : "";
-            sender.sendMessage(ChatColor.GREEN + record.getName() + version);
+            sender.sendMessage(ChatColor.GREEN + record.getName() + version + channelMarker(record));
         }
         return true;
     }

--- a/src/main/java/dansplugins/dpm/controllers/ConfigController.java
+++ b/src/main/java/dansplugins/dpm/controllers/ConfigController.java
@@ -42,6 +42,8 @@ public class ConfigController {
         String webhook = configRepository.getString("discordWebhook");
         String webhookDisplay = (webhook != null && !webhook.isEmpty()) ? "(set)" : "(not set)";
         sender.sendMessage(ChatColor.AQUA + "discordWebhook: " + webhookDisplay);
+        sender.sendMessage(ChatColor.AQUA + "experimentalReleaseTag: "
+                + configRepository.getStringOrDefault("experimentalReleaseTag", "dev"));
     }
 
     public boolean hasBeenAltered() {

--- a/src/main/java/dansplugins/dpm/controllers/GetController.java
+++ b/src/main/java/dansplugins/dpm/controllers/GetController.java
@@ -1,6 +1,8 @@
 package dansplugins.dpm.controllers;
 
 import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.objects.ReleaseChannel;
+import dansplugins.dpm.repositories.ChannelRepository;
 import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.services.DependencyResolutionService;
 import dansplugins.dpm.services.DiscordNotificationService;
@@ -24,18 +26,50 @@ public class GetController {
         private final Outcome outcome;
         private final int downloadedBytes;
         private final String storedTag;
+        private final ReleaseChannel channel;
 
-        PluginResult(ProjectRecord record, Outcome outcome, int downloadedBytes, String storedTag) {
+        PluginResult(ProjectRecord record, Outcome outcome, int downloadedBytes, String storedTag, ReleaseChannel channel) {
             this.record = record;
             this.outcome = outcome;
             this.downloadedBytes = downloadedBytes;
             this.storedTag = storedTag;
+            this.channel = channel;
         }
 
         public ProjectRecord getRecord() { return record; }
         public Outcome getOutcome() { return outcome; }
         public int getDownloadedBytes() { return downloadedBytes; }
         public String getStoredTag() { return storedTag; }
+        /** The channel this download was attempted on. */
+        public ReleaseChannel getChannel() { return channel; }
+    }
+
+    /**
+     * A plugin to download, plus the channel the sender explicitly asked for.
+     *
+     * <p>A null {@code requestedChannel} means "whatever this plugin is already pinned to" —
+     * that is what dependencies pulled in automatically use, so an {@code --experimental} flag on
+     * one plugin never drags its dependencies onto the experimental channel too.
+     */
+    public static final class Target {
+        private final ProjectRecord record;
+        private final ReleaseChannel requestedChannel;
+
+        private Target(ProjectRecord record, ReleaseChannel requestedChannel) {
+            this.record = record;
+            this.requestedChannel = requestedChannel;
+        }
+
+        public static Target of(ProjectRecord record, ReleaseChannel requestedChannel) {
+            return new Target(record, requestedChannel);
+        }
+
+        public static Target usingStoredChannel(ProjectRecord record) {
+            return new Target(record, null);
+        }
+
+        public ProjectRecord getRecord() { return record; }
+        public ReleaseChannel getRequestedChannel() { return requestedChannel; }
     }
 
     public static final class DependencyResolutionResult {
@@ -54,15 +88,17 @@ public class GetController {
     private final DownloadService downloadService;
     private final DependencyResolutionService dependencyResolutionService;
     private final VersionRepository versionRepository;
+    private final ChannelRepository channelRepository;
     private final DiscordNotificationService discordNotificationService;
     private final Logger logger;
 
     public GetController(DownloadService downloadService, DependencyResolutionService dependencyResolutionService,
-                         VersionRepository versionRepository, DiscordNotificationService discordNotificationService,
-                         Logger logger) {
+                         VersionRepository versionRepository, ChannelRepository channelRepository,
+                         DiscordNotificationService discordNotificationService, Logger logger) {
         this.downloadService = downloadService;
         this.dependencyResolutionService = dependencyResolutionService;
         this.versionRepository = versionRepository;
+        this.channelRepository = channelRepository;
         this.discordNotificationService = discordNotificationService;
         this.logger = logger;
     }
@@ -78,37 +114,73 @@ public class GetController {
     }
 
     public List<PluginResult> runBatch(List<ProjectRecord> records) {
-        List<PluginResult> results = new ArrayList<>();
+        List<Target> targets = new ArrayList<>();
         for (ProjectRecord record : records) {
-            results.add(download(record));
+            targets.add(Target.usingStoredChannel(record));
+        }
+        return runTargets(targets);
+    }
+
+    public List<PluginResult> runTargets(List<Target> targets) {
+        List<PluginResult> results = new ArrayList<>();
+        for (Target target : targets) {
+            results.add(download(target.getRecord(), target.getRequestedChannel()));
         }
         return results;
     }
 
     public PluginResult download(ProjectRecord record) {
-        int result = downloadService.downloadLatest(record);
+        return download(record, null);
+    }
+
+    /**
+     * Downloads one plugin. A null {@code requestedChannel} uses the plugin's stored channel;
+     * otherwise the requested channel is used, and pinned to the plugin if the download works out.
+     */
+    public PluginResult download(ProjectRecord record, ReleaseChannel requestedChannel) {
+        ReleaseChannel channel = requestedChannel != null
+                ? requestedChannel
+                : channelRepository.getChannel(record.getName());
+
+        int result = downloadService.downloadLatest(record, channel);
         if (result == DownloadService.NO_RELEASE) {
-            return new PluginResult(record, Outcome.NO_RELEASE, 0, null);
+            return new PluginResult(record, Outcome.NO_RELEASE, 0, null, channel);
         }
         if (result == DownloadService.ALREADY_UP_TO_DATE) {
-            return new PluginResult(record, Outcome.ALREADY_UP_TO_DATE, 0, versionRepository.getStoredTag(record.getName()));
+            pinChannel(record, requestedChannel);
+            return new PluginResult(record, Outcome.ALREADY_UP_TO_DATE, 0, versionRepository.getStoredTag(record.getName()), channel);
         }
         if (result == DownloadService.NETWORK_ERROR) {
             logger.warning("[DPM] Failed to install " + record.getName() + " — could not reach GitHub.");
             discordNotificationService.send("[DPM] Failed to install " + record.getName() + ": network error");
-            return new PluginResult(record, Outcome.NETWORK_ERROR, 0, null);
+            return new PluginResult(record, Outcome.NETWORK_ERROR, 0, null, channel);
         }
         if (result == DownloadService.FILE_ERROR) {
             logger.warning("[DPM] Failed to install " + record.getName() + " — could not write to plugins folder.");
             discordNotificationService.send("[DPM] Failed to install " + record.getName() + ": file write error");
-            return new PluginResult(record, Outcome.FILE_ERROR, 0, null);
+            return new PluginResult(record, Outcome.FILE_ERROR, 0, null, channel);
         }
         if (result < 0) {
             logger.warning("[DPM] Failed to install " + record.getName() + ".");
-            return new PluginResult(record, Outcome.OTHER_FAILURE, 0, null);
+            return new PluginResult(record, Outcome.OTHER_FAILURE, 0, null, channel);
         }
+        pinChannel(record, requestedChannel);
         String tag = versionRepository.getStoredTag(record.getName());
-        logger.info("[DPM] Installed " + record.getName() + (tag != null ? " " + tag : "") + ".");
-        return new PluginResult(record, Outcome.DOWNLOADED, result, tag);
+        logger.info("[DPM] Installed " + record.getName() + (tag != null ? " " + tag : "")
+                + (channel == ReleaseChannel.EXPERIMENTAL ? " (experimental)" : "") + ".");
+        return new PluginResult(record, Outcome.DOWNLOADED, result, tag, channel);
+    }
+
+    // Only an explicit request repins the plugin, and only once the channel has proven to have a
+    // build — pinning on a failed or unpublished channel would strand the plugin there, silently
+    // skipping it on every later /dpm update.
+    private void pinChannel(ProjectRecord record, ReleaseChannel requestedChannel) {
+        if (requestedChannel == null) return;
+        if (requestedChannel == ReleaseChannel.EXPERIMENTAL) {
+            channelRepository.setChannel(record.getName(), ReleaseChannel.EXPERIMENTAL);
+        } else {
+            // STABLE is the default, so returning to it means dropping the entry entirely.
+            channelRepository.removeChannel(record.getName());
+        }
     }
 }

--- a/src/main/java/dansplugins/dpm/controllers/RemoveController.java
+++ b/src/main/java/dansplugins/dpm/controllers/RemoveController.java
@@ -1,6 +1,7 @@
 package dansplugins.dpm.controllers;
 
 import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.repositories.ChannelRepository;
 import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
 import dansplugins.dpm.repositories.VersionRepository;
@@ -50,15 +51,17 @@ public class RemoveController {
     private final ProjectRecordRepository projectRecordRepository;
     private final PluginFileRepository pluginFileRepository;
     private final VersionRepository versionRepository;
+    private final ChannelRepository channelRepository;
     private final DependencyResolutionService dependencyResolutionService;
     private final Logger logger;
 
     public RemoveController(ProjectRecordRepository projectRecordRepository, PluginFileRepository pluginFileRepository,
-                            VersionRepository versionRepository, DependencyResolutionService dependencyResolutionService,
-                            Logger logger) {
+                            VersionRepository versionRepository, ChannelRepository channelRepository,
+                            DependencyResolutionService dependencyResolutionService, Logger logger) {
         this.projectRecordRepository = projectRecordRepository;
         this.pluginFileRepository = pluginFileRepository;
         this.versionRepository = versionRepository;
+        this.channelRepository = channelRepository;
         this.dependencyResolutionService = dependencyResolutionService;
         this.logger = logger;
     }
@@ -81,6 +84,7 @@ public class RemoveController {
         File jar = preview.getJar();
         if (jar.delete()) {
             versionRepository.removeTag(record.getName());
+            channelRepository.removeChannel(record.getName());
             logger.info("[DPM] Removed " + record.getName() + ".");
             return new RemovalResult(Outcome.DELETED, jar, preview.getDependents());
         }

--- a/src/main/java/dansplugins/dpm/controllers/UpdateController.java
+++ b/src/main/java/dansplugins/dpm/controllers/UpdateController.java
@@ -1,6 +1,8 @@
 package dansplugins.dpm.controllers;
 
 import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.objects.ReleaseChannel;
+import dansplugins.dpm.repositories.ChannelRepository;
 import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
 import dansplugins.dpm.repositories.VersionRepository;
@@ -59,16 +61,19 @@ public class UpdateController {
     private final PluginFileRepository pluginFileRepository;
     private final DownloadService downloadService;
     private final VersionRepository versionRepository;
+    private final ChannelRepository channelRepository;
     private final DiscordNotificationService discordNotificationService;
     private final Logger logger;
 
     public UpdateController(ProjectRecordRepository projectRecordRepository, PluginFileRepository pluginFileRepository,
                             DownloadService downloadService, VersionRepository versionRepository,
-                            DiscordNotificationService discordNotificationService, Logger logger) {
+                            ChannelRepository channelRepository, DiscordNotificationService discordNotificationService,
+                            Logger logger) {
         this.projectRecordRepository = projectRecordRepository;
         this.pluginFileRepository = pluginFileRepository;
         this.downloadService = downloadService;
         this.versionRepository = versionRepository;
+        this.channelRepository = channelRepository;
         this.discordNotificationService = discordNotificationService;
         this.logger = logger;
     }
@@ -111,9 +116,11 @@ public class UpdateController {
         return results;
     }
 
+    // /dpm update takes no channel flags — each plugin is updated on whatever channel it is pinned to.
     private PluginResult update(ProjectRecord record) {
         String oldTag = versionRepository.getStoredTag(record.getName());
-        int result = downloadService.downloadLatest(record, true);
+        ReleaseChannel channel = channelRepository.getChannel(record.getName());
+        int result = downloadService.downloadLatest(record, channel, true);
         if (result == DownloadService.ALREADY_UP_TO_DATE) {
             return new PluginResult(record, Outcome.ALREADY_UP_TO_DATE, oldTag, oldTag);
         }

--- a/src/main/java/dansplugins/dpm/objects/ReleaseChannel.java
+++ b/src/main/java/dansplugins/dpm/objects/ReleaseChannel.java
@@ -1,0 +1,27 @@
+package dansplugins.dpm.objects;
+
+/**
+ * Which stream of builds a plugin tracks.
+ *
+ * <p>{@link #STABLE} follows GitHub's "latest release" — the versions the maintainers have
+ * tagged and published. {@link #EXPERIMENTAL} follows the rolling prerelease built from the
+ * repository's main branch, which is unreviewed and may be broken.
+ */
+public enum ReleaseChannel {
+    STABLE,
+    EXPERIMENTAL;
+
+    /** Lowercase name used in the channel store, config, and player-facing messages. */
+    public String getDisplayName() {
+        return name().toLowerCase();
+    }
+
+    /** Parses a stored or user-supplied channel name, falling back to {@link #STABLE}. */
+    public static ReleaseChannel fromStored(String value) {
+        if (value == null) return STABLE;
+        for (ReleaseChannel channel : values()) {
+            if (channel.name().equalsIgnoreCase(value.trim())) return channel;
+        }
+        return STABLE;
+    }
+}

--- a/src/main/java/dansplugins/dpm/repositories/ChannelRepository.java
+++ b/src/main/java/dansplugins/dpm/repositories/ChannelRepository.java
@@ -1,0 +1,70 @@
+package dansplugins.dpm.repositories;
+
+import dansplugins.dpm.objects.ReleaseChannel;
+import dansplugins.dpm.utils.Logger;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Persists the release channel each plugin is pinned to.
+ *
+ * <p>Kept in its own properties file rather than as prefixed keys in the version store so that
+ * the version store's format stays unchanged. Plugins with no stored channel are treated as
+ * {@link ReleaseChannel#STABLE}, which is what every plugin installed before this feature is.
+ */
+public class ChannelRepository {
+    private final Logger logger;
+    private final File storeFile;
+    private final Properties props = new Properties();
+
+    public ChannelRepository(File storeFile, Logger logger) {
+        this.logger = logger;
+        this.storeFile = storeFile;
+        load();
+    }
+
+    /** Returns the channel the given plugin is pinned to, defaulting to STABLE. */
+    public ReleaseChannel getChannel(String pluginName) {
+        return ReleaseChannel.fromStored(props.getProperty(pluginName.toLowerCase()));
+    }
+
+    /** Pins the given plugin to a channel. */
+    public void setChannel(String pluginName, ReleaseChannel channel) {
+        props.setProperty(pluginName.toLowerCase(), channel.getDisplayName());
+        save();
+    }
+
+    /** Removes the stored channel for the given plugin, returning it to the STABLE default. */
+    public void removeChannel(String pluginName) {
+        props.remove(pluginName.toLowerCase());
+        save();
+    }
+
+    private void load() {
+        if (!storeFile.exists()) return;
+        try (FileInputStream in = new FileInputStream(storeFile)) {
+            props.load(in);
+        } catch (IOException e) {
+            warn("Could not load channel store (" + e.getMessage()
+                    + ") — all plugins will be treated as stable this session.");
+        }
+    }
+
+    private void save() {
+        storeFile.getParentFile().mkdirs();
+        try (FileOutputStream out = new FileOutputStream(storeFile)) {
+            props.store(out, null);
+        } catch (IOException e) {
+            warn("Could not save channel store (" + e.getMessage()
+                    + ") — plugin channel data will not persist across restarts.");
+        }
+    }
+
+    private void warn(String message) {
+        if (logger != null) logger.warn(message);
+    }
+}

--- a/src/main/java/dansplugins/dpm/repositories/ConfigRepository.java
+++ b/src/main/java/dansplugins/dpm/repositories/ConfigRepository.java
@@ -31,6 +31,9 @@ public class ConfigRepository {
         if (!isSet("discordWebhook")) {
             config.set("discordWebhook", "");
         }
+        if (!isSet("experimentalReleaseTag")) {
+            config.set("experimentalReleaseTag", "dev");
+        }
         config.options().copyDefaults(true);
         saveAction.run();
     }

--- a/src/main/java/dansplugins/dpm/repositories/GitHubReleaseRepository.java
+++ b/src/main/java/dansplugins/dpm/repositories/GitHubReleaseRepository.java
@@ -1,5 +1,6 @@
 package dansplugins.dpm.repositories;
 
+import dansplugins.dpm.objects.ReleaseChannel;
 import dansplugins.dpm.objects.ReleaseInfo;
 import dansplugins.dpm.utils.Logger;
 
@@ -15,9 +16,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class GitHubReleaseRepository {
     private static final String API_URL = "https://api.github.com/repos/%s/%s/releases/latest";
+    private static final String TAGGED_RELEASE_API_URL = "https://api.github.com/repos/%s/%s/releases/tags/%s";
+
+    /** The rolling prerelease tag experimental builds are published under, unless config overrides it. */
+    public static final String DEFAULT_EXPERIMENTAL_TAG = "dev";
 
     private final Logger logger;
     private String apiToken = "";
+    private String experimentalTag = DEFAULT_EXPERIMENTAL_TAG;
     private final ConcurrentHashMap<String, ReleaseInfo> releaseCache = new ConcurrentHashMap<>();
     private final AtomicInteger cacheGeneration = new AtomicInteger(0);
 
@@ -27,6 +33,15 @@ public class GitHubReleaseRepository {
 
     public void setApiToken(String token) {
         this.apiToken = token != null ? token : "";
+    }
+
+    /** Sets the tag experimental builds are fetched from; blank or null restores the default. */
+    public void setExperimentalTag(String tag) {
+        this.experimentalTag = (tag != null && !tag.trim().isEmpty()) ? tag.trim() : DEFAULT_EXPERIMENTAL_TAG;
+    }
+
+    public String getExperimentalTag() {
+        return experimentalTag;
     }
 
     public void clearCache() {
@@ -39,7 +54,24 @@ public class GitHubReleaseRepository {
     }
 
     public ReleaseInfo getLatestRelease(String owner, String repo) {
-        ReleaseInfo release = fetchRelease(owner, repo);
+        return withJarAsset(fetchRelease(owner, repo, ReleaseChannel.STABLE), owner, repo);
+    }
+
+    /**
+     * Fetches the rolling main-branch prerelease. Returns {@link ReleaseInfo#NO_RELEASE} when the
+     * repository publishes no experimental build (the tag 404s), matching the stable path.
+     */
+    public ReleaseInfo getExperimentalRelease(String owner, String repo) {
+        return withJarAsset(fetchRelease(owner, repo, ReleaseChannel.EXPERIMENTAL), owner, repo);
+    }
+
+    public ReleaseInfo getRelease(String owner, String repo, ReleaseChannel channel) {
+        return channel == ReleaseChannel.EXPERIMENTAL
+                ? getExperimentalRelease(owner, repo)
+                : getLatestRelease(owner, repo);
+    }
+
+    private ReleaseInfo withJarAsset(ReleaseInfo release, String owner, String repo) {
         if (release == null || release == ReleaseInfo.NO_RELEASE) return release;
         if (release.getJarUrl() == null) {
             logger.warn("Release " + release.getTagName() + " for " + owner + "/" + repo + " has no .jar asset.");
@@ -73,26 +105,49 @@ public class GitHubReleaseRepository {
     }
 
     public ReleaseInfo getLatestReleaseMetadata(String owner, String repo) {
-        return fetchRelease(owner, repo);
+        return fetchRelease(owner, repo, ReleaseChannel.STABLE);
+    }
+
+    public ReleaseInfo getReleaseMetadata(String owner, String repo, ReleaseChannel channel) {
+        return fetchRelease(owner, repo, channel);
     }
 
     // generation check prevents a pre-clearCache() fetch from re-populating the cache with stale data
-    private ReleaseInfo fetchRelease(String owner, String repo) {
-        String key = owner + "/" + repo;
+    private ReleaseInfo fetchRelease(String owner, String repo, ReleaseChannel channel) {
+        String key = cacheKey(owner, repo, channel);
         ReleaseInfo cached = releaseCache.get(key);
         if (cached != null) return cached;
 
         int generation = cacheGeneration.get();
-        ReleaseInfo fetched = doFetch(owner, repo);
+        ReleaseInfo fetched = fetchForChannel(owner, repo, channel);
         if (fetched != null && cacheGeneration.get() == generation) {
             releaseCache.putIfAbsent(key, fetched);
         }
         return fetched;
     }
 
+    // The two channels return different releases for the same repo, so they must not share a key.
+    String cacheKey(String owner, String repo, ReleaseChannel channel) {
+        String base = owner + "/" + repo;
+        return channel == ReleaseChannel.EXPERIMENTAL ? base + "@" + experimentalTag : base;
+    }
+
+    private ReleaseInfo fetchForChannel(String owner, String repo, ReleaseChannel channel) {
+        return channel == ReleaseChannel.EXPERIMENTAL ? doFetchExperimental(owner, repo) : doFetch(owner, repo);
+    }
+
     // package-private so tests can override via anonymous subclass without hitting the network
     ReleaseInfo doFetch(String owner, String repo) {
-        String apiUrl = String.format(API_URL, owner, repo);
+        return fetchFrom(String.format(API_URL, owner, repo), owner, repo, ReleaseChannel.STABLE);
+    }
+
+    // package-private for the same reason as doFetch()
+    ReleaseInfo doFetchExperimental(String owner, String repo) {
+        String apiUrl = String.format(TAGGED_RELEASE_API_URL, owner, repo, experimentalTag);
+        return fetchFrom(apiUrl, owner, repo, ReleaseChannel.EXPERIMENTAL);
+    }
+
+    private ReleaseInfo fetchFrom(String apiUrl, String owner, String repo, ReleaseChannel channel) {
         for (int attempt = 0; attempt < 2; attempt++) {
             if (attempt > 0) sleepMs(2000);
             HttpURLConnection connection = null;
@@ -125,7 +180,11 @@ public class GitHubReleaseRepository {
                     return null;
                 }
                 String json = readStream(connection.getInputStream());
-                return new ReleaseInfo(parseTagName(json), parseJarUrlFromAssets(json), parsePublishedAt(json));
+                String publishedAt = parsePublishedAt(json);
+                String version = channel == ReleaseChannel.EXPERIMENTAL
+                        ? synthesizeExperimentalVersion(parseTagName(json), parseTargetCommitish(json), publishedAt)
+                        : parseTagName(json);
+                return new ReleaseInfo(version, parseJarUrlFromAssets(json), publishedAt);
             } catch (IOException e) {
                 if (attempt == 0) continue;
                 logger.warn("Failed to reach GitHub API for " + owner + "/" + repo + ": " + e.getMessage());
@@ -148,8 +207,39 @@ public class GitHubReleaseRepository {
     }
 
     // direct quote-scan is safe for these fields — values are simple strings with no backslash escapes
-    String parseTagName(String json)     { return parseStringField(json, "tag_name"); }
-    String parsePublishedAt(String json) { return parseStringField(json, "published_at"); }
+    String parseTagName(String json)         { return parseStringField(json, "tag_name"); }
+    String parsePublishedAt(String json)     { return parseStringField(json, "published_at"); }
+    String parseTargetCommitish(String json) { return parseStringField(json, "target_commitish"); }
+
+    /**
+     * Builds a version identity for an experimental release.
+     *
+     * <p>Every experimental build carries the same tag, so the tag alone can never distinguish
+     * yesterday's build from today's — a plugin pinned to it would report "already up to date"
+     * forever. The commit the release points at is appended to make each build distinct, with the
+     * publish timestamp as a fallback for repositories whose {@code target_commitish} is a branch
+     * name rather than a sha.
+     */
+    String synthesizeExperimentalVersion(String tagName, String targetCommitish, String publishedAt) {
+        String base = (tagName != null && !tagName.isEmpty()) ? tagName : experimentalTag;
+        if (isCommitSha(targetCommitish)) {
+            return base + "-" + targetCommitish.substring(0, 7);
+        }
+        if (publishedAt != null && !publishedAt.isEmpty()) {
+            return base + "@" + publishedAt;
+        }
+        return base;
+    }
+
+    private boolean isCommitSha(String value) {
+        if (value == null || value.length() != 40) return false;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            boolean hex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+            if (!hex) return false;
+        }
+        return true;
+    }
 
     private String parseStringField(String json, String fieldName) {
         String key = "\"" + fieldName + "\"";

--- a/src/main/java/dansplugins/dpm/services/DownloadService.java
+++ b/src/main/java/dansplugins/dpm/services/DownloadService.java
@@ -1,6 +1,7 @@
 package dansplugins.dpm.services;
 
 import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.objects.ReleaseChannel;
 import dansplugins.dpm.objects.ReleaseInfo;
 import dansplugins.dpm.repositories.GitHubReleaseRepository;
 import dansplugins.dpm.repositories.PluginFileRepository;
@@ -39,13 +40,23 @@ public class DownloadService {
     }
 
     public int downloadLatest(ProjectRecord projectRecord) {
-        return downloadLatest(projectRecord, pluginFileRepository.isInstalled(projectRecord));
+        return downloadLatest(projectRecord, ReleaseChannel.STABLE);
+    }
+
+    public int downloadLatest(ProjectRecord projectRecord, ReleaseChannel channel) {
+        return downloadLatest(projectRecord, channel, pluginFileRepository.isInstalled(projectRecord));
     }
 
     // physicallyInstalled lets callers that have already confirmed the JAR is present (e.g. via
     // filterInstalled()) skip the per-call isInstalled() directory scan.
     public int downloadLatest(ProjectRecord projectRecord, boolean physicallyInstalled) {
-        ReleaseInfo release = gitHubReleaseRepository.getLatestRelease(projectRecord.getOwner(), projectRecord.getRepo());
+        return downloadLatest(projectRecord, ReleaseChannel.STABLE, physicallyInstalled);
+    }
+
+    // A channel switch needs no special handling: the stored tag from one channel never matches the
+    // other channel's tag, so the up-to-date check falls through and the JAR is re-downloaded.
+    public int downloadLatest(ProjectRecord projectRecord, ReleaseChannel channel, boolean physicallyInstalled) {
+        ReleaseInfo release = gitHubReleaseRepository.getRelease(projectRecord.getOwner(), projectRecord.getRepo(), channel);
         if (release == ReleaseInfo.NO_RELEASE) {
             return NO_RELEASE;
         }

--- a/src/main/java/dansplugins/dpm/utils/TabCompleter.java
+++ b/src/main/java/dansplugins/dpm/utils/TabCompleter.java
@@ -5,7 +5,33 @@ import java.util.List;
 
 public class TabCompleter {
 
+    /** Channel flags accepted by /dpm get, offered alongside plugin names. */
+    public static final List<String> CHANNEL_FLAGS = List.of("--experimental", "--stable");
+
     private TabCompleter() {}
+
+    /**
+     * Returns the plugin names plus the channel flags, for completing /dpm get arguments.
+     * The flags are mutually exclusive, so once either one is on the command line neither is
+     * suggested again.
+     */
+    public static List<String> pluginNamesWithChannelFlags(List<String> pluginNames, String[] argsSoFar) {
+        List<String> options = new ArrayList<>(pluginNames);
+        if (!containsChannelFlag(argsSoFar)) {
+            options.addAll(CHANNEL_FLAGS);
+        }
+        return options;
+    }
+
+    private static boolean containsChannelFlag(String[] values) {
+        if (values == null) return false;
+        for (String value : values) {
+            for (String flag : CHANNEL_FLAGS) {
+                if (flag.equalsIgnoreCase(value)) return true;
+            }
+        }
+        return false;
+    }
 
     public static List<String> filterByPrefix(List<String> options, String partial) {
         String lower = partial.toLowerCase();

--- a/src/test/java/dansplugins/dpm/TabCompletionTest.java
+++ b/src/test/java/dansplugins/dpm/TabCompletionTest.java
@@ -82,4 +82,41 @@ class TabCompletionTest {
         assertEquals(List.of("currencies", "conquestrecipes"),
                 TabCompleter.filterByPrefix(plugins, "c"));
     }
+
+    // -------------------------------------------------------------------------
+    // channel-flag completion for /dpm get
+    // -------------------------------------------------------------------------
+
+    @Test
+    void pluginNamesWithChannelFlags_offersBothFlagsAlongsidePluginNames() {
+        List<String> options = TabCompleter.pluginNamesWithChannelFlags(
+                List.of("currencies"), new String[]{"get", ""});
+
+        assertTrue(options.containsAll(List.of("currencies", "--experimental", "--stable")));
+    }
+
+    @Test
+    void pluginNamesWithChannelFlags_completesAPartiallyTypedFlag() {
+        List<String> options = TabCompleter.pluginNamesWithChannelFlags(
+                List.of("currencies"), new String[]{"get", "currencies", "--e"});
+
+        assertEquals(List.of("--experimental"), TabCompleter.filterByPrefix(options, "--e"));
+    }
+
+    @Test
+    void pluginNamesWithChannelFlags_stopsOfferingFlagsOnceOneIsPresent() {
+        List<String> options = TabCompleter.pluginNamesWithChannelFlags(
+                List.of("currencies"), new String[]{"get", "currencies", "--experimental", ""});
+
+        assertEquals(List.of("currencies"), options,
+                "The flags are mutually exclusive, so neither should be suggested a second time");
+    }
+
+    @Test
+    void pluginNamesWithChannelFlags_isCaseInsensitiveWhenDetectingAnExistingFlag() {
+        List<String> options = TabCompleter.pluginNamesWithChannelFlags(
+                List.of("currencies"), new String[]{"get", "currencies", "--STABLE", ""});
+
+        assertEquals(List.of("currencies"), options);
+    }
 }

--- a/src/test/java/dansplugins/dpm/commands/GetCommandTest.java
+++ b/src/test/java/dansplugins/dpm/commands/GetCommandTest.java
@@ -1,0 +1,106 @@
+package dansplugins.dpm.commands;
+
+import dansplugins.dpm.commands.GetCommand.ParsedArgs;
+import dansplugins.dpm.objects.ReleaseChannel;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// GetCommand itself depends on Bukkit and cannot be constructed here; parseArgs is static and
+// Bukkit-free, so the flag handling is covered directly.
+class GetCommandTest {
+
+    // -------------------------------------------------------------------------
+    // parseArgs()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void parseArgs_withNoFlagsLeavesTheChannelUnrequested() {
+        ParsedArgs parsed = GetCommand.parseArgs(new String[]{"Currencies", "Fiefs"});
+
+        assertNull(parsed.error);
+        assertNull(parsed.requestedChannel, "No flag means the plugin's stored channel is used");
+        assertEquals(List.of("Currencies", "Fiefs"), parsed.names);
+    }
+
+    @Test
+    void parseArgs_stripsTheExperimentalFlagFromTheNameList() {
+        ParsedArgs parsed = GetCommand.parseArgs(new String[]{"Currencies", "--experimental"});
+
+        assertNull(parsed.error);
+        assertEquals(ReleaseChannel.EXPERIMENTAL, parsed.requestedChannel);
+        assertEquals(List.of("Currencies"), parsed.names);
+    }
+
+    @Test
+    void parseArgs_acceptsTheFlagBeforeTheNames() {
+        ParsedArgs parsed = GetCommand.parseArgs(new String[]{"--experimental", "Currencies", "Fiefs"});
+
+        assertNull(parsed.error);
+        assertEquals(ReleaseChannel.EXPERIMENTAL, parsed.requestedChannel);
+        assertEquals(List.of("Currencies", "Fiefs"), parsed.names);
+    }
+
+    @Test
+    void parseArgs_acceptsTheFlagBetweenNames() {
+        ParsedArgs parsed = GetCommand.parseArgs(new String[]{"Currencies", "--stable", "Fiefs"});
+
+        assertNull(parsed.error);
+        assertEquals(ReleaseChannel.STABLE, parsed.requestedChannel);
+        assertEquals(List.of("Currencies", "Fiefs"), parsed.names);
+    }
+
+    @Test
+    void parseArgs_isCaseInsensitiveForFlags() {
+        ParsedArgs parsed = GetCommand.parseArgs(new String[]{"Currencies", "--Experimental"});
+
+        assertNull(parsed.error);
+        assertEquals(ReleaseChannel.EXPERIMENTAL, parsed.requestedChannel);
+    }
+
+    @Test
+    void parseArgs_allowsTheSameFlagRepeated() {
+        ParsedArgs parsed = GetCommand.parseArgs(new String[]{"--stable", "Currencies", "--stable"});
+
+        assertNull(parsed.error);
+        assertEquals(ReleaseChannel.STABLE, parsed.requestedChannel);
+        assertEquals(List.of("Currencies"), parsed.names);
+    }
+
+    @Test
+    void parseArgs_rejectsBothChannelFlagsTogether() {
+        ParsedArgs parsed = GetCommand.parseArgs(new String[]{"Currencies", "--experimental", "--stable"});
+
+        assertNotNull(parsed.error);
+        assertTrue(parsed.error.contains("cannot be used together"));
+    }
+
+    @Test
+    void parseArgs_rejectsAnUnknownFlag() {
+        ParsedArgs parsed = GetCommand.parseArgs(new String[]{"Currencies", "--beta"});
+
+        assertNotNull(parsed.error);
+        assertTrue(parsed.error.contains("--beta"));
+        assertTrue(parsed.error.contains("--experimental"));
+    }
+
+    @Test
+    void parseArgs_withOnlyAFlagYieldsNoNames() {
+        ParsedArgs parsed = GetCommand.parseArgs(new String[]{"--experimental"});
+
+        assertNull(parsed.error);
+        assertTrue(parsed.names.isEmpty(), "A bare flag must fall through to the usage message");
+    }
+
+    @Test
+    void parseArgs_treatsASingleDashArgumentAsAPluginName() {
+        // Only "--" prefixed arguments are options; a lone dash is passed through as a name so the
+        // existing "plugin not found" message explains the problem.
+        ParsedArgs parsed = GetCommand.parseArgs(new String[]{"-experimental"});
+
+        assertNull(parsed.error);
+        assertEquals(List.of("-experimental"), parsed.names);
+    }
+}

--- a/src/test/java/dansplugins/dpm/controllers/GetControllerTest.java
+++ b/src/test/java/dansplugins/dpm/controllers/GetControllerTest.java
@@ -3,7 +3,10 @@ package dansplugins.dpm.controllers;
 import dansplugins.dpm.controllers.GetController.DependencyResolutionResult;
 import dansplugins.dpm.controllers.GetController.Outcome;
 import dansplugins.dpm.controllers.GetController.PluginResult;
+import dansplugins.dpm.controllers.GetController.Target;
 import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.objects.ReleaseChannel;
+import dansplugins.dpm.repositories.ChannelRepository;
 import dansplugins.dpm.repositories.ConfigRepository;
 import dansplugins.dpm.repositories.VersionRepository;
 import dansplugins.dpm.services.DependencyResolutionService;
@@ -33,6 +36,10 @@ class GetControllerTest {
         return new VersionRepository(new File(tempDir.toFile(), "dpm-versions.properties"), null);
     }
 
+    private static ChannelRepository channelRepository(Path tempDir) {
+        return new ChannelRepository(new File(tempDir.toFile(), "dpm-channels.properties"), null);
+    }
+
     private static DiscordNotificationService recordingDiscordService(List<String> sent) {
         return new DiscordNotificationService((ConfigRepository) null) {
             @Override
@@ -43,19 +50,27 @@ class GetControllerTest {
     }
 
     private static DownloadService stubDownloadService(Map<String, Integer> resultsByName) {
+        return stubDownloadService(resultsByName, new ArrayList<>());
+    }
+
+    // Records the channel each download was attempted on, so channel routing can be asserted.
+    private static DownloadService stubDownloadService(Map<String, Integer> resultsByName, List<ReleaseChannel> channelsUsed) {
         return new DownloadService(null, null, null, null) {
             @Override
-            public int downloadLatest(ProjectRecord projectRecord) {
+            public int downloadLatest(ProjectRecord projectRecord, ReleaseChannel channel) {
+                channelsUsed.add(channel);
                 return resultsByName.get(projectRecord.getName());
             }
         };
     }
 
-    private static GetController controller(Map<String, Integer> resultsByName, VersionRepository versionRepository, List<String> sentDiscordMessages) {
+    private static GetController controller(Map<String, Integer> resultsByName, VersionRepository versionRepository,
+                                            ChannelRepository channelRepository, List<String> sentDiscordMessages) {
         return new GetController(
                 stubDownloadService(resultsByName),
                 new DependencyResolutionService(null, null),
                 versionRepository,
+                channelRepository,
                 recordingDiscordService(sentDiscordMessages),
                 Logger.getLogger("GetControllerTest"));
     }
@@ -76,7 +91,7 @@ class GetControllerTest {
         };
         GetController controller = new GetController(
                 stubDownloadService(new HashMap<>()), fakeResolution, versionRepository(tempDir),
-                recordingDiscordService(new ArrayList<>()), Logger.getLogger("GetControllerTest"));
+                channelRepository(tempDir), recordingDiscordService(new ArrayList<>()), Logger.getLogger("GetControllerTest"));
 
         controller.resolveDependencies(List.of(record("MedievalFactions")));
 
@@ -97,7 +112,7 @@ class GetControllerTest {
         };
         GetController controller = new GetController(
                 stubDownloadService(new HashMap<>()), fakeResolution, versionRepository(tempDir),
-                recordingDiscordService(new ArrayList<>()), Logger.getLogger("GetControllerTest"));
+                channelRepository(tempDir), recordingDiscordService(new ArrayList<>()), Logger.getLogger("GetControllerTest"));
 
         DependencyResolutionResult result = controller.resolveDependencies(List.of(record("MedievalFactions")));
 
@@ -113,7 +128,7 @@ class GetControllerTest {
     void download_returnsNoReleaseOutcomeWhenNoPublishedRelease(@TempDir Path tempDir) {
         Map<String, Integer> results = new HashMap<>();
         results.put("MyPlugin", DownloadService.NO_RELEASE);
-        GetController controller = controller(results, versionRepository(tempDir), new ArrayList<>());
+        GetController controller = controller(results, versionRepository(tempDir), channelRepository(tempDir), new ArrayList<>());
 
         PluginResult result = controller.download(record("MyPlugin"));
 
@@ -127,7 +142,7 @@ class GetControllerTest {
         versionRepository.setTag("MyPlugin", "v1.2.3");
         Map<String, Integer> results = new HashMap<>();
         results.put("MyPlugin", DownloadService.ALREADY_UP_TO_DATE);
-        GetController controller = controller(results, versionRepository, new ArrayList<>());
+        GetController controller = controller(results, versionRepository, channelRepository(tempDir), new ArrayList<>());
 
         PluginResult result = controller.download(record("MyPlugin"));
 
@@ -140,7 +155,7 @@ class GetControllerTest {
         Map<String, Integer> results = new HashMap<>();
         results.put("MyPlugin", DownloadService.NETWORK_ERROR);
         List<String> sent = new ArrayList<>();
-        GetController controller = controller(results, versionRepository(tempDir), sent);
+        GetController controller = controller(results, versionRepository(tempDir), channelRepository(tempDir), sent);
 
         PluginResult result = controller.download(record("MyPlugin"));
 
@@ -154,7 +169,7 @@ class GetControllerTest {
         Map<String, Integer> results = new HashMap<>();
         results.put("MyPlugin", DownloadService.FILE_ERROR);
         List<String> sent = new ArrayList<>();
-        GetController controller = controller(results, versionRepository(tempDir), sent);
+        GetController controller = controller(results, versionRepository(tempDir), channelRepository(tempDir), sent);
 
         PluginResult result = controller.download(record("MyPlugin"));
 
@@ -168,7 +183,7 @@ class GetControllerTest {
         Map<String, Integer> results = new HashMap<>();
         results.put("MyPlugin", -99);
         List<String> sent = new ArrayList<>();
-        GetController controller = controller(results, versionRepository(tempDir), sent);
+        GetController controller = controller(results, versionRepository(tempDir), channelRepository(tempDir), sent);
 
         PluginResult result = controller.download(record("MyPlugin"));
 
@@ -182,13 +197,126 @@ class GetControllerTest {
         versionRepository.setTag("MyPlugin", "v2.0.0");
         Map<String, Integer> results = new HashMap<>();
         results.put("MyPlugin", 4096);
-        GetController controller = controller(results, versionRepository, new ArrayList<>());
+        GetController controller = controller(results, versionRepository, channelRepository(tempDir), new ArrayList<>());
 
         PluginResult result = controller.download(record("MyPlugin"));
 
         assertEquals(Outcome.DOWNLOADED, result.getOutcome());
         assertEquals(4096, result.getDownloadedBytes());
         assertEquals("v2.0.0", result.getStoredTag());
+    }
+
+    // -------------------------------------------------------------------------
+    // download() — release channels
+    // -------------------------------------------------------------------------
+
+    @Test
+    void download_usesTheStoredChannelWhenNoChannelIsRequested(@TempDir Path tempDir) {
+        ChannelRepository channelRepository = channelRepository(tempDir);
+        channelRepository.setChannel("MyPlugin", ReleaseChannel.EXPERIMENTAL);
+        List<ReleaseChannel> channelsUsed = new ArrayList<>();
+        Map<String, Integer> results = new HashMap<>();
+        results.put("MyPlugin", 2048);
+        GetController controller = new GetController(
+                stubDownloadService(results, channelsUsed), new DependencyResolutionService(null, null),
+                versionRepository(tempDir), channelRepository, recordingDiscordService(new ArrayList<>()),
+                Logger.getLogger("GetControllerTest"));
+
+        PluginResult result = controller.download(record("MyPlugin"));
+
+        assertEquals(List.of(ReleaseChannel.EXPERIMENTAL), channelsUsed);
+        assertEquals(ReleaseChannel.EXPERIMENTAL, result.getChannel());
+    }
+
+    @Test
+    void download_pinsThePluginToExperimentalAfterASuccessfulDownload(@TempDir Path tempDir) {
+        ChannelRepository channelRepository = channelRepository(tempDir);
+        Map<String, Integer> results = new HashMap<>();
+        results.put("MyPlugin", 2048);
+        GetController controller = controller(results, versionRepository(tempDir), channelRepository, new ArrayList<>());
+
+        controller.download(record("MyPlugin"), ReleaseChannel.EXPERIMENTAL);
+
+        assertEquals(ReleaseChannel.EXPERIMENTAL, channelRepository.getChannel("MyPlugin"));
+    }
+
+    @Test
+    void download_pinsThePluginToExperimentalWhenItIsAlreadyUpToDate(@TempDir Path tempDir) {
+        ChannelRepository channelRepository = channelRepository(tempDir);
+        Map<String, Integer> results = new HashMap<>();
+        results.put("MyPlugin", DownloadService.ALREADY_UP_TO_DATE);
+        GetController controller = controller(results, versionRepository(tempDir), channelRepository, new ArrayList<>());
+
+        controller.download(record("MyPlugin"), ReleaseChannel.EXPERIMENTAL);
+
+        assertEquals(ReleaseChannel.EXPERIMENTAL, channelRepository.getChannel("MyPlugin"));
+    }
+
+    @Test
+    void download_stableRequestClearsAnExistingExperimentalPin(@TempDir Path tempDir) {
+        ChannelRepository channelRepository = channelRepository(tempDir);
+        channelRepository.setChannel("MyPlugin", ReleaseChannel.EXPERIMENTAL);
+        Map<String, Integer> results = new HashMap<>();
+        results.put("MyPlugin", 2048);
+        GetController controller = controller(results, versionRepository(tempDir), channelRepository, new ArrayList<>());
+
+        controller.download(record("MyPlugin"), ReleaseChannel.STABLE);
+
+        assertEquals(ReleaseChannel.STABLE, channelRepository.getChannel("MyPlugin"));
+    }
+
+    @Test
+    void download_doesNotPinWhenTheRequestedChannelPublishesNoBuild(@TempDir Path tempDir) {
+        // Pinning here would strand the plugin on a channel with nothing to install,
+        // silently skipping it on every later /dpm update.
+        ChannelRepository channelRepository = channelRepository(tempDir);
+        Map<String, Integer> results = new HashMap<>();
+        results.put("MyPlugin", DownloadService.NO_RELEASE);
+        GetController controller = controller(results, versionRepository(tempDir), channelRepository, new ArrayList<>());
+
+        PluginResult result = controller.download(record("MyPlugin"), ReleaseChannel.EXPERIMENTAL);
+
+        assertEquals(Outcome.NO_RELEASE, result.getOutcome());
+        assertEquals(ReleaseChannel.EXPERIMENTAL, result.getChannel());
+        assertEquals(ReleaseChannel.STABLE, channelRepository.getChannel("MyPlugin"));
+    }
+
+    @Test
+    void download_doesNotPinWhenTheDownloadFails(@TempDir Path tempDir) {
+        ChannelRepository channelRepository = channelRepository(tempDir);
+        Map<String, Integer> results = new HashMap<>();
+        results.put("MyPlugin", DownloadService.NETWORK_ERROR);
+        GetController controller = controller(results, versionRepository(tempDir), channelRepository, new ArrayList<>());
+
+        controller.download(record("MyPlugin"), ReleaseChannel.EXPERIMENTAL);
+
+        assertEquals(ReleaseChannel.STABLE, channelRepository.getChannel("MyPlugin"));
+    }
+
+    // -------------------------------------------------------------------------
+    // runTargets()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void runTargets_doesNotApplyARequestedChannelToDependencies(@TempDir Path tempDir) {
+        ChannelRepository channelRepository = channelRepository(tempDir);
+        List<ReleaseChannel> channelsUsed = new ArrayList<>();
+        Map<String, Integer> results = new HashMap<>();
+        results.put("Dependency", 1024);
+        results.put("MyPlugin", 2048);
+        GetController controller = new GetController(
+                stubDownloadService(results, channelsUsed), new DependencyResolutionService(null, null),
+                versionRepository(tempDir), channelRepository, recordingDiscordService(new ArrayList<>()),
+                Logger.getLogger("GetControllerTest"));
+
+        controller.runTargets(List.of(
+                Target.usingStoredChannel(record("Dependency")),
+                Target.of(record("MyPlugin"), ReleaseChannel.EXPERIMENTAL)));
+
+        assertEquals(List.of(ReleaseChannel.STABLE, ReleaseChannel.EXPERIMENTAL), channelsUsed,
+                "A dependency must keep its own channel rather than inheriting --experimental");
+        assertEquals(ReleaseChannel.STABLE, channelRepository.getChannel("Dependency"));
+        assertEquals(ReleaseChannel.EXPERIMENTAL, channelRepository.getChannel("MyPlugin"));
     }
 
     // -------------------------------------------------------------------------
@@ -200,7 +328,7 @@ class GetControllerTest {
         Map<String, Integer> results = new HashMap<>();
         results.put("PluginA", DownloadService.ALREADY_UP_TO_DATE);
         results.put("PluginB", DownloadService.NO_RELEASE);
-        GetController controller = controller(results, versionRepository(tempDir), new ArrayList<>());
+        GetController controller = controller(results, versionRepository(tempDir), channelRepository(tempDir), new ArrayList<>());
 
         List<PluginResult> batchResults = controller.runBatch(List.of(record("PluginA"), record("PluginB")));
 

--- a/src/test/java/dansplugins/dpm/controllers/RemoveControllerTest.java
+++ b/src/test/java/dansplugins/dpm/controllers/RemoveControllerTest.java
@@ -4,6 +4,8 @@ import dansplugins.dpm.controllers.RemoveController.Outcome;
 import dansplugins.dpm.controllers.RemoveController.RemovalPreview;
 import dansplugins.dpm.controllers.RemoveController.RemovalResult;
 import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.objects.ReleaseChannel;
+import dansplugins.dpm.repositories.ChannelRepository;
 import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
 import dansplugins.dpm.repositories.VersionRepository;
@@ -44,12 +46,17 @@ class RemoveControllerTest {
         return new VersionRepository(new File(tempDir.toFile(), "dpm-versions.properties"), null);
     }
 
+    private static ChannelRepository channelRepository(Path tempDir) {
+        return new ChannelRepository(new File(tempDir.toFile(), "dpm-channels.properties"), null);
+    }
+
     private static RemoveController controller(ProjectRecordRepository projectRecordRepository, PluginFileRepository pluginFileRepository,
-                                                VersionRepository versionRepository) {
+                                                VersionRepository versionRepository, ChannelRepository channelRepository) {
         return new RemoveController(
                 projectRecordRepository,
                 pluginFileRepository,
                 versionRepository,
+                channelRepository,
                 new DependencyResolutionService(projectRecordRepository, pluginFileRepository),
                 Logger.getLogger("RemoveControllerTest"));
     }
@@ -63,7 +70,7 @@ class RemoveControllerTest {
         ProjectRecord notInstalled = record("NotInstalled");
         PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         ProjectRecordRepository projectRecordRepository = projectRecordRepository(notInstalled);
-        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository(tempDir));
+        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository(tempDir), channelRepository(tempDir));
 
         RemovalPreview preview = controller.preview(notInstalled);
 
@@ -78,7 +85,7 @@ class RemoveControllerTest {
         new File(tempDir.toFile(), "Installed.jar").createNewFile();
         PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         ProjectRecordRepository projectRecordRepository = projectRecordRepository(installed);
-        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository(tempDir));
+        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository(tempDir), channelRepository(tempDir));
 
         RemovalPreview preview = controller.preview(installed);
 
@@ -95,7 +102,7 @@ class RemoveControllerTest {
         new File(tempDir.toFile(), "Dependent.jar").createNewFile();
         PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         ProjectRecordRepository projectRecordRepository = projectRecordRepository(target, dependent);
-        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository(tempDir));
+        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository(tempDir), channelRepository(tempDir));
 
         RemovalPreview preview = controller.preview(target);
 
@@ -111,7 +118,7 @@ class RemoveControllerTest {
         ProjectRecord notInstalled = record("NotInstalled");
         PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         ProjectRecordRepository projectRecordRepository = projectRecordRepository(notInstalled);
-        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository(tempDir));
+        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository(tempDir), channelRepository(tempDir));
 
         RemovalResult result = controller.remove(notInstalled);
 
@@ -128,7 +135,7 @@ class RemoveControllerTest {
         ProjectRecordRepository projectRecordRepository = projectRecordRepository(installed);
         VersionRepository versionRepository = versionRepository(tempDir);
         versionRepository.setTag("Installed", "v1.0.0");
-        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository);
+        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository, channelRepository(tempDir));
 
         RemovalResult result = controller.remove(installed);
 
@@ -145,12 +152,28 @@ class RemoveControllerTest {
         new File(tempDir.toFile(), "Dependent.jar").createNewFile();
         PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         ProjectRecordRepository projectRecordRepository = projectRecordRepository(target, dependent);
-        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository(tempDir));
+        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository(tempDir), channelRepository(tempDir));
 
         RemovalResult result = controller.remove(target);
 
         assertEquals(Outcome.DELETED, result.getOutcome());
         assertEquals(List.of("Dependent"), result.getDependents());
+    }
+
+    @Test
+    void remove_clearsTheStoredChannelSoAReinstallStartsOnStable(@TempDir Path tempDir) throws Exception {
+        ProjectRecord installed = record("Installed");
+        new File(tempDir.toFile(), "Installed.jar").createNewFile();
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
+        ProjectRecordRepository projectRecordRepository = projectRecordRepository(installed);
+        ChannelRepository channelRepository = channelRepository(tempDir);
+        channelRepository.setChannel("Installed", ReleaseChannel.EXPERIMENTAL);
+        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository(tempDir), channelRepository);
+
+        RemovalResult result = controller.remove(installed);
+
+        assertEquals(Outcome.DELETED, result.getOutcome());
+        assertEquals(ReleaseChannel.STABLE, channelRepository.getChannel("Installed"));
     }
 
     @Test
@@ -165,7 +188,7 @@ class RemoveControllerTest {
         ProjectRecord installed = record("Installed");
         PluginFileRepository pluginFileRepository = new PluginFileRepository(readOnlyDir.getAbsolutePath() + "/");
         ProjectRecordRepository projectRecordRepository = projectRecordRepository(installed);
-        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository(tempDir));
+        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository(tempDir), channelRepository(tempDir));
 
         RemovalResult result = controller.remove(installed);
 
@@ -186,7 +209,7 @@ class RemoveControllerTest {
         new File(tempDir.toFile(), "Installed.jar").createNewFile();
         PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         ProjectRecordRepository projectRecordRepository = projectRecordRepository(installed, notInstalled);
-        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository(tempDir));
+        RemoveController controller = controller(projectRecordRepository, pluginFileRepository, versionRepository(tempDir), channelRepository(tempDir));
 
         List<ProjectRecord> result = controller.getInstalledPlugins();
 

--- a/src/test/java/dansplugins/dpm/controllers/UpdateControllerTest.java
+++ b/src/test/java/dansplugins/dpm/controllers/UpdateControllerTest.java
@@ -4,6 +4,8 @@ import dansplugins.dpm.controllers.UpdateController.Outcome;
 import dansplugins.dpm.controllers.UpdateController.PluginResult;
 import dansplugins.dpm.controllers.UpdateController.SelectionResult;
 import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.objects.ReleaseChannel;
+import dansplugins.dpm.repositories.ChannelRepository;
 import dansplugins.dpm.repositories.ConfigRepository;
 import dansplugins.dpm.repositories.PluginFileRepository;
 import dansplugins.dpm.repositories.ProjectRecordRepository;
@@ -33,6 +35,10 @@ class UpdateControllerTest {
         return new VersionRepository(new File(tempDir.toFile(), "dpm-versions.properties"), null);
     }
 
+    private static ChannelRepository channelRepository(Path tempDir) {
+        return new ChannelRepository(new File(tempDir.toFile(), "dpm-channels.properties"), null);
+    }
+
     private static DiscordNotificationService recordingDiscordService(List<String> sent) {
         return new DiscordNotificationService((ConfigRepository) null) {
             @Override
@@ -43,9 +49,15 @@ class UpdateControllerTest {
     }
 
     private static DownloadService stubDownloadService(Map<String, Integer> resultsByName) {
+        return stubDownloadService(resultsByName, new ArrayList<>());
+    }
+
+    // Records the channel each update was attempted on, so channel routing can be asserted.
+    private static DownloadService stubDownloadService(Map<String, Integer> resultsByName, List<ReleaseChannel> channelsUsed) {
         return new DownloadService(null, null, null, null) {
             @Override
-            public int downloadLatest(ProjectRecord projectRecord, boolean physicallyInstalled) {
+            public int downloadLatest(ProjectRecord projectRecord, ReleaseChannel channel, boolean physicallyInstalled) {
+                channelsUsed.add(channel);
                 return resultsByName.get(projectRecord.getName());
             }
         };
@@ -61,12 +73,13 @@ class UpdateControllerTest {
 
     private static UpdateController controller(ProjectRecordRepository projectRecordRepository, PluginFileRepository pluginFileRepository,
                                                 Map<String, Integer> resultsByName, VersionRepository versionRepository,
-                                                List<String> sentDiscordMessages) {
+                                                ChannelRepository channelRepository, List<String> sentDiscordMessages) {
         return new UpdateController(
                 projectRecordRepository,
                 pluginFileRepository,
                 stubDownloadService(resultsByName),
                 versionRepository,
+                channelRepository,
                 recordingDiscordService(sentDiscordMessages),
                 Logger.getLogger("UpdateControllerTest"));
     }
@@ -82,7 +95,7 @@ class UpdateControllerTest {
         new File(tempDir.toFile(), "Installed.jar").createNewFile();
         PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         ProjectRecordRepository projectRecordRepository = projectRecordRepository(installed, notInstalled);
-        UpdateController controller = controller(projectRecordRepository, pluginFileRepository, new HashMap<>(), versionRepository(tempDir), new ArrayList<>());
+        UpdateController controller = controller(projectRecordRepository, pluginFileRepository, new HashMap<>(), versionRepository(tempDir), channelRepository(tempDir), new ArrayList<>());
 
         List<ProjectRecord> result = controller.getInstalledPlugins();
 
@@ -98,7 +111,7 @@ class UpdateControllerTest {
     void selectForUpdate_returnsNotFoundForUnknownPluginName(@TempDir Path tempDir) {
         PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         ProjectRecordRepository projectRecordRepository = projectRecordRepository();
-        UpdateController controller = controller(projectRecordRepository, pluginFileRepository, new HashMap<>(), versionRepository(tempDir), new ArrayList<>());
+        UpdateController controller = controller(projectRecordRepository, pluginFileRepository, new HashMap<>(), versionRepository(tempDir), channelRepository(tempDir), new ArrayList<>());
 
         SelectionResult result = controller.selectForUpdate(new String[]{"Unknown"});
 
@@ -112,7 +125,7 @@ class UpdateControllerTest {
         ProjectRecord notInstalled = record("NotInstalled");
         PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         ProjectRecordRepository projectRecordRepository = projectRecordRepository(notInstalled);
-        UpdateController controller = controller(projectRecordRepository, pluginFileRepository, new HashMap<>(), versionRepository(tempDir), new ArrayList<>());
+        UpdateController controller = controller(projectRecordRepository, pluginFileRepository, new HashMap<>(), versionRepository(tempDir), channelRepository(tempDir), new ArrayList<>());
 
         SelectionResult result = controller.selectForUpdate(new String[]{"NotInstalled"});
 
@@ -127,7 +140,7 @@ class UpdateControllerTest {
         new File(tempDir.toFile(), "Installed.jar").createNewFile();
         PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
         ProjectRecordRepository projectRecordRepository = projectRecordRepository(installed);
-        UpdateController controller = controller(projectRecordRepository, pluginFileRepository, new HashMap<>(), versionRepository(tempDir), new ArrayList<>());
+        UpdateController controller = controller(projectRecordRepository, pluginFileRepository, new HashMap<>(), versionRepository(tempDir), channelRepository(tempDir), new ArrayList<>());
 
         SelectionResult result = controller.selectForUpdate(new String[]{"Installed"});
 
@@ -146,7 +159,7 @@ class UpdateControllerTest {
         versionRepository.setTag("MyPlugin", "v1.2.3");
         Map<String, Integer> results = new HashMap<>();
         results.put("MyPlugin", DownloadService.ALREADY_UP_TO_DATE);
-        UpdateController controller = controller(projectRecordRepository(), new PluginFileRepository(tempDir.toString()), results, versionRepository, new ArrayList<>());
+        UpdateController controller = controller(projectRecordRepository(), new PluginFileRepository(tempDir.toString()), results, versionRepository, channelRepository(tempDir), new ArrayList<>());
 
         List<PluginResult> batchResults = controller.runBatch(List.of(record("MyPlugin")));
 
@@ -159,7 +172,7 @@ class UpdateControllerTest {
     void runBatch_returnsNoReleaseOutcomeWhenNoPublishedRelease(@TempDir Path tempDir) {
         Map<String, Integer> results = new HashMap<>();
         results.put("MyPlugin", DownloadService.NO_RELEASE);
-        UpdateController controller = controller(projectRecordRepository(), new PluginFileRepository(tempDir.toString()), results, versionRepository(tempDir), new ArrayList<>());
+        UpdateController controller = controller(projectRecordRepository(), new PluginFileRepository(tempDir.toString()), results, versionRepository(tempDir), channelRepository(tempDir), new ArrayList<>());
 
         List<PluginResult> batchResults = controller.runBatch(List.of(record("MyPlugin")));
 
@@ -172,7 +185,7 @@ class UpdateControllerTest {
         versionRepository.setTag("MyPlugin", "v1.0.0");
         Map<String, Integer> results = new HashMap<>();
         results.put("MyPlugin", 4096);
-        UpdateController controller = controller(projectRecordRepository(), new PluginFileRepository(tempDir.toString()), results, versionRepository, new ArrayList<>());
+        UpdateController controller = controller(projectRecordRepository(), new PluginFileRepository(tempDir.toString()), results, versionRepository, channelRepository(tempDir), new ArrayList<>());
 
         List<PluginResult> batchResults = controller.runBatch(List.of(record("MyPlugin")));
 
@@ -185,7 +198,7 @@ class UpdateControllerTest {
     void runBatch_returnsNetworkErrorOutcomeForNetworkFailure(@TempDir Path tempDir) {
         Map<String, Integer> results = new HashMap<>();
         results.put("MyPlugin", DownloadService.NETWORK_ERROR);
-        UpdateController controller = controller(projectRecordRepository(), new PluginFileRepository(tempDir.toString()), results, versionRepository(tempDir), new ArrayList<>());
+        UpdateController controller = controller(projectRecordRepository(), new PluginFileRepository(tempDir.toString()), results, versionRepository(tempDir), channelRepository(tempDir), new ArrayList<>());
 
         List<PluginResult> batchResults = controller.runBatch(List.of(record("MyPlugin")));
 
@@ -196,7 +209,7 @@ class UpdateControllerTest {
     void runBatch_returnsFileErrorOutcomeForFileWriteFailure(@TempDir Path tempDir) {
         Map<String, Integer> results = new HashMap<>();
         results.put("MyPlugin", DownloadService.FILE_ERROR);
-        UpdateController controller = controller(projectRecordRepository(), new PluginFileRepository(tempDir.toString()), results, versionRepository(tempDir), new ArrayList<>());
+        UpdateController controller = controller(projectRecordRepository(), new PluginFileRepository(tempDir.toString()), results, versionRepository(tempDir), channelRepository(tempDir), new ArrayList<>());
 
         List<PluginResult> batchResults = controller.runBatch(List.of(record("MyPlugin")));
 
@@ -207,11 +220,30 @@ class UpdateControllerTest {
     void runBatch_returnsOtherFailureOutcomeForUnrecognizedNegativeResult(@TempDir Path tempDir) {
         Map<String, Integer> results = new HashMap<>();
         results.put("MyPlugin", -99);
-        UpdateController controller = controller(projectRecordRepository(), new PluginFileRepository(tempDir.toString()), results, versionRepository(tempDir), new ArrayList<>());
+        UpdateController controller = controller(projectRecordRepository(), new PluginFileRepository(tempDir.toString()), results, versionRepository(tempDir), channelRepository(tempDir), new ArrayList<>());
 
         List<PluginResult> batchResults = controller.runBatch(List.of(record("MyPlugin")));
 
         assertEquals(Outcome.OTHER_FAILURE, batchResults.get(0).getOutcome());
+    }
+
+    @Test
+    void runBatch_updatesEachPluginOnItsOwnStoredChannel(@TempDir Path tempDir) {
+        ChannelRepository channelRepository = channelRepository(tempDir);
+        channelRepository.setChannel("OnExperimental", ReleaseChannel.EXPERIMENTAL);
+        List<ReleaseChannel> channelsUsed = new ArrayList<>();
+        Map<String, Integer> results = new HashMap<>();
+        results.put("OnStable", 1024);
+        results.put("OnExperimental", 2048);
+        UpdateController controller = new UpdateController(
+                projectRecordRepository(), new PluginFileRepository(tempDir.toString()),
+                stubDownloadService(results, channelsUsed), versionRepository(tempDir), channelRepository,
+                recordingDiscordService(new ArrayList<>()), Logger.getLogger("UpdateControllerTest"));
+
+        controller.runBatch(List.of(record("OnStable"), record("OnExperimental")));
+
+        assertEquals(List.of(ReleaseChannel.STABLE, ReleaseChannel.EXPERIMENTAL), channelsUsed,
+                "/dpm update must follow each plugin's pinned channel");
     }
 
     @Test
@@ -224,7 +256,7 @@ class UpdateControllerTest {
         results.put("UpToDate", DownloadService.ALREADY_UP_TO_DATE);
         results.put("Failed", DownloadService.NETWORK_ERROR);
         List<String> sent = new ArrayList<>();
-        UpdateController controller = controller(projectRecordRepository(), new PluginFileRepository(tempDir.toString()), results, versionRepository, sent);
+        UpdateController controller = controller(projectRecordRepository(), new PluginFileRepository(tempDir.toString()), results, versionRepository, channelRepository(tempDir), sent);
 
         controller.runBatch(List.of(record("Updated"), record("UpToDate"), record("Failed")));
 

--- a/src/test/java/dansplugins/dpm/repositories/ChannelRepositoryTest.java
+++ b/src/test/java/dansplugins/dpm/repositories/ChannelRepositoryTest.java
@@ -1,0 +1,115 @@
+package dansplugins.dpm.repositories;
+
+import dansplugins.dpm.objects.ReleaseChannel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ChannelRepositoryTest {
+
+    private static ChannelRepository repository(Path tempDir) {
+        return new ChannelRepository(new File(tempDir.toFile(), "dpm-channels.properties"), null);
+    }
+
+    // -------------------------------------------------------------------------
+    // getChannel()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getChannel_defaultsToStableForUnknownPlugin(@TempDir Path tempDir) {
+        assertEquals(ReleaseChannel.STABLE, repository(tempDir).getChannel("NeverSeen"));
+    }
+
+    @Test
+    void getChannel_isCaseInsensitiveInPluginName(@TempDir Path tempDir) {
+        ChannelRepository repository = repository(tempDir);
+        repository.setChannel("MedievalFactions", ReleaseChannel.EXPERIMENTAL);
+
+        assertEquals(ReleaseChannel.EXPERIMENTAL, repository.getChannel("medievalfactions"));
+        assertEquals(ReleaseChannel.EXPERIMENTAL, repository.getChannel("MEDIEVALFACTIONS"));
+    }
+
+    @Test
+    void getChannel_fallsBackToStableForUnrecognizedStoredValue(@TempDir Path tempDir) throws Exception {
+        File store = new File(tempDir.toFile(), "dpm-channels.properties");
+        Files.writeString(store.toPath(), "myplugin=bananas\n");
+
+        assertEquals(ReleaseChannel.STABLE, new ChannelRepository(store, null).getChannel("MyPlugin"));
+    }
+
+    // -------------------------------------------------------------------------
+    // setChannel()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void setChannel_roundTripsThroughANewRepositoryInstance(@TempDir Path tempDir) {
+        repository(tempDir).setChannel("MyPlugin", ReleaseChannel.EXPERIMENTAL);
+
+        assertEquals(ReleaseChannel.EXPERIMENTAL, repository(tempDir).getChannel("MyPlugin"),
+                "Channel must persist across restarts");
+    }
+
+    @Test
+    void setChannel_overwritesPreviousChannel(@TempDir Path tempDir) {
+        ChannelRepository repository = repository(tempDir);
+        repository.setChannel("MyPlugin", ReleaseChannel.EXPERIMENTAL);
+        repository.setChannel("MyPlugin", ReleaseChannel.STABLE);
+
+        assertEquals(ReleaseChannel.STABLE, repository.getChannel("MyPlugin"));
+    }
+
+    @Test
+    void setChannel_doesNotAffectOtherPlugins(@TempDir Path tempDir) {
+        ChannelRepository repository = repository(tempDir);
+        repository.setChannel("PluginA", ReleaseChannel.EXPERIMENTAL);
+
+        assertEquals(ReleaseChannel.STABLE, repository.getChannel("PluginB"));
+    }
+
+    // -------------------------------------------------------------------------
+    // removeChannel()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void removeChannel_returnsPluginToTheStableDefault(@TempDir Path tempDir) {
+        ChannelRepository repository = repository(tempDir);
+        repository.setChannel("MyPlugin", ReleaseChannel.EXPERIMENTAL);
+
+        repository.removeChannel("MyPlugin");
+
+        assertEquals(ReleaseChannel.STABLE, repository.getChannel("MyPlugin"));
+        assertEquals(ReleaseChannel.STABLE, repository(tempDir).getChannel("MyPlugin"),
+                "Removal must persist across restarts");
+    }
+
+    @Test
+    void removeChannel_isSafeForAPluginThatWasNeverPinned(@TempDir Path tempDir) {
+        ChannelRepository repository = repository(tempDir);
+
+        assertDoesNotThrow(() -> repository.removeChannel("NeverSeen"));
+        assertEquals(ReleaseChannel.STABLE, repository.getChannel("NeverSeen"));
+    }
+
+    // -------------------------------------------------------------------------
+    // ReleaseChannel.fromStored()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void fromStored_parsesKnownNamesIgnoringCaseAndWhitespace() {
+        assertEquals(ReleaseChannel.EXPERIMENTAL, ReleaseChannel.fromStored("experimental"));
+        assertEquals(ReleaseChannel.EXPERIMENTAL, ReleaseChannel.fromStored(" EXPERIMENTAL "));
+        assertEquals(ReleaseChannel.STABLE, ReleaseChannel.fromStored("stable"));
+    }
+
+    @Test
+    void fromStored_defaultsToStableForNullOrUnknown() {
+        assertEquals(ReleaseChannel.STABLE, ReleaseChannel.fromStored(null));
+        assertEquals(ReleaseChannel.STABLE, ReleaseChannel.fromStored(""));
+        assertEquals(ReleaseChannel.STABLE, ReleaseChannel.fromStored("beta"));
+    }
+}

--- a/src/test/java/dansplugins/dpm/repositories/ConfigRepositoryTest.java
+++ b/src/test/java/dansplugins/dpm/repositories/ConfigRepositoryTest.java
@@ -25,6 +25,18 @@ class ConfigRepositoryTest {
         assertFalse(config.getBoolean("debugMode"));
         assertEquals("", config.getString("githubToken"));
         assertEquals("", config.getString("discordWebhook"));
+        assertEquals("dev", config.getString("experimentalReleaseTag"));
+    }
+
+    @Test
+    void saveMissingConfigDefaultsIfNotPresent_doesNotOverwriteExistingExperimentalReleaseTag() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("experimentalReleaseTag", "nightly");
+        ConfigRepository repository = repository(config, "v1.0", new ArrayList<>());
+
+        repository.saveMissingConfigDefaultsIfNotPresent();
+
+        assertEquals("nightly", config.getString("experimentalReleaseTag"));
     }
 
     @Test

--- a/src/test/java/dansplugins/dpm/repositories/GitHubReleaseRepositoryTest.java
+++ b/src/test/java/dansplugins/dpm/repositories/GitHubReleaseRepositoryTest.java
@@ -1,5 +1,6 @@
 package dansplugins.dpm.repositories;
 
+import dansplugins.dpm.objects.ReleaseChannel;
 import dansplugins.dpm.objects.ReleaseInfo;
 import dansplugins.dpm.utils.Logger;
 import org.junit.jupiter.api.Test;
@@ -421,6 +422,231 @@ class GitHubReleaseRepositoryTest {
         // No closing bracket — bracket-depth tracking should handle gracefully
         String json = "{\"assets\":[{\"name\":\"Plugin-1.0.jar\",\"browser_download_url\":\"https://example.com/Plugin-1.0.jar\"";
         assertNull(service.parseJarUrlFromAssets(json));
+    }
+
+    // -------------------------------------------------------------------------
+    // synthesizeExperimentalVersion()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void synthesizeExperimentalVersion_usesShortShaWhenTargetCommitishIsACommitSha() {
+        assertEquals("dev-abc1234",
+                service.synthesizeExperimentalVersion("dev", "abc1234def5678901234567890123456789abcde", "2024-01-01T00:00:00Z"));
+    }
+
+    @Test
+    void synthesizeExperimentalVersion_fallsBackToPublishedAtWhenTargetCommitishIsABranchName() {
+        assertEquals("dev@2024-03-15T10:00:00Z",
+                service.synthesizeExperimentalVersion("dev", "main", "2024-03-15T10:00:00Z"));
+    }
+
+    @Test
+    void synthesizeExperimentalVersion_fallsBackToTagWhenNeitherShaNorPublishedAtAvailable() {
+        assertEquals("dev", service.synthesizeExperimentalVersion("dev", "main", null));
+        assertEquals("dev", service.synthesizeExperimentalVersion("dev", null, ""));
+    }
+
+    @Test
+    void synthesizeExperimentalVersion_usesConfiguredTagWhenReleaseTagNameIsMissing() {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null);
+        svc.setExperimentalTag("nightly");
+        assertEquals("nightly-abc1234",
+                svc.synthesizeExperimentalVersion(null, "abc1234def5678901234567890123456789abcde", null));
+    }
+
+    @Test
+    void synthesizeExperimentalVersion_rejectsNonHexAndWrongLengthCommitish() {
+        // 40 characters but not hex — must not be mistaken for a sha.
+        assertEquals("dev@2024-01-01T00:00:00Z",
+                service.synthesizeExperimentalVersion("dev", "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", "2024-01-01T00:00:00Z"));
+        // A short sha is not a full commitish and must not be truncated silently.
+        assertEquals("dev@2024-01-01T00:00:00Z",
+                service.synthesizeExperimentalVersion("dev", "abc1234", "2024-01-01T00:00:00Z"));
+    }
+
+    // -------------------------------------------------------------------------
+    // parseTargetCommitish()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void parseTargetCommitish_returnsValue() {
+        String json = "{\"tag_name\":\"dev\",\"target_commitish\":\"abc1234def5678901234567890123456789abcde\"}";
+        assertEquals("abc1234def5678901234567890123456789abcde", service.parseTargetCommitish(json));
+    }
+
+    @Test
+    void parseTargetCommitish_returnsNullWhenMissing() {
+        assertNull(service.parseTargetCommitish("{\"tag_name\":\"dev\"}"));
+    }
+
+    // -------------------------------------------------------------------------
+    // getExperimentalRelease()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getExperimentalRelease_requestsTheConfiguredTagAndSynthesizesAVersionFromTheCommit() throws IOException {
+        List<String> requestedUrls = new ArrayList<>();
+        String json = "{\"tag_name\":\"dev\",\"target_commitish\":\"abc1234def5678901234567890123456789abcde\"," +
+                "\"published_at\":\"2024-05-01T00:00:00Z\"," +
+                "\"assets\":[{\"browser_download_url\":\"https://example.com/plugin.jar\"}]}";
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null) {
+            @Override
+            HttpURLConnection openConnection(String url) throws IOException {
+                requestedUrls.add(url);
+                return fakeConnection(200, null, json);
+            }
+        };
+
+        ReleaseInfo release = svc.getExperimentalRelease("org", "repo");
+
+        assertNotNull(release);
+        assertEquals("dev-abc1234", release.getTagName());
+        assertEquals("https://example.com/plugin.jar", release.getJarUrl());
+        assertEquals(List.of("https://api.github.com/repos/org/repo/releases/tags/dev"), requestedUrls);
+    }
+
+    @Test
+    void getExperimentalRelease_honoursACustomExperimentalTag() throws IOException {
+        List<String> requestedUrls = new ArrayList<>();
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null) {
+            @Override
+            HttpURLConnection openConnection(String url) throws IOException {
+                requestedUrls.add(url);
+                return fakeConnection(404, null);
+            }
+        };
+        svc.setExperimentalTag("nightly");
+
+        svc.getExperimentalRelease("org", "repo");
+
+        assertEquals(List.of("https://api.github.com/repos/org/repo/releases/tags/nightly"), requestedUrls);
+    }
+
+    @Test
+    void getExperimentalRelease_returnsNoReleaseWhenTagDoesNotExist() throws IOException {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null) {
+            @Override
+            HttpURLConnection openConnection(String url) throws IOException {
+                return fakeConnection(404, null);
+            }
+        };
+
+        assertSame(ReleaseInfo.NO_RELEASE, svc.getExperimentalRelease("org", "repo"),
+                "A repository that publishes no experimental build must report NO_RELEASE, not an error");
+    }
+
+    @Test
+    void getExperimentalRelease_returnsNullAndWarnsWhenPrereleaseHasNoJarAsset() throws IOException {
+        List<String> warnings = new ArrayList<>();
+        String json = "{\"tag_name\":\"dev\",\"target_commitish\":\"abc1234def5678901234567890123456789abcde\"," +
+                "\"assets\":[{\"browser_download_url\":\"https://example.com/checksums.txt\"}]}";
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(capturingLogger(warnings)) {
+            @Override
+            HttpURLConnection openConnection(String url) throws IOException {
+                return fakeConnection(200, null, json);
+            }
+        };
+
+        assertNull(svc.getExperimentalRelease("org", "repo"));
+        assertTrue(warnings.stream().anyMatch(m -> m.contains("no .jar asset")),
+                "A dev prerelease with no JAR attached must warn");
+    }
+
+    @Test
+    void setExperimentalTag_blankOrNullRestoresTheDefault() {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null);
+        svc.setExperimentalTag("nightly");
+        svc.setExperimentalTag("   ");
+        assertEquals("dev", svc.getExperimentalTag());
+        svc.setExperimentalTag("nightly");
+        svc.setExperimentalTag(null);
+        assertEquals("dev", svc.getExperimentalTag());
+    }
+
+    // -------------------------------------------------------------------------
+    // channel-aware caching
+    // -------------------------------------------------------------------------
+
+    @Test
+    void cache_keepsStableAndExperimentalEntriesSeparateForTheSameRepo() {
+        AtomicInteger stableFetches = new AtomicInteger(0);
+        AtomicInteger experimentalFetches = new AtomicInteger(0);
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null) {
+            @Override
+            ReleaseInfo doFetch(String owner, String repo) {
+                stableFetches.incrementAndGet();
+                return new ReleaseInfo("v1.0", "https://example.com/stable.jar", null);
+            }
+            @Override
+            ReleaseInfo doFetchExperimental(String owner, String repo) {
+                experimentalFetches.incrementAndGet();
+                return new ReleaseInfo("dev-abc1234", "https://example.com/dev.jar", null);
+            }
+        };
+
+        assertEquals("v1.0", svc.getLatestRelease("org", "repo").getTagName());
+        assertEquals("dev-abc1234", svc.getExperimentalRelease("org", "repo").getTagName(),
+                "The experimental fetch must not be served the cached stable release");
+        assertEquals("v1.0", svc.getLatestRelease("org", "repo").getTagName(),
+                "The stable fetch must not be served the cached experimental release");
+
+        assertEquals(1, stableFetches.get(), "Stable should be fetched once and then cached");
+        assertEquals(1, experimentalFetches.get(), "Experimental should be fetched once and then cached");
+    }
+
+    @Test
+    void cacheKey_changesWithTheConfiguredExperimentalTag() {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null);
+        String stableKey = svc.cacheKey("org", "repo", ReleaseChannel.STABLE);
+        String devKey = svc.cacheKey("org", "repo", ReleaseChannel.EXPERIMENTAL);
+        svc.setExperimentalTag("nightly");
+        String nightlyKey = svc.cacheKey("org", "repo", ReleaseChannel.EXPERIMENTAL);
+
+        assertNotEquals(stableKey, devKey);
+        assertNotEquals(devKey, nightlyKey);
+    }
+
+    @Test
+    void clearCache_refetchesBothChannels() {
+        AtomicInteger stableFetches = new AtomicInteger(0);
+        AtomicInteger experimentalFetches = new AtomicInteger(0);
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null) {
+            @Override
+            ReleaseInfo doFetch(String owner, String repo) {
+                stableFetches.incrementAndGet();
+                return new ReleaseInfo("v1.0", "https://example.com/stable.jar", null);
+            }
+            @Override
+            ReleaseInfo doFetchExperimental(String owner, String repo) {
+                experimentalFetches.incrementAndGet();
+                return new ReleaseInfo("dev-abc1234", "https://example.com/dev.jar", null);
+            }
+        };
+        svc.getLatestRelease("org", "repo");
+        svc.getExperimentalRelease("org", "repo");
+        svc.clearCache();
+        svc.getLatestRelease("org", "repo");
+        svc.getExperimentalRelease("org", "repo");
+
+        assertEquals(2, stableFetches.get());
+        assertEquals(2, experimentalFetches.get());
+    }
+
+    @Test
+    void getRelease_dispatchesOnChannel() {
+        GitHubReleaseRepository svc = new GitHubReleaseRepository(null) {
+            @Override
+            ReleaseInfo doFetch(String owner, String repo) {
+                return new ReleaseInfo("v1.0", "https://example.com/stable.jar", null);
+            }
+            @Override
+            ReleaseInfo doFetchExperimental(String owner, String repo) {
+                return new ReleaseInfo("dev-abc1234", "https://example.com/dev.jar", null);
+            }
+        };
+
+        assertEquals("v1.0", svc.getRelease("org", "repo", ReleaseChannel.STABLE).getTagName());
+        assertEquals("dev-abc1234", svc.getRelease("org", "repo", ReleaseChannel.EXPERIMENTAL).getTagName());
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
+++ b/src/test/java/dansplugins/dpm/services/DownloadServiceTest.java
@@ -1,6 +1,7 @@
 package dansplugins.dpm.services;
 
 import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.objects.ReleaseChannel;
 import dansplugins.dpm.objects.ReleaseInfo;
 import dansplugins.dpm.repositories.GitHubReleaseRepository;
 import dansplugins.dpm.repositories.PluginFileRepository;
@@ -201,6 +202,112 @@ class DownloadServiceTest {
     }
 
     // -------------------------------------------------------------------------
+    // downloadLatest(record, channel[, physicallyInstalled])
+    // -------------------------------------------------------------------------
+
+    @Test
+    void downloadLatest_experimentalChannel_persistsTheSynthesizedDevVersion(@TempDir Path tempDir) throws IOException {
+        File src = tempDir.resolve("plugin.jar").toFile();
+        Files.write(src.toPath(), new byte[]{1, 2, 3});
+
+        VersionRepository versionRepository = versionRepository(tempDir);
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
+        DownloadService svc = noSleepService(null,
+                fakeChannelledRelease("v1.0.0", "dev-abc1234", src.toURI().toString()),
+                pluginFileRepository, versionRepository);
+
+        ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
+        assertTrue(svc.downloadLatest(record, ReleaseChannel.EXPERIMENTAL) > 0);
+        assertEquals("dev-abc1234", versionRepository.getStoredTag("testplugin"));
+    }
+
+    @Test
+    void downloadLatest_switchingFromStableToExperimental_reDownloadsEvenThoughTheJarIsPresent(@TempDir Path tempDir) throws IOException {
+        // Installed on stable at v1.0.0, with the JAR physically present.
+        VersionRepository versionRepository = versionRepository(tempDir);
+        versionRepository.setTag("testplugin", "v1.0.0");
+        Files.write(tempDir.resolve("testplugin.jar"), new byte[]{9});
+
+        File src = tempDir.resolve("source.jar").toFile();
+        Files.write(src.toPath(), new byte[]{1, 2, 3});
+
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
+        DownloadService svc = noSleepService(null,
+                fakeChannelledRelease("v1.0.0", "dev-abc1234", src.toURI().toString()),
+                pluginFileRepository, versionRepository);
+
+        ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
+        assertTrue(svc.downloadLatest(record, ReleaseChannel.EXPERIMENTAL) > 0,
+                "A channel switch must re-download — the other channel's tag never matches the stored one");
+        assertEquals("dev-abc1234", versionRepository.getStoredTag("testplugin"));
+    }
+
+    @Test
+    void downloadLatest_switchingFromExperimentalBackToStable_reDownloads(@TempDir Path tempDir) throws IOException {
+        VersionRepository versionRepository = versionRepository(tempDir);
+        versionRepository.setTag("testplugin", "dev-abc1234");
+        Files.write(tempDir.resolve("testplugin.jar"), new byte[]{9});
+
+        File src = tempDir.resolve("source.jar").toFile();
+        Files.write(src.toPath(), new byte[]{1, 2, 3});
+
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
+        DownloadService svc = noSleepService(null,
+                fakeChannelledRelease("v1.0.0", "dev-abc1234", src.toURI().toString()),
+                pluginFileRepository, versionRepository);
+
+        ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
+        assertTrue(svc.downloadLatest(record, ReleaseChannel.STABLE) > 0);
+        assertEquals("v1.0.0", versionRepository.getStoredTag("testplugin"));
+    }
+
+    @Test
+    void downloadLatest_experimentalChannel_returnsAlreadyUpToDateWhenTheDevBuildIsUnchanged(@TempDir Path tempDir) throws IOException {
+        VersionRepository versionRepository = versionRepository(tempDir);
+        versionRepository.setTag("testplugin", "dev-abc1234");
+        Files.write(tempDir.resolve("testplugin.jar"), new byte[]{1});
+
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
+        DownloadService svc = new DownloadService(null,
+                fakeChannelledRelease("v1.0.0", "dev-abc1234", "http://unused"),
+                pluginFileRepository, versionRepository);
+
+        ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
+        assertEquals(DownloadService.ALREADY_UP_TO_DATE, svc.downloadLatest(record, ReleaseChannel.EXPERIMENTAL));
+    }
+
+    @Test
+    void downloadLatest_experimentalChannel_returnsNoReleaseWhenRepoPublishesNoDevBuild(@TempDir Path tempDir) {
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
+        GitHubReleaseRepository noDevBuild = new GitHubReleaseRepository(null) {
+            @Override
+            public ReleaseInfo getExperimentalRelease(String owner, String repo) {
+                return ReleaseInfo.NO_RELEASE;
+            }
+        };
+        DownloadService svc = new DownloadService(null, noDevBuild, pluginFileRepository, versionRepository(tempDir));
+
+        ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
+        assertEquals(DownloadService.NO_RELEASE, svc.downloadLatest(record, ReleaseChannel.EXPERIMENTAL));
+    }
+
+    @Test
+    void downloadLatest_defaultOverloadsStillUseTheStableChannel(@TempDir Path tempDir) throws IOException {
+        File src = tempDir.resolve("plugin.jar").toFile();
+        Files.write(src.toPath(), new byte[]{1, 2, 3});
+
+        VersionRepository versionRepository = versionRepository(tempDir);
+        PluginFileRepository pluginFileRepository = new PluginFileRepository(tempDir.toString());
+        DownloadService svc = noSleepService(null,
+                fakeChannelledRelease("v1.0.0", "dev-abc1234", src.toURI().toString()),
+                pluginFileRepository, versionRepository);
+
+        ProjectRecord record = ProjectRecord.forGitHub("testplugin", "Org", "Repo");
+        assertTrue(svc.downloadLatest(record) > 0);
+        assertEquals("v1.0.0", versionRepository.getStoredTag("testplugin"));
+    }
+
+    // -------------------------------------------------------------------------
     // removeConflictingJars — ordering relative to download
     // -------------------------------------------------------------------------
 
@@ -343,6 +450,20 @@ class DownloadServiceTest {
             @Override
             public ReleaseInfo getLatestRelease(String owner, String repo) {
                 return new ReleaseInfo(tag, jarUrl);
+            }
+        };
+    }
+
+    // Serves a different tag per channel, as the real repository does.
+    private GitHubReleaseRepository fakeChannelledRelease(String stableTag, String experimentalTag, String jarUrl) {
+        return new GitHubReleaseRepository(null) {
+            @Override
+            public ReleaseInfo getLatestRelease(String owner, String repo) {
+                return new ReleaseInfo(stableTag, jarUrl);
+            }
+            @Override
+            public ReleaseInfo getExperimentalRelease(String owner, String repo) {
+                return new ReleaseInfo(experimentalTag, jarUrl);
             }
         };
     }


### PR DESCRIPTION
## Summary

An opt-in release channel is added so that main-branch changes can be picked up as soon as they are merged, rather than waiting for a published release.

```
/dpm get medievalfactions --experimental   # switch to main-branch builds
/dpm get medievalfactions --stable         # switch back
```

The channel is sticky per plugin: once a plugin is opted in, plain `/dpm get` and `/dpm update` keep it on experimental builds until `--stable` is passed. This mirrors how a package manager pins a package to a channel.

Experimental builds are read from a rolling `dev` prerelease that each plugin repository's CI is expected to publish on every push to `main`. **No DPC repository publishes one yet** — that is Phase 2 and is not included here. Until then, `--experimental` reports that no experimental build is published and leaves the plugin where it was.

## What was added

| Concern | Where |
|---|---|
| Channel model | `objects/ReleaseChannel.java` |
| Channel persistence | `repositories/ChannelRepository.java` — `dpm-channels.properties` |
| Experimental fetch | `GitHubReleaseRepository.getExperimentalRelease()` |
| Channel-aware download | `DownloadService.downloadLatest(record, channel[, physicallyInstalled])` |
| Flag parsing | `GetCommand.parseArgs()` |

Three decisions are worth calling out, since each guards against a specific failure:

**Version identity.** Every experimental build carries the same tag, so tag equality alone would report "already up to date" forever. The release's `target_commitish` is parsed and the version is recorded as `dev-<short sha>` (falling back to `dev@<published_at>` when the commitish is a branch name rather than a sha). Everything downstream — the version store, `/dpm list`, `/dpm info`, Discord notifications — is unmodified as a result.

**Channel-aware cache key.** The release cache is keyed `owner/repo` for stable and `owner/repo@<tag>` for experimental. Sharing a key would let one channel serve the other channel's release.

**Pinning only after the channel proves it has a build.** A pin is written on a successful download or an already-up-to-date result, never on `NO_RELEASE` or a failure. Pinning eagerly would strand a plugin on a channel that publishes nothing, silently skipping it on every later `/dpm update`.

Dependencies pulled in automatically keep their own stored channel — `--experimental` on one plugin does not drag its dependencies onto experimental builds. This is asserted by `runTargets_doesNotApplyARequestedChannelToDependencies` and documented in the user guide.

## Other user-visible changes

- `/dpm update` follows each plugin's pinned channel. It takes no channel flags; channels are switched with `/dpm get`.
- `/dpm info` shows a `Channel:` line and reports against that plugin's channel, so "Update available" matches what `/dpm update` would install.
- `/dpm list` marks experimental installs with a trailing `[experimental]`.
- `/dpm remove --confirm` clears the stored channel along with the stored version tag, so a reinstall does not silently return to experimental builds.
- Tab completion for `/dpm get` offers `--experimental` / `--stable`.
- New config option `experimentalReleaseTag` (default `dev`), applied on `/dpm reload`.

Existing installations are unaffected: a plugin with no stored channel is treated as stable.

## Testing

`mvn clean package` was run locally. 259 tests run, of which 56 are new.

Two tests fail in this sandbox and are unrelated to this change — both were confirmed to fail identically on `main` at `a06ef63`:

- `DownloadServiceTest.downloadLatest_returnsFileError_whenDestinationUnwritable`
- `RemoveControllerTest.remove_returnsDeleteFailedOutcomeWhenFileCannotBeDeleted`

Both set up an unwritable directory with `setWritable(false)`, which the local environment's root user bypasses. CI does not run as root, so the CI result on this PR should be treated as the authoritative check.

New coverage: experimental fetch (200 / 404 / no-jar-asset / custom tag), version-identity synthesis (sha, branch-name fallback, non-hex and short-commitish rejection), channel-aware caching and cache clearing, channel-switch re-download in both directions, `ChannelRepository` round-trip and defaults, channel pinning rules in `GetController`, per-plugin channel routing in `UpdateController`, channel cleanup in `RemoveController`, flag parsing, and tab completion.

The integration harness gains three steps: the experimental path (accepting either outcome so it does not break during the Phase 2 rollout), an unknown-option rejection, and a conflicting-flags rejection. The coverage table in `integration-test/README.md` was updated, including what remains uncoverable until a repository publishes a `dev` build.

## Follow-up — not in this PR

Phase 2 adds a `dev-release.yml` workflow to each managed plugin repository. It is recommended that this be piloted on `Medieval-Factions` alone and verified end to end against a real server before the remaining repositories are opened, since the delete-and-recreate publish approach has not yet been exercised against a real repository.

---
_drafted by Claude on behalf of Daniel Stephenson_