### PR TITLE
fix: report the pinned channel in /dpm update results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `/dpm remove --confirm` now clears the stored release channel along with the stored version tag, so a later reinstall starts on stable
 - Tab completion for `/dpm get` now suggests `--experimental` and `--stable` alongside plugin names
 
+### Fixed
+- `/dpm update` no longer reports a plugin pinned to the experimental channel as having "no published release yet" when its repository publishes no main-branch build. That wording describes a project that has never cut a release, while the real situation is a plugin pinned to a channel with nothing on it, silently skipped by every update run. The message now names the pin and the way out of it, and a matching warning is written to the console
+- `/dpm get <plugin-name> --experimental` no longer labels a whole batch "(experimental)" when that batch also carries automatically resolved dependencies, which are downloaded on their own channel
+- Tab completion no longer withdraws `--experimental` / `--stable` at the moment the flag is fully typed. The token under the cursor was counted as an argument already entered, so completing the flag suppressed the suggestion being completed
+- An unrecognised value in `dpm-channels.properties` now logs a warning naming the value instead of silently treating the plugin as stable
+- The default experimental release tag is read from a single constant rather than repeated as a `"dev"` literal in the config defaults and the config listing
+
 ## [0.7.0-SNAPSHOT-8-8-2026] – 2026-08-08
 
 ### Changed

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -51,6 +51,7 @@ Notes:
 - **`/dpm list installed` marks them.** Plugins on experimental builds are shown with a trailing `[experimental]`.
 - **Switching channels always re-downloads**, because the two channels never share a version identity.
 - **Not every plugin publishes experimental builds.** If a repository has no rolling build, `/dpm get <plugin> --experimental` reports that no experimental build is published and leaves the plugin on its current channel.
+- **If a repository stops publishing them, the plugin stops updating.** A plugin already pinned to experimental stays pinned even when its rolling build disappears, so `/dpm update` skips it on every run rather than quietly moving it back to releases. Both the chat message and the console say so and name the plugin; `/dpm get <plugin> --stable` returns it to published releases.
 - **Removing a plugin resets it to stable**, so a later reinstall does not silently return to experimental builds.
 
 ## Permissions

--- a/src/main/java/dansplugins/dpm/commands/GetCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/GetCommand.java
@@ -111,7 +111,7 @@ public class GetCommand extends AbstractPluginCommand {
             }
             allToFetch.add(Target.of(record, requestedChannel));
             sender.sendMessage(ChatColor.AQUA + "Fetching " + allToFetch.size() + " plugin(s)"
-                    + channelSuffix(requestedChannel) + "...");
+                    + batchChannelSuffix(requestedChannel, !depsToFetch.isEmpty()) + "...");
             Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> runBatch(sender, allToFetch, 0));
         }
         return true;
@@ -150,7 +150,7 @@ public class GetCommand extends AbstractPluginCommand {
 
         if (allToFetch.isEmpty()) return false;
         sender.sendMessage(ChatColor.AQUA + "Fetching " + allToFetch.size() + " plugin(s)"
-                + channelSuffix(requestedChannel) + "...");
+                + batchChannelSuffix(requestedChannel, !depsToFetch.isEmpty()) + "...");
         final int fn = notFound;
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> runBatch(sender, allToFetch, fn));
         return true;
@@ -165,6 +165,15 @@ public class GetCommand extends AbstractPluginCommand {
 
     private String channelSuffix(ReleaseChannel requestedChannel) {
         return requestedChannel == ReleaseChannel.EXPERIMENTAL ? " (experimental)" : "";
+    }
+
+    // The flag applies only to the named plugins, so a batch that also carries dependencies must not
+    // claim the whole batch is experimental — the dependencies are on whatever channel they are pinned to.
+    private String batchChannelSuffix(ReleaseChannel requestedChannel, boolean includesDependencies) {
+        if (requestedChannel != ReleaseChannel.EXPERIMENTAL) return "";
+        return includesDependencies
+                ? " (experimental — dependencies keep their own channel)"
+                : " (experimental)";
     }
 
     // On the experimental channel a 404 means the repository publishes no main-branch build, which

--- a/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
+++ b/src/main/java/dansplugins/dpm/commands/UpdateCommand.java
@@ -4,6 +4,7 @@ import dansplugins.dpm.controllers.UpdateController;
 import dansplugins.dpm.controllers.UpdateController.PluginResult;
 import dansplugins.dpm.controllers.UpdateController.SelectionResult;
 import dansplugins.dpm.objects.ProjectRecord;
+import dansplugins.dpm.objects.ReleaseChannel;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -62,6 +63,18 @@ public class UpdateCommand extends AbstractPluginCommand {
                 .stream().map(ProjectRecord::getName).collect(Collectors.toList());
     }
 
+    // A plugin pinned to experimental is skipped by every update run for as long as its repository
+    // publishes no main-branch build, so the message has to name the pin and the way out of it —
+    // otherwise it reads as "this project has never cut a release", which is a different problem.
+    private String noReleaseSuffix(PluginResult result) {
+        if (result.getChannel() != ReleaseChannel.EXPERIMENTAL) {
+            return " has no published release yet.";
+        }
+        return " has no experimental build published — it stays pinned to the experimental channel"
+                + " and will be skipped until one is published. Use /dpm get " + result.getRecord().getName()
+                + " --stable to switch it back to published releases.";
+    }
+
     private void runUpdates(CommandSender sender, List<ProjectRecord> records) {
         List<PluginResult> results = updateController.runBatch(records);
         int updated = 0, upToDate = 0, skipped = 0, failed = 0;
@@ -76,7 +89,7 @@ public class UpdateCommand extends AbstractPluginCommand {
                     break;
                 case NO_RELEASE:
                     skipped++;
-                    msg = ChatColor.YELLOW + record.getName() + " has no published release yet.";
+                    msg = ChatColor.YELLOW + record.getName() + noReleaseSuffix(result);
                     break;
                 case UPDATED:
                     updated++;

--- a/src/main/java/dansplugins/dpm/controllers/ConfigController.java
+++ b/src/main/java/dansplugins/dpm/controllers/ConfigController.java
@@ -1,6 +1,7 @@
 package dansplugins.dpm.controllers;
 
 import dansplugins.dpm.repositories.ConfigRepository;
+import dansplugins.dpm.repositories.GitHubReleaseRepository;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
@@ -43,7 +44,8 @@ public class ConfigController {
         String webhookDisplay = (webhook != null && !webhook.isEmpty()) ? "(set)" : "(not set)";
         sender.sendMessage(ChatColor.AQUA + "discordWebhook: " + webhookDisplay);
         sender.sendMessage(ChatColor.AQUA + "experimentalReleaseTag: "
-                + configRepository.getStringOrDefault("experimentalReleaseTag", "dev"));
+                + configRepository.getStringOrDefault("experimentalReleaseTag",
+                        GitHubReleaseRepository.DEFAULT_EXPERIMENTAL_TAG));
     }
 
     public boolean hasBeenAltered() {

--- a/src/main/java/dansplugins/dpm/controllers/UpdateController.java
+++ b/src/main/java/dansplugins/dpm/controllers/UpdateController.java
@@ -27,18 +27,22 @@ public class UpdateController {
         private final Outcome outcome;
         private final String oldTag;
         private final String newTag;
+        private final ReleaseChannel channel;
 
-        PluginResult(ProjectRecord record, Outcome outcome, String oldTag, String newTag) {
+        PluginResult(ProjectRecord record, Outcome outcome, String oldTag, String newTag, ReleaseChannel channel) {
             this.record = record;
             this.outcome = outcome;
             this.oldTag = oldTag;
             this.newTag = newTag;
+            this.channel = channel;
         }
 
         public ProjectRecord getRecord() { return record; }
         public Outcome getOutcome() { return outcome; }
         public String getOldTag() { return oldTag; }
         public String getNewTag() { return newTag; }
+        /** The channel this plugin is pinned to, and so the one the update ran against. */
+        public ReleaseChannel getChannel() { return channel; }
     }
 
     public static final class SelectionResult {
@@ -122,27 +126,34 @@ public class UpdateController {
         ReleaseChannel channel = channelRepository.getChannel(record.getName());
         int result = downloadService.downloadLatest(record, channel, true);
         if (result == DownloadService.ALREADY_UP_TO_DATE) {
-            return new PluginResult(record, Outcome.ALREADY_UP_TO_DATE, oldTag, oldTag);
+            return new PluginResult(record, Outcome.ALREADY_UP_TO_DATE, oldTag, oldTag, channel);
         }
         if (result == DownloadService.NO_RELEASE) {
-            return new PluginResult(record, Outcome.NO_RELEASE, oldTag, null);
+            // A plugin pinned to a channel that publishes nothing is skipped on every run, so the
+            // console gets a warning naming the pin — the chat message alone is easy to miss.
+            if (channel == ReleaseChannel.EXPERIMENTAL) {
+                logger.warning("[DPM] " + record.getName() + " is pinned to the experimental channel but "
+                        + "no experimental build is published — it will be skipped by /dpm update until "
+                        + "one is published or it is switched back with /dpm get " + record.getName() + " --stable.");
+            }
+            return new PluginResult(record, Outcome.NO_RELEASE, oldTag, null, channel);
         }
         if (result > 0) {
             String newTag = versionRepository.getStoredTag(record.getName());
             String versionDiff = versionDiffSuffix(oldTag, newTag);
             logger.info("[DPM] Updated " + record.getName() + versionDiff + ".");
-            return new PluginResult(record, Outcome.UPDATED, oldTag, newTag);
+            return new PluginResult(record, Outcome.UPDATED, oldTag, newTag, channel);
         }
         if (result == DownloadService.NETWORK_ERROR) {
             logger.warning("[DPM] Failed to update " + record.getName() + " — could not reach GitHub.");
-            return new PluginResult(record, Outcome.NETWORK_ERROR, oldTag, null);
+            return new PluginResult(record, Outcome.NETWORK_ERROR, oldTag, null, channel);
         }
         if (result == DownloadService.FILE_ERROR) {
             logger.warning("[DPM] Failed to update " + record.getName() + " — could not write to plugins folder.");
-            return new PluginResult(record, Outcome.FILE_ERROR, oldTag, null);
+            return new PluginResult(record, Outcome.FILE_ERROR, oldTag, null, channel);
         }
         logger.warning("[DPM] Failed to update " + record.getName() + ".");
-        return new PluginResult(record, Outcome.OTHER_FAILURE, oldTag, null);
+        return new PluginResult(record, Outcome.OTHER_FAILURE, oldTag, null, channel);
     }
 
     private void sendUpdateNotification(List<PluginResult> results) {

--- a/src/main/java/dansplugins/dpm/repositories/ChannelRepository.java
+++ b/src/main/java/dansplugins/dpm/repositories/ChannelRepository.java
@@ -29,7 +29,15 @@ public class ChannelRepository {
 
     /** Returns the channel the given plugin is pinned to, defaulting to STABLE. */
     public ReleaseChannel getChannel(String pluginName) {
-        return ReleaseChannel.fromStored(props.getProperty(pluginName.toLowerCase()));
+        String stored = props.getProperty(pluginName.toLowerCase());
+        ReleaseChannel channel = ReleaseChannel.fromStored(stored);
+        // A hand-edited or corrupted entry silently demotes a plugin to stable, which looks like the
+        // pin was forgotten rather than rejected — so say which value was not understood.
+        if (stored != null && !stored.trim().isEmpty() && !stored.trim().equalsIgnoreCase(channel.name())) {
+            warn("Unrecognised channel '" + stored + "' stored for " + pluginName
+                    + " — treating it as " + channel.getDisplayName() + ".");
+        }
+        return channel;
     }
 
     /** Pins the given plugin to a channel. */

--- a/src/main/java/dansplugins/dpm/repositories/ConfigRepository.java
+++ b/src/main/java/dansplugins/dpm/repositories/ConfigRepository.java
@@ -32,7 +32,7 @@ public class ConfigRepository {
             config.set("discordWebhook", "");
         }
         if (!isSet("experimentalReleaseTag")) {
-            config.set("experimentalReleaseTag", "dev");
+            config.set("experimentalReleaseTag", GitHubReleaseRepository.DEFAULT_EXPERIMENTAL_TAG);
         }
         config.options().copyDefaults(true);
         saveAction.run();

--- a/src/main/java/dansplugins/dpm/utils/TabCompleter.java
+++ b/src/main/java/dansplugins/dpm/utils/TabCompleter.java
@@ -14,20 +14,24 @@ public class TabCompleter {
      * Returns the plugin names plus the channel flags, for completing /dpm get arguments.
      * The flags are mutually exclusive, so once either one is on the command line neither is
      * suggested again.
+     *
+     * <p>The final element of {@code argsSoFar} is the token being typed rather than a token
+     * already entered, so it is excluded from that check — otherwise finishing "--experimental"
+     * would withdraw the very suggestion the player is completing.
      */
     public static List<String> pluginNamesWithChannelFlags(List<String> pluginNames, String[] argsSoFar) {
         List<String> options = new ArrayList<>(pluginNames);
-        if (!containsChannelFlag(argsSoFar)) {
+        if (!containsChannelFlag(argsSoFar, 1)) {
             options.addAll(CHANNEL_FLAGS);
         }
         return options;
     }
 
-    private static boolean containsChannelFlag(String[] values) {
+    private static boolean containsChannelFlag(String[] values, int trailingToIgnore) {
         if (values == null) return false;
-        for (String value : values) {
+        for (int i = 0; i < values.length - trailingToIgnore; i++) {
             for (String flag : CHANNEL_FLAGS) {
-                if (flag.equalsIgnoreCase(value)) return true;
+                if (flag.equalsIgnoreCase(values[i])) return true;
             }
         }
         return false;

--- a/src/test/java/dansplugins/dpm/TabCompletionTest.java
+++ b/src/test/java/dansplugins/dpm/TabCompletionTest.java
@@ -113,6 +113,16 @@ class TabCompletionTest {
     }
 
     @Test
+    void pluginNamesWithChannelFlags_stillOffersTheFlagBeingTypedAsTheCurrentToken() {
+        List<String> options = TabCompleter.pluginNamesWithChannelFlags(
+                List.of("currencies"), new String[]{"get", "currencies", "--experimental"});
+
+        assertEquals(List.of("--experimental"), TabCompleter.filterByPrefix(options, "--experimental"),
+                "The token under the cursor is being typed, not already entered, so completing it "
+                        + "must not withdraw the suggestion");
+    }
+
+    @Test
     void pluginNamesWithChannelFlags_isCaseInsensitiveWhenDetectingAnExistingFlag() {
         List<String> options = TabCompleter.pluginNamesWithChannelFlags(
                 List.of("currencies"), new String[]{"get", "currencies", "--STABLE", ""});

--- a/src/test/java/dansplugins/dpm/controllers/UpdateControllerTest.java
+++ b/src/test/java/dansplugins/dpm/controllers/UpdateControllerTest.java
@@ -247,6 +247,24 @@ class UpdateControllerTest {
     }
 
     @Test
+    void runBatch_reportsThePinnedChannelOnEachResult(@TempDir Path tempDir) {
+        ChannelRepository channelRepository = channelRepository(tempDir);
+        channelRepository.setChannel("OnExperimental", ReleaseChannel.EXPERIMENTAL);
+        Map<String, Integer> results = new HashMap<>();
+        results.put("OnStable", DownloadService.NO_RELEASE);
+        results.put("OnExperimental", DownloadService.NO_RELEASE);
+        UpdateController controller = controller(projectRecordRepository(), new PluginFileRepository(tempDir.toString()), results, versionRepository(tempDir), channelRepository, new ArrayList<>());
+
+        List<PluginResult> batchResults = controller.runBatch(List.of(record("OnStable"), record("OnExperimental")));
+
+        // Without the channel on the result, a plugin pinned to experimental whose repository
+        // publishes no main-branch build is reported as "no published release yet" — indistinguishable
+        // from a project that never cut a release, while it is silently skipped by every update run.
+        assertEquals(ReleaseChannel.STABLE, batchResults.get(0).getChannel());
+        assertEquals(ReleaseChannel.EXPERIMENTAL, batchResults.get(1).getChannel());
+    }
+
+    @Test
     void runBatch_sendsDiscordSummaryWithCountsAndVersionDiff(@TempDir Path tempDir) throws Exception {
         VersionRepository versionRepository = versionRepository(tempDir);
         versionRepository.setTag("Updated", "v1.0.0");


### PR DESCRIPTION
Follow-ups from a review of #122, which added the experimental release channel.

## The issue that motivated this

`GetCommand` was given a channel-aware "no release" message in #122, but `UpdateController.PluginResult` carried no channel, so `UpdateCommand` could not distinguish the two cases and kept the stable wording.

The effect: when a plugin is pinned to the experimental channel and its repository publishes no main-branch build — the tag was deleted, the publishing workflow was removed, or `experimentalReleaseTag` is misconfigured — `/dpm update` reports *"<plugin> has no published release yet"* and skips it. That sentence describes a project that has never cut a release. The actual situation is a plugin pinned to a channel with nothing on it, which will be skipped on every future update run while published releases go on being ignored, and nothing in the output points at the pin as the cause.

The channel is now carried on `UpdateController.PluginResult`, so the message names the pin and points at `/dpm get <name> --stable`. A matching warning is written to the console, since a chat line during a multi-plugin update run is easy to miss.

## Also addressed

- A batch that also carries automatically resolved dependencies is no longer labelled `(experimental)` as a whole. Dependencies are downloaded on their own channel, which is what `USER_GUIDE.md` documents, so the old message contradicted it.
- Tab completion no longer withdraws `--experimental` / `--stable` at the moment the flag is fully typed. The token under the cursor was being counted as an argument already entered, so completing the flag suppressed the very suggestion being completed.
- An unrecognised value in `dpm-channels.properties` is now warned about by name rather than silently treated as stable, which previously looked like a forgotten pin rather than a rejected one.
- The default experimental tag is read from `GitHubReleaseRepository.DEFAULT_EXPERIMENTAL_TAG` in the config defaults and the config listing, rather than repeated as a `"dev"` literal in three places.

## Testing

`mvn test` — 261 tests, 2 failures, both pre-existing on `main` and unrelated: `RemoveControllerTest.remove_returnsDeleteFailedOutcomeWhenFileCannotBeDeleted` and `DownloadServiceTest.downloadLatest_returnsFileError_whenDestinationUnwritable`. Both depend on a read-only directory blocking writes, which does not hold when the suite runs as root — that is #120. They were confirmed to fail on unmodified `main` in the same environment.

Two regression tests were added: one asserting the channel reaches each `UpdateController.PluginResult`, and one asserting tab completion still offers the flag being typed.

`CHANGELOG.md` and the Release channels section of `USER_GUIDE.md` were updated. No command syntax or permission node changed, so `HelpCommand` and `COMMANDS.md` are untouched.

---

_drafted by Claude on behalf of Daniel Stephenson_
